### PR TITLE
expand .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 data.c
 data.h
 __pycache__
+launch.json
+settings.json
+.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.x
 data.c
 data.h
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
 .env
+.github
+.ruff_cache
+*.logs
+*.o
+*.ll12
+*.ll
+*.x
+data.c
+data.h


### PR DESCRIPTION
Expand the .gitignore file to exclude common build files and python thingies (env, pycache, ...)