### PR TITLE
Compiler: add transform snax-to-func

### DIFF
--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -8,6 +8,7 @@ from compiler.transforms.set_memory_space import SetMemorySpace
 from compiler.transforms.insert_sync_barrier import InsertSyncBarrier
 from compiler.transforms.dispatch_regions import DispatchRegions
 from compiler.transforms.snax_copy_to_dma import SNAXCopyToDMA
+from compiler.transforms.snax_to_func import SNAXToFunc
 from collections.abc import Sequence
 
 
@@ -35,6 +36,7 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(InsertSyncBarrier)
         super().register_pass(DispatchRegions)
         super().register_pass(SNAXCopyToDMA)
+        super().register_pass(SNAXToFunc)
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/transforms/snax_to_func.py
+++ b/compiler/transforms/snax_to_func.py
@@ -1,0 +1,42 @@
+from xdsl.dialects import builtin, func
+from xdsl.ir import MLContext
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriteWalker,
+    PatternRewriter,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from compiler.dialects import snax
+from xdsl.traits import SymbolTable
+
+
+class InsertFunctionCall(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, func_op: snax.ClusterSyncOp, rewriter: PatternRewriter):
+        """Swap cluster sync op with function call"""
+        func_call = func.Call("snrt_cluster_hw_barrier", [], [])
+        rewriter.replace_matched_op(func_call)
+
+
+class InsertFunctionDeclaration(RewritePattern):
+    """Insert external function declarations of snrt_cluster_hw_barrier"""
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, module_op: builtin.ModuleOp, rewriter: PatternRewriter):
+        func_op = func.FuncOp.external("snrt_cluster_hw_barrier", [], [])
+        SymbolTable.insert_or_update(module_op, func_op)
+
+
+class SNAXToFunc(ModulePass):
+    name = "snax-to-func"
+
+    def apply(self, ctx: MLContext, module: builtin.ModuleOp) -> None:
+        contains_sync = any(
+            isinstance(op_in_module, snax.ClusterSyncOp)
+            for op_in_module in module.walk()
+        )
+
+        if contains_sync:
+            PatternRewriteWalker(InsertFunctionCall()).rewrite_module(module)
+            PatternRewriteWalker(InsertFunctionDeclaration()).rewrite_module(module)

--- a/tests/filecheck/transforms/snax_to_func.mlir
+++ b/tests/filecheck/transforms/snax_to_func.mlir
@@ -1,0 +1,11 @@
+// RUN: ./compiler/snax-opt --split-input-file %s -p snax-to-func --print-op-generic | filecheck %s
+
+"builtin.module"() ({
+  "snax.cluster_sync_op"() : () -> ()
+}) : () -> ()
+
+//CHECK: "builtin.module"() ({
+//CHECK-NEXT:   "func.call"() <{"callee" = @snrt_cluster_hw_barrier}> : () -> ()
+//CHECK-NEXT:   "func.func"() <{"sym_name" = "snrt_cluster_hw_barrier", "function_type" = () -> (), "sym_visibility" = "private"}> ({
+//CHECK-NEXT:   }) : () -> ()
+//CHECK-NEXT: }) : () -> ()


### PR DESCRIPTION
This pass transform snax dialect ops to external function calls, such that they can be implemented with the C runtime of snitch

For now, this is only the cluster sync op