### PR TITLE
end-to-end workflow

### DIFF
--- a/.github/workflows/build-run-kernel.yml
+++ b/.github/workflows/build-run-kernel.yml
@@ -10,12 +10,14 @@ jobs:
   build-and-run-kernels:
     runs-on: ubuntu-latest
     container: 
-      image: ghcr.io/kuleuven-micas/snax-mlir:pr-9@sha256:f1f626db8f7acf021272fb441165fd8a657622881650202e76dc464012d16491
+      image: ghcr.io/kuleuven-micas/snax-mlir:main
     steps:
       - uses: actions/checkout@v3
       - name: Install snax compiler
         run: |
           /opt/python3.11/bin/python3 -m pip install -e .
       - name: Build and run kernel simple mult
-        run: make allrun
+        run: |
+          export PATH=/opt/python3.11/bin:$PATH
+          make allrun
         working-directory: kernels/simple_mult

--- a/.github/workflows/build-run-kernel.yml
+++ b/.github/workflows/build-run-kernel.yml
@@ -7,9 +7,10 @@ on:
   pull_request:
 
 jobs:
-  build-and-run-kernels: 
+  build-and-run-kernels:
     runs-on: ubuntu-latest
-    container: ghcr.io/kuleuven-micas/snax-mlir:main
+    container: 
+      image: ghcr.io/kuleuven-micas/snax-mlir:pr-9@sha256:f1f626db8f7acf021272fb441165fd8a657622881650202e76dc464012d16491
     steps:
       - uses: actions/checkout@v3
       - name: Install snax compiler

--- a/.github/workflows/build-run-kernel.yml
+++ b/.github/workflows/build-run-kernel.yml
@@ -7,11 +7,14 @@ on:
   pull_request:
 
 jobs:
-  build-and-run-kernels:
+  build-and-run-kernels: 
     runs-on: ubuntu-latest
     container: ghcr.io/kuleuven-micas/snax-mlir:main
     steps:
       - uses: actions/checkout@v3
+      - name: Install snax compiler
+        run: |
+          pip3 install -e .
       - name: Build and run kernel simple mult
         run: make allrun
         working-directory: kernels/simple_mult

--- a/.github/workflows/build-run-kernel.yml
+++ b/.github/workflows/build-run-kernel.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install snax compiler
         run: |
-          pip3 install -e .
+          /opt/python3.11/bin/python3 -m pip install -e .
       - name: Build and run kernel simple mult
         run: make allrun
         working-directory: kernels/simple_mult

--- a/.github/workflows/lit-tests.yml
+++ b/.github/workflows/lit-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container: 
-      image: ghcr.io/kuleuven-micas/snax-mlir:pr-9@sha256:f1f626db8f7acf021272fb441165fd8a657622881650202e76dc464012d16491
+      image: ghcr.io/kuleuven-micas/snax-mlir:main
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/lit-tests.yml
+++ b/.github/workflows/lit-tests.yml
@@ -25,5 +25,6 @@ jobs:
     - name: Test with lit
       shell: bash
       run: |
+        export PATH=/opt/python3.11/bin:$PATH
         /opt/python3.11/bin/lit tests/filecheck -v
 

--- a/.github/workflows/lit-tests.yml
+++ b/.github/workflows/lit-tests.yml
@@ -25,6 +25,5 @@ jobs:
     - name: Test with lit
       shell: bash
       run: |
-        export PATH=/opt/python3.11/bin:$PATH
         /opt/python3.11/bin/lit tests/filecheck -v
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .env
-.github
 .ruff_cache
 *.logs
 *.o

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ settings.json
 .pyc
 .lit*
 *.egg*
+build

--- a/kernels/simple_mult/main.c
+++ b/kernels/simple_mult/main.c
@@ -6,6 +6,12 @@
 // Kernel provided via external definition
 void simple_mult(int32_t *a, int32_t *b, int32_t *d);
 
