### PR TITLE
Add memref calling convention

### DIFF
--- a/kernels/simple_mult/baseline.c
+++ b/kernels/simple_mult/baseline.c
@@ -4,9 +4,20 @@
 
 #include <stdint.h>
 
-void simple_mult(const int32_t *A, const int32_t *B, int32_t *D) {
+struct OneDMemrefI32 {
+  int32_t *data; // allocated pointer: Pointer to data buffer as allocated,
+                 // only used for deallocating the memref
+  int32_t *aligned_data; // aligned pointer: Pointer to properly aligned data
+                         // that memref indexes
+  uint32_t *offset;
+  uint32_t *shape[1];
+  uint32_t *stride[1];
+};
+
+void _mlir_ciface_simple_mult(struct OneDMemrefI32 *A, struct OneDMemrefI32 *B,
+                              struct OneDMemrefI32 *D) {
   const uint32_t n = N;
   for (uint32_t i = 0; i < n; ++i) {
-    D[i] = A[i] * B[i];
+    D->aligned_data[i] = A->aligned_data[i] * B->aligned_data[i];
   }
 }

--- a/kernels/simple_mult/baseline.c
+++ b/kernels/simple_mult/baseline.c
@@ -1,21 +1,12 @@
 #include "data.h"
+#include "memref.h"
 
 #include <snrt.h>
 
 #include <stdint.h>
 
-struct OneDMemrefI32 {
-  int32_t *data; // allocated pointer: Pointer to data buffer as allocated,
-                 // only used for deallocating the memref
-  int32_t *aligned_data; // aligned pointer: Pointer to properly aligned data
-                         // that memref indexes
-  uint32_t *offset;
-  uint32_t *shape[1];
-  uint32_t *stride[1];
-};
-
-void _mlir_ciface_simple_mult(struct OneDMemrefI32 *A, struct OneDMemrefI32 *B,
-                              struct OneDMemrefI32 *D) {
+void _mlir_ciface_simple_mult(OneDMemrefI32_t *A, OneDMemrefI32_t *B,
+                              OneDMemrefI32_t *D) {
   const uint32_t n = N;
   for (uint32_t i = 0; i < n; ++i) {
     D->aligned_data[i] = A->aligned_data[i] * B->aligned_data[i];

--- a/kernels/simple_mult/main.c
+++ b/kernels/simple_mult/main.c
@@ -11,8 +11,6 @@ void _mlir_ciface_simple_mult(OneDMemrefI32_t *a, OneDMemrefI32_t *b,
 
 void _mlir_ciface_snax_hwpe_mult(OneDMemrefI32_t *a, OneDMemrefI32_t *b,
                                  OneDMemrefI32_t *d) {
-  // shape of data is statically defined in data.h
-  // printf("%x\n", *((uint32_t*)a->shape[0]));
   snax_mac_setup_simple_mult(a->aligned_data, b->aligned_data, d->aligned_data,
                              a->shape[0]);
   snax_mac_launch();
@@ -53,10 +51,6 @@ int main() {
       .shape[0] = &constant_size,
       .stride[0] = &constant_zero,
   };
-
-  // int32_t *local_A = (int32_t *)snrt_l1_next();
-  // int32_t *local_B = local_A + N;
-  // int32_t *local_D = local_B + N;
 
   // Copy data in shared local memory
   if (snrt_is_dm_core()) {

--- a/kernels/simple_mult/main.c
+++ b/kernels/simple_mult/main.c
@@ -1,26 +1,16 @@
 #include "data.h"
 #include "mac.h"
+#include "memref.h"
 #include "stdint.h"
 
 #include <snrt.h>
 
-struct OneDMemrefI32 {
-  int32_t *data; // allocated pointer: Pointer to data buffer as allocated,
-                 // only used for deallocating the memref
-  int32_t *aligned_data; // aligned pointer: Pointer to properly aligned data
-                         // that memref indexes
-  uint32_t *offset;
-  uint32_t *shape[1];
-  uint32_t *stride[1];
-};
-
 // Kernel provided via external definition
-void _mlir_ciface_simple_mult(struct OneDMemrefI32 *a, struct OneDMemrefI32 *b,
-                              struct OneDMemrefI32 *d);
+void _mlir_ciface_simple_mult(OneDMemrefI32_t *a, OneDMemrefI32_t *b,
+                              OneDMemrefI32_t *d);
 
-void _mlir_ciface_snax_hwpe_mult(struct OneDMemrefI32 *a,
-                                 struct OneDMemrefI32 *b,
-                                 struct OneDMemrefI32 *d) {
+void _mlir_ciface_snax_hwpe_mult(OneDMemrefI32_t *a, OneDMemrefI32_t *b,
+                                 OneDMemrefI32_t *d) {
   // shape of data is statically defined in data.h
   // printf("%x\n", *((uint32_t*)a->shape[0]));
   snax_mac_setup_simple_mult(a->aligned_data, b->aligned_data, d->aligned_data,
@@ -40,7 +30,7 @@ int main() {
   uint32_t constant_size = N;
   // Allocate memory for the fields
 
-  struct OneDMemrefI32 memrefA = {
+  OneDMemrefI32_t memrefA = {
       .data = (int32_t *)snrt_l1_next(),
       .aligned_data = memrefA.data,
       .offset = &constant_zero,
@@ -48,7 +38,7 @@ int main() {
       .stride[0] = &constant_zero,
   };
 
-  struct OneDMemrefI32 memrefB = {
+  OneDMemrefI32_t memrefB = {
       .data = (int32_t *)memrefA.data + N,
       .aligned_data = memrefB.data,
       .offset = &constant_zero,
@@ -56,7 +46,7 @@ int main() {
       .stride[0] = &constant_zero,
   };
 
-  struct OneDMemrefI32 memrefD = {
+  OneDMemrefI32_t memrefD = {
       .data = (int32_t *)memrefB.data + N,
       .aligned_data = memrefD.data,
       .offset = &constant_zero,

--- a/kernels/simple_mult/main.c
+++ b/kernels/simple_mult/main.c
@@ -60,8 +60,10 @@ int main() {
 
   // Copy data in shared local memory
   if (snrt_is_dm_core()) {
-    snrt_dma_start_1d(memrefA.data, A, N * sizeof(int32_t));
-    snrt_dma_start_1d(memrefB.data, B, N * sizeof(int32_t));
+    snrt_dma_start_1d(memrefA.aligned_data, A,
+                      *(memrefA.shape[0]) * sizeof(int32_t));
+    snrt_dma_start_1d(memrefB.aligned_data, B,
+                      *(memrefB.shape[0]) * sizeof(int32_t));
   }
 
   snrt_cluster_hw_barrier();
@@ -78,7 +80,7 @@ int main() {
   // Correctness check
   int nerr = 0;
   for (int i = 0; i < N; i++) {
-    int32_t error = memrefD.data[i] - G[i];
+    int32_t error = memrefD.aligned_data[i] - G[i];
     if (error != 0)
       nerr += 1;
   }

--- a/kernels/simple_mult/main.c
+++ b/kernels/simple_mult/main.c
@@ -4,12 +4,27 @@
 
 #include <snrt.h>
 
-// Kernel provided via external definition
-void simple_mult(int32_t *a, int32_t *b, int32_t *d);
+struct OneDMemrefI32 {
+  int32_t *data; // allocated pointer: Pointer to data buffer as allocated,
+                 // only used for deallocating the memref
+  int32_t *aligned_data; // aligned pointer: Pointer to properly aligned data
+                         // that memref indexes
+  uint32_t *offset;
+  uint32_t *shape[1];
+  uint32_t *stride[1];
+};
 
-void snax_hwpe_mult(int32_t *a, int32_t *b, int32_t *d) {
+// Kernel provided via external definition
+void _mlir_ciface_simple_mult(struct OneDMemrefI32 *a, struct OneDMemrefI32 *b,
+                              struct OneDMemrefI32 *d);
+
+void _mlir_ciface_snax_hwpe_mult(struct OneDMemrefI32 *a,
+                                 struct OneDMemrefI32 *b,
+                                 struct OneDMemrefI32 *d) {
   // shape of data is statically defined in data.h
-  snax_mac_setup_simple_mult(a, b, d, N);
+  // printf("%x\n", *((uint32_t*)a->shape[0]));
+  snax_mac_setup_simple_mult(a->aligned_data, b->aligned_data, d->aligned_data,
+                             a->shape[0]);
   snax_mac_launch();
   snax_mac_sw_barrier();
 }
@@ -20,14 +35,43 @@ int main() {
   // (snrt_l1_next()) that is the same for all the cores in the cluster, we are
   // essentially providing the same memory regions to all the cores in this
   // cluster.
-  int32_t *local_A = (int32_t *)snrt_l1_next();
-  int32_t *local_B = local_A + N;
-  int32_t *local_D = local_B + N;
+
+  uint32_t constant_zero = 0;
+  uint32_t constant_size = N;
+  // Allocate memory for the fields
+
+  struct OneDMemrefI32 memrefA = {
+      .data = (int32_t *)snrt_l1_next(),
+      .aligned_data = memrefA.data,
+      .offset = &constant_zero,
+      .shape[0] = &constant_size,
+      .stride[0] = &constant_zero,
+  };
+
+  struct OneDMemrefI32 memrefB = {
+      .data = (int32_t *)memrefA.data + N,
+      .aligned_data = memrefB.data,
+      .offset = &constant_zero,
+      .shape[0] = &constant_size,
+      .stride[0] = &constant_zero,
+  };
+
+  struct OneDMemrefI32 memrefD = {
+      .data = (int32_t *)memrefB.data + N,
+      .aligned_data = memrefD.data,
+      .offset = &constant_zero,
+      .shape[0] = &constant_size,
+      .stride[0] = &constant_zero,
+  };
+
+  // int32_t *local_A = (int32_t *)snrt_l1_next();
+  // int32_t *local_B = local_A + N;
+  // int32_t *local_D = local_B + N;
 
   // Copy data in shared local memory
   if (snrt_is_dm_core()) {
-    snrt_dma_start_1d(local_A, A, N * sizeof(float));
-    snrt_dma_start_1d(local_B, B, N * sizeof(float));
+    snrt_dma_start_1d(memrefA.data, A, N * sizeof(int32_t));
+    snrt_dma_start_1d(memrefB.data, B, N * sizeof(int32_t));
   }
 
   snrt_cluster_hw_barrier();
@@ -38,13 +82,13 @@ int main() {
     return 0;
 
   (void)snrt_mcycle();
-  simple_mult(local_A, local_B, local_D);
+  _mlir_ciface_simple_mult(&memrefA, &memrefB, &memrefD);
   (void)snrt_mcycle();
 
   // Correctness check
   int nerr = 0;
   for (int i = 0; i < N; i++) {
-    int32_t error = local_D[i] - G[i];
+    int32_t error = memrefD.data[i] - G[i];
     if (error != 0)
       nerr += 1;
   }

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -35,6 +35,7 @@ CFLAGS += -I$(SNITCH_RTL_PATH)/sw/math/src/internal
 CFLAGS += -I$(SNITCH_RTL_PATH)/sw/math/include/bits
 CFLAGS += -I$(SNITCH_RTL_PATH)/sw/math/include
 CFLAGS += -I$(SNITCH_RTL_PATH)/target/snitch_cluster/sw/snax/mac/include
+CFLAGS += -I$(MAKEFILE_RULES_DIRNAME)include
 CFLAGS += -D__DEFINED_uint64_t
 CFLAGS += -menable-experimental-extensions
 CFLAGS += -mcpu=snitch

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -103,8 +103,9 @@ MLIROPTFLAGS += --convert-scf-to-cf
 MLIROPTFLAGS += --canonicalize
 MLIROPTFLAGS += --cse
 MLIROPTFLAGS += --convert-math-to-llvm
+MLIROPTFLAGS += --llvm-request-c-wrappers
 MLIROPTFLAGS += --convert-memref-to-llvm='use-generic-functions index-bitwidth=32'
-MLIROPTFLAGS += --convert-func-to-llvm='use-bare-ptr-memref-call-conv index-bitwidth=32'
+MLIROPTFLAGS += --convert-func-to-llvm='index-bitwidth=32'
 MLIROPTFLAGS += --convert-index-to-llvm=index-bitwidth=32
 MLIROPTFLAGS += --convert-cf-to-llvm=index-bitwidth=32
 MLIROPTFLAGS += --convert-arith-to-llvm=index-bitwidth=32

--- a/runtime/include/memref.h
+++ b/runtime/include/memref.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <stdint.h>
+
+struct OneDMemrefI32 {
+  int32_t *data; // allocated pointer: Pointer to data buffer as allocated,
+                 // only used for deallocating the memref
+  int32_t *aligned_data; // aligned pointer: Pointer to properly aligned data
+                         // that memref indexes
+  uint32_t *offset;
+  uint32_t *shape[1];
+  uint32_t *stride[1];
+};
+
+typedef struct OneDMemrefI32 OneDMemrefI32_t;


### PR DESCRIPTION
This PR steps away from bare-ptr-calling-conv in mlir and uses mlir's C wrappers instead.
This means that we can represent more shapes (even dynamic ones! - but not unranked ones :( ).
We can also only represent strided memrefs, not just any memref.

Note that this applies the new wrappers to both the calling functions and the called functions of mlir.

I'm expecting a slight performance degradation from this update, this might mean that we should look into lto with LLD?