### PR TITLE
Add Dockerfile

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,39 @@
+name: build-docker
+on:
+  pull_request:
+    paths:
+      - 'container/Dockerfile'
+  push:
+    branches: [main]
+  workflow_dispatch:
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+jobs:
+  build-docker:
+    name: Deploy Docker image
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: GHCR Log-in
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: container/Dockerfile
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |-
+            SNITCH_LLVM_VERSION=latest

--- a/README.md
+++ b/README.md
@@ -5,3 +5,19 @@ Repository for running MLIR compiled stuff on SNAX
 ## Requirements
 
 [stardew](https://github.com/Groverkss/stardew)
+
+## Docker Container
+
+For compiling the low-level kernels you need the snitch compilation toolchain, 
+which is easiest to get through a docker container.
+A Dockerfile for such container is provided here:
+```sh
+cd container
+docker build . -t snax-toolchain
+cd ..
+```
+Then you can run your experiments in this repository with:
+```sh
+docker run -itv `pwd`:/repo:z snax-toolchain
+```
+The repository will be available under `/repo`

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Repository for running MLIR compiled stuff on SNAX
 
 For compiling the low-level kernels you need the snitch compilation toolchain, 
 which is easiest to get through a docker container.
-A Dockerfile for such container is provided here:
+A Dockerfile for such container is provided here (note that leaving out the `config` `--build-arg` will use the default `snitch_cluster` setup:
 ```sh
 cd container
-docker build . -t snax-toolchain
+docker build . -t snax-toolchain --build-arg config=path_to_your_hjson_file.hjson
 cd ..
 ```
 Then you can run your experiments in this repository with:

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -4,9 +4,12 @@ ARG config=target/snitch_cluster/cfg/default.hjson
 
 FROM ghcr.io/pulp-platform/snitch_cluster:latest@sha256:aa0d9a25022d1ef51f451dc667b850e3e8dba4c15d949b51b5cfde10f89defe9 as builder
 
-RUN git clone --recursive https://github.com/kuleuven-micas/snitch_cluster.git /src \
+RUN git clone https://github.com/kuleuven-micas/snitch_cluster.git /src \
+ && cd /src \
+ && git reset --hard 49adab2090275f5c8dee2b73060f673bff37767b \
+ && git submodule update --init \
  # verilator model
- && make CFG_OVERRIDE=$config -C /src/target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
+ && make CFG_OVERRIDE=$config -C target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
  # spike-dasm
 RUN cd /src/target/snitch_cluster/work-vlt/riscv-isa-sim \
  && ./configure --prefix=/opt/snitch-spike \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,18 +1,19 @@
 # Courtesy of Federico Ficarelli
 
-FROM ghcr.io/pulp-platform/snitch_cluster:latest@sha256:9978f9d0e3e6b7ad1b2c1f0eb628a113226e8443bc42ae8b4ddd3f34d9528e96 as builder
+ARG config=target/snitch_cluster/cfg/default.hjson
+
+FROM ghcr.io/pulp-platform/snitch_cluster:latest@sha256:aa0d9a25022d1ef51f451dc667b850e3e8dba4c15d949b51b5cfde10f89defe9 as builder
 
 RUN git clone --recursive https://github.com/kuleuven-micas/snitch_cluster.git /src \
  # verilator model
- && cd /src/target/snitch_cluster \
- && make bin/snitch_cluster.vlt
+ && make CFG_OVERRIDE=$config -C /src/target/snitch_cluster bin/snitch_cluster.vlt -j$(nproc)
  # spike-dasm
 RUN cd /src/target/snitch_cluster/work-vlt/riscv-isa-sim \
  && ./configure --prefix=/opt/snitch-spike \
  && make install 
  # snitch runtime
 RUN cd /src/target/snitch_cluster \
- && make DEBUG=ON sw 
+ && make DEBUG=ON sw  -j$(nproc)
  # clang+llvm+lld
 RUN mkdir -p /opt/snitch-llvm \
  && wget -qO- https://github.com/pulp-platform/llvm-project/releases/download/0.12.0/riscv32-pulp-llvm-ubuntu1804-0.12.0.tar.gz | \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,87 @@
+# Courtesy of Federico Ficarelli
+
+FROM ghcr.io/pulp-platform/snitch_cluster:latest@sha256:9978f9d0e3e6b7ad1b2c1f0eb628a113226e8443bc42ae8b4ddd3f34d9528e96 as builder
+
+RUN git clone --recursive https://github.com/kuleuven-micas/snitch_cluster.git /src \
+ # verilator model
+ && cd /src/target/snitch_cluster \
+ && make bin/snitch_cluster.vlt
+ # spike-dasm
+RUN cd /src/target/snitch_cluster/work-vlt/riscv-isa-sim \
+ && ./configure --prefix=/opt/snitch-spike \
+ && make install 
+ # snitch runtime
+RUN cd /src/target/snitch_cluster \
+ && make DEBUG=ON sw 
+ # clang+llvm+lld
+RUN mkdir -p /opt/snitch-llvm \
+ && wget -qO- https://github.com/pulp-platform/llvm-project/releases/download/0.12.0/riscv32-pulp-llvm-ubuntu1804-0.12.0.tar.gz | \
+    tar xz --strip-components=1 -C /opt/snitch-llvm 
+ # python 3.11
+ RUN apt update -y \
+ && apt install -y \
+      build-essential \
+      zlib1g-dev \
+      libncurses5-dev \
+      libgdbm-dev \
+      libnss3-dev \
+      libssl-dev \
+      libreadline-dev \
+      libffi-dev \
+      libsqlite3-dev \
+      wget \
+      libbz2-dev \
+ && mkdir -p /tmp/python-src \
+ && wget -qO- https://www.python.org/ftp/python/3.11.5/Python-3.11.5.tgz | \
+    tar xz --strip-components=1 -C /tmp/python-src \
+ && cd /tmp/python-src \
+ && ./configure --prefix=/opt/python3.11 \
+ && make install
+
+FROM ubuntu:18.04 as toolchain
+COPY --from=builder /src/target/snitch_cluster/bin/snitch_cluster.vlt /opt/snitch-rtl/bin/snitch_cluster.vlt
+COPY --from=builder /opt/snitch-spike /opt/snitch-spike
+COPY --from=builder /opt/snitch-llvm /opt/snitch-llvm
+COPY --from=builder /opt/python3.11 /opt/python3.11
+COPY --from=builder /src/util/trace /opt/snitch_cluster/util/trace
+# Compile and link time dependencies
+COPY --from=builder /src/sw/snRuntime /opt/snitch_cluster/sw/snRuntime
+COPY --from=builder /src/target/snitch_cluster/sw/runtime/rtl /opt/snitch_cluster/target/snitch_cluster/sw/runtime/rtl
+COPY --from=builder /src/target/snitch_cluster/sw/runtime/common /opt/snitch_cluster/target/snitch_cluster/sw/runtime/common
+COPY --from=builder /src/sw/math/ /opt/snitch_cluster/sw/math/
+# Transitive deps, this stuff must go at some point
+COPY --from=builder /src/sw/deps/riscv-opcodes /opt/snitch_cluster/sw/deps/riscv-opcodes
+COPY --from=builder /src/sw/deps/printf /opt/snitch_cluster/sw/deps/printf
+
+RUN apt-get -y update \
+ && apt-get -y upgrade \
+ # python runtime dependencies
+ && apt-get -y install \
+      wget \
+      zlib1g \
+      libncurses5 \
+      libgdbm5 \
+      libnss3 \
+      libssl1.1 \
+      libreadline7 \
+      libffi6 \
+      libsqlite3-0 \
+      bzip2 \
+ # make pip able to install via git
+ && apt-get -y install git \
+ # mlir
+ && apt-get -y install wget lsb-release software-properties-common gnupg \
+ && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+ && echo "\
+deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main \n\
+deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic main \n\
+deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-16 main \n\
+deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-16 main\n" >> /etc/apt/sources.list \
+ && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+ && apt-get -y update \
+ && apt-get -y upgrade \
+ && apt-get -y install mlir-16-tools \
+ # misc stuff
+ && apt-get -y install make \
+ #
+ && rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*


### PR DESCRIPTION
Courtesy of @nazavode

This dockerfile does the following:

Stage 1:  Inside the snitch_cluster container:
1) Download the latest  `https://github.com/kuleuven-micas/snitch_cluster.git` and build it with verilator.
2) compile `spike-dasm` and install
3) compile `snitch runtime`
4) download snitch-specifc versions of clang/llvm/lld
5) download and compile python 3.11

Stage 2: Inside the `ubuntu 18.04` container:
1) copy-paste all binaries built in the previous stage
2) install python's ubuntu dependencies
3) install git
4) install a pre-built mlir (version 16.0.6), available as `mlir-opt-16` inside the container, optimized build, without assertions
5) install make

I'm currently/temporarily providing a public build of this dockerfile here for you to try out:
```
docker pull ghcr.io/jossevandelm/snax-toolchain
```