### PR TITLE
add dynamic alloc support

### DIFF
--- a/compiler/transforms/set_memory_space.py
+++ b/compiler/transforms/set_memory_space.py
@@ -159,6 +159,7 @@ class RealizeMemorySpaceCasts(RewritePattern):
         shapes = [x.value.data for x in op.results[0].type.shape.data]
         dyn_operands = []
         for i in range(len(shapes)):
+            # Dynamic shapes are represented as -1
             if shapes[i] == -1:
                 ## create dim op
                 index = arith.Constant.from_int_and_width(i, builtin.IndexType())

--- a/kernels/simple_mult/linalg.mlir
+++ b/kernels/simple_mult/linalg.mlir
@@ -10,12 +10,12 @@
 // https://github.com/pulp-platform/hwpe-mac-engine
 // in 'simple_mult' mode, it takes two 32bit fixed-point streams (vectors),
 // A, B and computes D = A * B where '*' is the elementwise product.
-func.func public @simple_mult(%A: memref<10xi32>,
-                             %B: memref<10xi32>,
-                             %D: memref<10xi32>) -> () {
+func.func public @simple_mult(%A: memref<?xi32>,
+                             %B: memref<?xi32>,
+                             %D: memref<?xi32>) -> () {
   linalg.generic #simple_mult_attributes
-  ins(%A, %B: memref<10xi32>, memref<10xi32>)
-  outs(%D: memref<10xi32>) {
+  ins(%A, %B: memref<?xi32>, memref<?xi32>)
+  outs(%D: memref<?xi32>) {
   ^bb0(%a: i32, %b: i32, %d: i32):
     %r0 = arith.muli %a, %b : i32
     linalg.yield %r0 : i32

--- a/tests/filecheck/transforms/set-memory-space.mlir
+++ b/tests/filecheck/transforms/set-memory-space.mlir
@@ -12,12 +12,12 @@
   }) : () -> ()
 }) : () -> ()
 
-//CHECK:      "builtin.module"() ({
+//CHECK: "builtin.module"() ({
 //CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
 //CHECK-NEXT:   ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
-//CHECK-NEXT:     %0 = "memref.alloc"() <{"operandSegmentSizes" = array<i32: 0, 0>}> {"alignment" = 64 : i64} : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     %1 = "memref.alloc"() <{"operandSegmentSizes" = array<i32: 0, 0>}> {"alignment" = 64 : i64} : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     %2 = "memref.alloc"() <{"operandSegmentSizes" = array<i32: 0, 0>}> {"alignment" = 64 : i64} : () -> memref<64xi32, 1 : i32>
+//CHECK-NEXT:     %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+//CHECK-NEXT:     %1 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+//CHECK-NEXT:     %2 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
 //CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
 //CHECK-NEXT:     "memref.copy"(%arg1, %1) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
 //CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
@@ -50,12 +50,12 @@
 }) : () -> ()
 
 
-//CHECK:      "builtin.module"() ({
+//CHECK: "builtin.module"() ({
 //CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
 //CHECK-NEXT:   ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
-//CHECK-NEXT:     %0 = "memref.alloc"() <{"operandSegmentSizes" = array<i32: 0, 0>}> {"alignment" = 64 : i64} : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     %1 = "memref.alloc"() <{"operandSegmentSizes" = array<i32: 0, 0>}> {"alignment" = 64 : i64} : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     %2 = "memref.alloc"() <{"operandSegmentSizes" = array<i32: 0, 0>}> {"alignment" = 64 : i64} : () -> memref<64xi32, 1 : i32>
+//CHECK-NEXT:     %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+//CHECK-NEXT:     %1 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+//CHECK-NEXT:     %2 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
 //CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
 //CHECK-NEXT:     "memref.copy"(%arg1, %1) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
 //CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
