### PR TITLE
add numpy to requirements

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -97,6 +97,12 @@ deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-16 main\n" >> /etc/apt
 # add python3.11 to path in bashrc
 RUN echo "export PATH=/opt/python3.11/bin:$PATH" >> ~/.bashrc
 
+# install python requirements
+RUN export PATH=/opt/python3.11/bin:$PATH \
+ && git clone https://github.com/kuleuven-micas/snax-mlir.git \
+ && cd /snax-mlir \
+ && pip3 install -r requirements.txt
+
 # install latest xdsl and test dependencies
 RUN export PATH=/opt/python3.11/bin:$PATH \
    && pip3 install git+https://github.com/xdslproject/xdsl.git@4c04de0a16df7c3b29f81aa66a7a2603d6b80f1e\

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -100,7 +100,7 @@ RUN echo "export PATH=/opt/python3.11/bin:$PATH" >> ~/.bashrc
 # install python requirements
 RUN export PATH=/opt/python3.11/bin:$PATH \
  && git clone https://github.com/kuleuven-micas/snax-mlir.git \
- && cd /snax-mlir \
+ && cd snax-mlir \
  && pip3 install -r requirements.txt
 
 # install latest xdsl and test dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pre-commit
 filecheck
 lit
+numpy
 


### PR DESCRIPTION
Apperently, numpy was only installed in the container because it was a dependency of torch-mlir.
This pull request adds numpy to the requirements, and also installs the requirements of this repository in the container build