### PR TITLE
Add simple HWPE integer multiplication kernel

### DIFF
--- a/.github/workflows/build-run-kernel.yml
+++ b/.github/workflows/build-run-kernel.yml
@@ -1,0 +1,17 @@
+name: Build and run kernels
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-and-run-kernels:
+    runs-on: ubuntu-latest
+    container: ghcr.io/kuleuven-micas/snax-mlir:main
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and run kernel simple mult
+        run: make allrun
+        working-directory: kernels/simple_mult

--- a/README.md
+++ b/README.md
@@ -40,3 +40,11 @@ All C code is lowered with the same flow (1):
 
 1. `c code` -> `clang-12` (snitch-specific) -> RISC-V binary -> `ld.lld-12` -> RISC-V executable
 2. `linalg code` -> `mlir-opt-16` (16.0.6) -> `llvm` dialect -> `mlir-translate-16` (16.0.6) -> `llvm` bytecode -> `tollvm12.py` -> `llvm-12` bytecode -> `clang-12` (snitch-specific) -> RISC-V binary -> `ld.lld-12` -> RISC-V executable
+
+Note: We use a `tollvm12.py` script for multiple reasons:
+* Certain ABI information is required to be added, since `mlir-translate-16` does not add this, and otherwise it is not possible to link it with the C runtime libraries provided by snitch.
+* Certain LLVM metadata, introduced by `mlir-translate-16` was only introduced in versions later than LLVM 12, and they would throw an error if they are not removed.
+
+Note: Due to snitch's dependency on a custom LLVM-12 backend (which does not support LLVM opaque pointers) we are stuck with MLIR version 16.
+Opaque pointers were introduced in LLVM 15, and support for typed pointers is removed in LLVM 17. 
+More information is available [here](https://llvm.org/docs/OpaquePointers.html). 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Repository for running MLIR compiled stuff on SNAX
 
 ## Requirements
 
-[stardew](https://github.com/Groverkss/stardew)
+* [stardew](https://github.com/Groverkss/stardew)
+* numpy
 
 ## Docker Container
 
@@ -21,3 +22,21 @@ Then you can run your experiments in this repository with:
 docker run -itv `pwd`:/repo:z snax-toolchain
 ```
 The repository will be available under `/repo`
+
+## Run Kernels
+
+Inside the docker container:
+```sh
+cd /kernels/simple_mult
+make allrun
+```
+This will compile `main.c` two different `kernel`s:
+
+1. `baseline.c`: A C implementation of the kernel
+2. `linalg.mlir`: An MLIR Linalg implementation of the kernel
+
+Note that for both kernels, a different lowering path is employed.
+All C code is lowered with the same flow (1):
+
+1. `c code` -> `clang-12` (snitch-specific) -> RISC-V binary -> `ld.lld-12` -> RISC-V executable
+2. `linalg code` -> `mlir-opt-16` (16.0.6) -> `llvm` dialect -> `mlir-translate-16` (16.0.6) -> `llvm` bytecode -> `tollvm12.py` -> `llvm-12` bytecode -> `clang-12` (snitch-specific) -> RISC-V binary -> `ld.lld-12` -> RISC-V executable

--- a/kernels/simple_mult/Makefile
+++ b/kernels/simple_mult/Makefile
@@ -1,0 +1,33 @@
+# Courtesy of Federico Ficarelli
+
+.DEFAULT_GOAL := all
+
+include ../../runtime/Makefile.rules
+
+TESTS =
+TESTS += baseline.x
+TESTS += linalg.x
+
+CFLAGS += -std=gnu11
+CFLAGS += -Wall -Wextra
+
+data.c data.h:
+	$(PYTHON) gendata.py
+
+%.x: %.o main.o data.o
+	$(LD) $(LDFLAGS) $^ -o $@
+
+sim_%: %
+	rm -fr ./logs/
+	$(VLTSIM) $<
+
+RUN = $(addprefix run_, $(TESTS))
+$(RUN): run_%: sim_%
+	mv logs $(subst sim_,,$<).logs
+
+all: $(TESTS)
+
+allrun: $(RUN)
+
+clean:
+	rm -fr *.ll12 *.x *.o *.logs/ logs/ data.h data.c

--- a/kernels/simple_mult/baseline.c
+++ b/kernels/simple_mult/baseline.c
@@ -1,0 +1,12 @@
+#include "data.h"
+
+#include <snrt.h>
+
+#include <stdint.h>
+
+void simple_mult(const int32_t* A, const int32_t* B, int32_t* D) {
+    const uint32_t n = N;
+    for (uint32_t i = 0; i < n; ++i) {
+        D[i] = A[i] * B[i];
+    }
+}

--- a/kernels/simple_mult/gendata.py
+++ b/kernels/simple_mult/gendata.py
@@ -1,0 +1,44 @@
+# simple script to generate inputs and expected outputs for simple_mult
+import numpy as np
+from numpy import typing as npt
+from typing import Dict
+
+def create_header(file_name: str, size: int, variables: Dict[str, npt.NDArray]) -> None:
+    with open(file_name, "w") as f:
+        includes = ["#include <stdint.h>",
+                    "#pragma once", 
+                    "",
+                    f"#define N {size}",
+                    ""]
+        includes = "\n".join(includes)
+        variable_names = list(variables.keys())
+        variables_string = [f"extern const int32_t {i}[N];" for i in variable_names]
+        variables_string = "\n".join(variables_string)
+        f.write(includes)
+        f.write(variables_string)
+        f.write("\n")
+
+def create_data(file_name: str, size: int, variables: Dict[str, npt.NDArray]):
+    includes = ['#include "data.h"', "", ""]
+    includes = "\n".join(includes)
+    with open(file_name, "w") as f:
+        f.write(includes)
+        for variable_name, variable_value in variables.items():
+            f.write(f"const int32_t {variable_name}[N] = "+"{\n")
+            variable_str = ["\t"+str(i) for i in variable_value]
+            f.write(",\n".join(variable_str))
+            f.write("\n};\n\n")
+
+if __name__ == "__main__":
+    # Reset random seed for reproducible behavior
+    low_bound = -128
+    high_bound = 128
+    array_size = 10
+    np.random.seed(0)
+    # G = A*B
+    A = np.random.randint(low_bound, high_bound, size=array_size, dtype=np.dtype("int32"))
+    B = np.random.randint(low_bound, high_bound, size=array_size, dtype=np.dtype("int32"))
+    G = A * B
+    variables = {"A": A, "B": B, "G": G}
+    create_header("data.h", array_size, variables)
+    create_data("data.c", array_size, variables)

--- a/kernels/simple_mult/linalg.mlir
+++ b/kernels/simple_mult/linalg.mlir
@@ -1,0 +1,24 @@
+#simple_mult_attributes = {
+  indexing_maps = [
+    affine_map<(n) -> (n)>,
+    affine_map<(n) -> (n)>,
+    affine_map<(n) -> (n)>
+  ],
+  iterator_types = ["parallel"]
+}
+
+// https://github.com/pulp-platform/hwpe-mac-engine
+// in 'simple_mult' mode, it takes two 32bit fixed-point streams (vectors),
+// A, B and computes D = A * B where '*' is the elementwise product.
+func.func public @simple_mult(%A: memref<64xi32>,
+                             %B: memref<64xi32>,
+                             %D: memref<64xi32>) -> () {
+  linalg.generic #simple_mult_attributes
+  ins(%A, %B: memref<64xi32>, memref<64xi32>)
+  outs(%D: memref<64xi32>) {
+  ^bb0(%a: i32, %b: i32, %d: i32):
+    %r0 = arith.muli %a, %b : i32
+    linalg.yield %r0 : i32
+  }
+  return
+}

--- a/kernels/simple_mult/main.c
+++ b/kernels/simple_mult/main.c
@@ -1,0 +1,41 @@
+#include "data.h"
+#include "stdint.h"
+
+#include <snrt.h>
+
+// Kernel provided via external definition
+void simple_mult(int32_t *a, int32_t *b, int32_t *d);
+
+int main() {
+    // Allocate shared local memory
+    // By avoiding allocators and bumping by a known offset a base pointer
+    // (snrt_l1_next()) that is the same for all the cores in the cluster, we are
+    // essentially providing the same memory regions to all the cores in this cluster.
+    int32_t *local_A = (int32_t*)snrt_l1_next();
+    int32_t *local_B = local_A + N;
+    int32_t *local_D = local_B + N;
+
+    // Copy data in shared local memory
+    if (snrt_is_dm_core()) {
+        snrt_dma_start_1d(local_A, A, N * sizeof(float));
+        snrt_dma_start_1d(local_B, B, N * sizeof(float));
+    }
+
+    snrt_cluster_hw_barrier();
+
+    // Launch kernel: from this point on only core 0 is required to be alive.
+    int thiscore = snrt_cluster_core_idx();
+    if (thiscore != 0) return 0;
+
+    (void)snrt_mcycle();
+    simple_mult(local_A, local_B, local_D);
+    (void)snrt_mcycle();
+
+    // Correctness check
+    int nerr = 0;
+    for (int i = 0; i < N; i++) {
+        int32_t error = local_D[i] - G[i];
+        if (error != 0) nerr+=1;   
+    }
+    return nerr;
+}

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -1,0 +1,102 @@
+MAKEFILE_RULES_DIRNAME := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# Courtesy of Federico Ficarelli
+
+# NOTE: we are using  absolute paths from the Docker container
+SNITCH_LLVM_PATH = /opt/snitch-llvm
+SNITCH_RTL_PATH = /opt/snitch_cluster
+CC            = $(SNITCH_LLVM_PATH)/bin/riscv32-unknown-elf-clang
+LD            = $(SNITCH_LLVM_PATH)/bin/riscv32-unknown-elf-clang
+AR            = $(SNITCH_LLVM_PATH)/bin/llvm-ar
+RANLIB        = $(SNITCH_LLVM_PATH)/bin/llvm-ranlib
+VLTSIM        = /opt/snitch-rtl/bin/snitch_cluster.vlt
+DASM          = /opt/snitch-spike/bin/spike-dasm
+GENTRACE      = /opt/snitch_cluster/util/trace/gen_trace.py
+MLIROPT       = mlir-opt-16
+MLIRTRANSLATE = mlir-translate-16
+PYTHON        = /opt/python3.11/bin/python3
+
+CFLAGS =
+# Mixing .c and .ll files makes some flags, useful for the former,
+# unused for the latter (e.g. -I)
+CFLAGS += -Wno-unused-command-line-argument
+# Common flags
+CFLAGS += -I$(SNITCH_RTL_PATH)/target/snitch_cluster/sw/runtime/rtl/src
+CFLAGS += -I$(SNITCH_RTL_PATH)/target/snitch_cluster/sw/runtime/common
+CFLAGS += -I$(SNITCH_RTL_PATH)/sw/snRuntime/api
+CFLAGS += -I$(SNITCH_RTL_PATH)/sw/snRuntime/src
+CFLAGS += -I$(SNITCH_RTL_PATH)/sw/snRuntime/src/omp/
+CFLAGS += -I$(SNITCH_RTL_PATH)/sw/snRuntime/api/omp/
+CFLAGS += -I$(SNITCH_RTL_PATH)/sw/math/arch/riscv64/bits/
+CFLAGS += -I$(SNITCH_RTL_PATH)/sw/math/arch/generic
+CFLAGS += -I$(SNITCH_RTL_PATH)/sw/math/src/include
+CFLAGS += -I$(SNITCH_RTL_PATH)/sw/math/src/internal
+CFLAGS += -I$(SNITCH_RTL_PATH)/sw/math/include/bits
+CFLAGS += -I$(SNITCH_RTL_PATH)/sw/math/include
+CFLAGS += -D__DEFINED_uint64_t
+CFLAGS += -menable-experimental-extensions
+CFLAGS += -mcpu=snitch
+CFLAGS += -mabi=ilp32d
+CFLAGS += -mcmodel=medany
+CFLAGS += -ftls-model=local-exec
+CFLAGS += -ffast-math
+CFLAGS += -fno-builtin-printf
+CFLAGS += -fno-common
+CFLAGS += -O3
+
+LDFLAGS =
+LDFLAGS += -fuse-ld=$(SNITCH_LLVM_PATH)/bin/ld.lld
+LDFLAGS += -L$(SNITCH_LLVM_PATH)/lib/clang/12.0.1/lib/
+LDFLAGS += -T$(SNITCH_RTL_PATH)/sw/snRuntime/base.ld
+LDFLAGS += -L$(SNITCH_RTL_PATH)/target/snitch_cluster/sw/runtime/rtl
+LDFLAGS += -L$(SNITCH_RTL_PATH)/target/snitch_cluster/sw/runtime/rtl/build
+LDFLAGS += -nostartfiles
+LDFLAGS += -nostdlib
+LDFLAGS += -lclang_rt.builtins-riscv32
+LDFLAGS += -lc
+LDFLAGS += -lsnRuntime
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+%.ll12: %.ll
+	$(MAKEFILE_RULES_DIRNAME)/tollvm12.py < $< > $@
+
+%.o: %.ll12
+	$(CC) $(CFLAGS) -x ir -c $< -o $@
+
+%.o: %.S
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# MLIR
+
+MLIROPTFLAGS =
+MLIROPTFLAGS += -opaque-pointers=0
+MLIROPTFLAGS += --convert-linalg-to-loops
+MLIROPTFLAGS += --convert-scf-to-cf
+MLIROPTFLAGS += --canonicalize
+MLIROPTFLAGS += --cse
+MLIROPTFLAGS += --convert-math-to-llvm
+MLIROPTFLAGS += --convert-memref-to-llvm='use-generic-functions index-bitwidth=32'
+MLIROPTFLAGS += --convert-func-to-llvm='use-bare-ptr-memref-call-conv index-bitwidth=32'
+MLIROPTFLAGS += --convert-index-to-llvm=index-bitwidth=32
+MLIROPTFLAGS += --convert-cf-to-llvm=index-bitwidth=32
+MLIROPTFLAGS += --convert-arith-to-llvm=index-bitwidth=32
+MLIROPTFLAGS += --reconcile-unrealized-casts
+
+%.ll.mlir: %.mlir
+	$(MLIROPT) $(MLIROPTFLAGS) -o $@ $<
+
+%.ll: %.ll.mlir
+	$(MLIRTRANSLATE) -opaque-pointers=0 --mlir-to-llvmir -o $@ $<
+
+# Trace rules
+
+%.trace.txt %.trace.json: %.dasm
+	$(DASM) < $< | $(GENTRACE) --permissive -d $*.trace.json > $*.trace.txt
+
+define get_trace_targets
+	$(addsuffix .trace.txt, $(basename $(shell find $(1) -name 'trace_hart_*.dasm')))
+endef
+
+traces: $(call get_trace_targets,.)

--- a/runtime/tollvm12.py
+++ b/runtime/tollvm12.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+# Courtesy of Federico Ficarelli
+
+import re
+import sys
+import argparse
+
+PARSER = argparse.ArgumentParser(
+    prog="tollvm12.py",
+    description="""Transform an LLVM IR module to make it compatible with LLVM 12.
+Reads from stdin, outputs to stdout.
+
+Caveats:
+* This applies textual changes, no parsing is involved, so your mileage may
+  vary according to the input IR
+* The input IR must use typed pointee pointers
+
+Changes applied:
+* Fix (or add if not present) the module target triple
+* Fix (or add if not present) the module target data layout
+* Remove backward incompatible side effects attributes on functions
+* Fix (or add if not present) module flags specifying ABI and code model
+""",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+)
+
+SNITCH_DATALAYOUT = "e-m:e-p:32:32-i64:64-n32-S128"
+SNITCH_TRIPLE = "riscv32-unknown-unknown-elf"
+SNITCH_MODULE_METADATA = [
+    '{i32 1, !"wchar_size", i32 4}',
+    '{i32 1, !"target-abi", !"ilp32d"}',
+    '{i32 1, !"Code Model", i32 3}',
+    '{i32 1, !"SmallDataLimit", i32 8}',
+]
+
+
+def get_availale_metadata_id(ir):
+    return (
+        max(
+            (int(match.groups()[0]) for match in LLVM_NAMED_METADATA.finditer(ir)),
+            default=-1,
+        )
+        + 1
+    )
+
+
+if __name__ == "__main__":
+    args = PARSER.parse_args()
+    LLVM_TARGET_TRIPLE = re.compile('target\s+triple\s*=\s*".+"')
+    LLVM_TARGET_DATALAYOUT = re.compile('target\s+datalayout\s*=\s*".+"')
+    LLVM_NAMED_METADATA = re.compile("!(\d+)\s*=\s*!")
+    LLVM_MODULE_FLAGS = re.compile("!llvm\.module\.flags\s*=\s*.+")
+    LLVM_ATTR_SIDEEFFECT = re.compile("memory\(.*\)")
+    ir = sys.stdin.read()
+    # Remove offending stuff:
+    ir = re.sub(LLVM_TARGET_TRIPLE, "", ir)
+    ir = re.sub(LLVM_TARGET_DATALAYOUT, "", ir)
+    ir = re.sub(LLVM_ATTR_SIDEEFFECT, "", ir)
+    ir = re.sub(LLVM_MODULE_FLAGS, "", ir)
+    # Add top-level entities:
+    ir = (
+        f'target triple = "{SNITCH_TRIPLE}"\n'
+        + f'target datalayout = "{SNITCH_DATALAYOUT}"\n'
+        + ir
+    )
+    # Add metadata and module flags:
+    moduleflags = "!llvm.module.flags = !{ "
+    for metaid, meta in enumerate(SNITCH_MODULE_METADATA, get_availale_metadata_id(ir)):
+        ir += f"!{metaid} = !{meta}\n"
+        moduleflags += f"!{metaid}, "
+    moduleflags = moduleflags.rstrip(" ,")
+    moduleflags += "}\n"
+    ir += moduleflags
+    print(ir)


### PR DESCRIPTION
Makefiles, main.c, baseline.c and tollvm12.py script are courtesy of @nazavode :heart: 

Other files are made by me.

Initial example of a compilation flow (to CPU) to run stuff (a kernel that could run on HWPE-mac engine) on cpu 0 of a snitch_cluster.

This PR is ready for review in my opinion, but I'm waiting for a few things:
* A PR from Joren that installs stardew (I need to add numpy to a requirements file for gendata.py)
* A PR from Ryan that  changes the default snax config hjson (we can merge before!)

After Joren's PR I can add a CI job that runs all kernels in CI and checks for errors