### PR TITLE
Move dependences to requirements.txt (#40)

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -37,3 +37,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |-
             SNITCH_LLVM_VERSION=latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -124,9 +124,3 @@ RUN export PATH=/opt/python3.11/bin:$PATH \
  && git clone https://github.com/kuleuven-micas/snax-mlir.git \
  && cd snax-mlir \
  && pip3 install -r requirements.txt
-
-# install latest xdsl and test dependencies
-RUN export PATH=/opt/python3.11/bin:$PATH \
-   && pip3 install git+https://github.com/xdslproject/xdsl.git@4c04de0a16df7c3b29f81aa66a7a2603d6b80f1e\
-   && pip3 install filecheck \
-   && pip3 install lit

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ pre-commit
 filecheck
 lit
 numpy
+xdsl @ git+https://github.com/xdslproject/xdsl.git@4c04de0a16df7c3b29f81aa66a7a2603d6b80f1e
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ pre-commit
 filecheck
 lit
 numpy
-xdsl @ git+https://github.com/xdslproject/xdsl.git@4c04de0a16df7c3b29f81aa66a7a2603d6b80f1e
+xdsl @ git+https://github.com/xdslproject/xdsl.git@82e4af23bacddefa100ecf662385e34c3b4a1c5f
 


### PR DESCRIPTION
Filecheck and lit are already moved, so we can just drop them.