@@ -69,6 +69,54 @@
 //CHECK-NEXT:       "linalg.yield"(%4) : (i32) -> ()
 //CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
 //CHECK-NEXT:     "memref.copy"(%2, %arg2) : (memref<64xi32, 1 : i32>, memref<64xi32, 0 : i32>) -> ()
+//CHECK-NEXT:     "func.return"() : () -> ()
+//CHECK-NEXT:   }) : () -> ()
+//CHECK-NEXT: }) : () -> ()
+
+// -----
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (), sym_name = "simple_mult", sym_visibility = "public"}> ({
+  ^bb0(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>):
+    "linalg.generic"(%arg0, %arg1, %arg2) <{indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = [#linalg.iterator_type<parallel>], operandSegmentSizes = array<i32: 2, 1>}> ({
+    ^bb0(%arg3: i32, %arg4: i32, %arg5: i32):
+      %0 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+      "linalg.yield"(%0) : (i32) -> ()
+    }) : (memref<?xi32>, memref<?xi32>, memref<?xi32>) -> ()
+    "linalg.generic"(%arg0, %arg1, %arg2) <{indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = [#linalg.iterator_type<parallel>], operandSegmentSizes = array<i32: 2, 1>}> ({
+    ^bb0(%arg3: i32, %arg4: i32, %arg5: i32):
+      %0 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+      "linalg.yield"(%0) : (i32) -> ()
+    }) : (memref<?xi32>, memref<?xi32>, memref<?xi32>) -> ()
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+//CHECK: "builtin.module"() ({
+//CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+//CHECK-NEXT:   ^0(%arg0 : memref<?xi32, 0 : i32>, %arg1 : memref<?xi32, 0 : i32>, %arg2 : memref<?xi32, 0 : i32>):
+//CHECK-NEXT:     %0 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+//CHECK-NEXT:     %1 = "memref.dim"(%arg0, %0) : (memref<?xi32, 0 : i32>, index) -> index
+//CHECK-NEXT:     %2 = "memref.alloc"(%1) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
+//CHECK-NEXT:     %3 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+//CHECK-NEXT:     %4 = "memref.dim"(%arg1, %3) : (memref<?xi32, 0 : i32>, index) -> index
+//CHECK-NEXT:     %5 = "memref.alloc"(%4) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
+//CHECK-NEXT:     %6 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+//CHECK-NEXT:     %7 = "memref.dim"(%arg2, %6) : (memref<?xi32, 0 : i32>, index) -> index
+//CHECK-NEXT:     %8 = "memref.alloc"(%7) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
+//CHECK-NEXT:     "memref.copy"(%arg0, %2) : (memref<?xi32, 0 : i32>, memref<?xi32, 1 : i32>) -> ()
+//CHECK-NEXT:     "memref.copy"(%arg1, %5) : (memref<?xi32, 0 : i32>, memref<?xi32, 1 : i32>) -> ()
+//CHECK-NEXT:     "linalg.generic"(%2, %5, %8) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+//CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+//CHECK-NEXT:       %9 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+//CHECK-NEXT:       "linalg.yield"(%9) : (i32) -> ()
+//CHECK-NEXT:     }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
+//CHECK-NEXT:     "linalg.generic"(%2, %5, %8) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+//CHECK-NEXT:     ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
+//CHECK-NEXT:       %10 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
+//CHECK-NEXT:       "linalg.yield"(%10) : (i32) -> ()
+//CHECK-NEXT:     }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
+//CHECK-NEXT:     "memref.copy"(%8, %arg2) : (memref<?xi32, 1 : i32>, memref<?xi32, 0 : i32>) -> ()
 //CHECK-NEXT:     "func.return"() : () -> ()
 //CHECK-NEXT:   }) : () -> ()
 //CHECK-NEXT: }) : () -> ()


### PR DESCRIPTION
This PR adds dynamic shape support for the pass `set-memory-spaces`. 
If the pass realizes a memory cast on dynamically shaped memrefs, the dynamic allocations are now correctly handled.

The kernel `simple_mult` is adapted to use dynamic shapes.