+void snax_hwpe_mult(int32_t *a, int32_t *b, int32_t *d) {
+  for (uint32_t i = 0; i < 64; ++i) {
+    d[i] = a[i] * b[i];
+  }
+}
+
 int main() {
   // Allocate shared local memory
   // By avoiding allocators and bumping by a known offset a base pointer

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -14,7 +14,7 @@ DASM          = /opt/snitch-spike/bin/spike-dasm
 GENTRACE      = /opt/snitch_cluster/util/trace/gen_trace.py
 MLIROPT       = mlir-opt-16
 MLIRTRANSLATE = mlir-translate-16
-SNAXOPT 	  = snax-opt
+SNAXOPT 	  = $(MAKEFILE_RULES_DIRNAME)/../compiler/snax-opt
 PYTHON        = /opt/python3.11/bin/python3
 
 CFLAGS =

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -14,6 +14,7 @@ DASM          = /opt/snitch-spike/bin/spike-dasm
 GENTRACE      = /opt/snitch_cluster/util/trace/gen_trace.py
 MLIROPT       = mlir-opt-16
 MLIRTRANSLATE = mlir-translate-16
+SNAXOPT 	  = snax-opt
 PYTHON        = /opt/python3.11/bin/python3
 
 CFLAGS =
@@ -68,6 +69,29 @@ LDFLAGS += -lsnRuntime
 %.o: %.S
 	$(CC) $(CFLAGS) -c $< -o $@
 
+# MLIR Preprocessing
+
+MLIRPREPROCFLAGS =
+MLIRPREPROCFLAGS += --linalg-generalize-named-ops
+MLIRPREPROCFLAGS += --mlir-print-op-generic
+MLIRPREPROCFLAGS += --mlir-print-local-scope
+
+%.preproc.mlir: %.mlir
+	$(MLIROPT) $(MLIRPREPROCFLAGS) -o $@ $<
+
+# SNAX opt
+
+SNAXOPTFLAGS = -p dispatch-elementwise-mult,linalg-to-library-call
+
+%.preproc18.mlir: %.preproc.mlir
+	$(MAKEFILE_RULES_DIRNAME)/tomlir18.py < $< > $@
+
+%.snax-opt18.mlir: %.preproc18.mlir
+	$(SNAXOPT) $(SNAXOPTFLAGS) -o $@ $<
+
+%.snax-opt.mlir: %.snax-opt18.mlir
+	$(MAKEFILE_RULES_DIRNAME)/tomlir16.py < $< > $@
+
 # MLIR
 
 MLIROPTFLAGS =
@@ -84,7 +108,7 @@ MLIROPTFLAGS += --convert-cf-to-llvm=index-bitwidth=32
 MLIROPTFLAGS += --convert-arith-to-llvm=index-bitwidth=32
 MLIROPTFLAGS += --reconcile-unrealized-casts
 
-%.ll.mlir: %.mlir
+%.ll.mlir: %.snax-opt.mlir
 	$(MLIROPT) $(MLIROPTFLAGS) -o $@ $<
 
 %.ll: %.ll.mlir

--- a/runtime/tomlir16.py
+++ b/runtime/tomlir16.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+
+
+if __name__ == "__main__":
+    ir = sys.stdin.read()
+    ir = re.sub(
+        r"<({.*?})>\s*(\({[^}]*}\))", lambda x: f"{x.group(2)} {x.group(1)}", ir
+    )
+    ir = re.sub('"indexing_maps"', "indexing_maps", ir)
+    ir = re.sub('"iterator_types"', "iterator_types", ir)
+    ir = re.sub('"operandSegmentSizes"', "operand_segment_sizes", ir)
+    print(ir)

--- a/runtime/tomlir16.py
+++ b/runtime/tomlir16.py
@@ -1,15 +1,29 @@
 #!/usr/bin/env python3
 
+""" Convert an MLIR18 file to MLIR16
+This program performs the following conversion steps:
+    *   take properties enclosed in <{}> and make them attributes:
+        change enclosing to {} and move them to come after the 
+        region of the operation
+    *   change operandSegmentSizes to operand_segment_sizes
+    *   remove double quotes from attribute names 
+"""
+
 import re
 import sys
 
 
 if __name__ == "__main__":
     ir = sys.stdin.read()
+
+    # swap attributes and region from place, and remove <> from attributes
     ir = re.sub(
         r"<({.*?})>\s*(\({[^}]*}\))", lambda x: f"{x.group(2)} {x.group(1)}", ir
     )
+    # remove quotes
     ir = re.sub('"indexing_maps"', "indexing_maps", ir)
+    # remove quotes
     ir = re.sub('"iterator_types"', "iterator_types", ir)
+    # remove quotes and change spelling
     ir = re.sub('"operandSegmentSizes"', "operand_segment_sizes", ir)
     print(ir)

--- a/runtime/tomlir18.py
+++ b/runtime/tomlir18.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+
+
+if __name__ == "__main__":
+    ir = sys.stdin.read()
+    ir = re.sub("indexing_maps", '"indexing_maps"', ir)
+    ir = re.sub("iterator_types", '"iterator_types"', ir)
+    ir = re.sub("operand_segment_sizes", '"operandSegmentSizes"', ir)
+    print(ir)

--- a/runtime/tomlir18.py
+++ b/runtime/tomlir18.py
@@ -1,12 +1,21 @@
 #!/usr/bin/env python3
 
+""" Convert an MLIR18 file to MLIR16
+This program performs the following conversion steps:
+    *   change operand_segment_sizes to operandSegmentSizes
+    *   add double quotes to attribute names 
+"""
+
 import re
 import sys
 
 
 if __name__ == "__main__":
     ir = sys.stdin.read()
+    # add quotes
     ir = re.sub("indexing_maps", '"indexing_maps"', ir)
+    # add quotes
     ir = re.sub("iterator_types", '"iterator_types"', ir)
+    # add quotes and change spelling
     ir = re.sub("operand_segment_sizes", '"operandSegmentSizes"', ir)
     print(ir)


### PR DESCRIPTION
This pull request implements an end-to-end flow from mlir to simulation on a snitch cluster. The steps taken look like this:

Preprocess the input mlir to with generic printing and local scope
`input.mlir ->  input.preproc.mlir`

Translate MLIR 16 to MLIR18 with a python script
`input.preproc.mlir -> input.preproc18.mlir`

Apply the custom `snax-opt` compiler. This includes passes to lower the linalg generics to external function calls which drive the accelerator
`input.preproc18.mlir -> input.snax-opt18.mlir`

Translate back to MLIR 16
`input.snax-opt18.mlir -> input.snax-opt.mlir`

Now use the existing MLIR workflow to lower and translate the remaining MLIR to LLVM, compile and run
