### PR TITLE
fix xdsl bug

### DIFF
--- a/.github/workflows/build-run-kernel.yml
+++ b/.github/workflows/build-run-kernel.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Install snax compiler
         run: |
           /opt/python3.11/bin/python3 -m pip install -e .
+      - name: Reinstall pip modules from requirements
+        run: |
+          /opt/python3.11/bin/python3 -m pip install -r requirements.txt
       - name: Build and run kernel simple mult
         run: |
           export PATH=/opt/python3.11/bin:$PATH

--- a/.github/workflows/lit-tests.yml
+++ b/.github/workflows/lit-tests.yml
@@ -22,6 +22,10 @@ jobs:
       shell: bash
       run: |
         /opt/python3.11/bin/python3 -m pip install -e .
+    - name: Reinstall pip modules from requirements
+      shell: bash
+      run: |
+        /opt/python3.11/bin/python3 -m pip install -r requirements.txt
     - name: Test with lit
       shell: bash
       run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,6 +22,10 @@
 #       shell: bash
 #       run: |
 #         /opt/python3.11/bin/python3 -m pip install pytest
+#     - name: Reinstall pip modules from requirements
+#       shell: bash
+#       run: |
+#         /opt/python3.11/bin/python3 -m pip install -r requirements.txt
 #     - name: Test with pytest
 #       shell: bash
 #       run: |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Note: leaving out the `config` `--build-arg` will use the default `snitch_cluste
 
 Our github actions use the container build to run tests. The actions always use the last docker build from the `main` branch. Be aware that if you make changes to the Dockerfile in a certain PR, the actions will still run on the `main` Docker build, which may result in errors. Changes to `requirements.txt` are reinstalled before every test, so these are safe to change. The following packages are only defined in the Dockerfile and thus require extra caution when changing:
 
-* [snax-cluster](https://github.com/kuleuven-micas/snitch_cluster) and dependencies (runtime, verilator, runtime, spike)
+* [snax-cluster](https://github.com/kuleuven-micas/snitch_cluster) and dependencies (runtime, verilator, spike)
 * llvm (llvm, clang, lld)
 * standard linux packages
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Our github actions use the container build to run tests. The actions always use 
 
 * [snax-cluster](https://github.com/kuleuven-micas/snitch_cluster) and dependencies (runtime, verilator, spike)
 * llvm (llvm, clang, lld)
-* standard linux packages
+* standard linux packages (everything installed with `apt`)
 
 ## Pytorch -> Linalg
 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,17 @@ pytorch -> `torch-mlir` -> linalg dialect -> mlir-opt, mlir-translate, clang -> 
 
 ## Setup with Docker Container
 
-For compiling the low-level kernels you need the snitch compilation toolchain, 
+For compiling the low-level kernels you need the snitch compilation toolchain,
 which is easiest to get through a docker container.
 
 ### Getting the container remotely
 
 You can run tests/experiments in this repository with:
+
 ```sh
 docker run -itv `pwd`:/repo:z ghcr.io/kuleuven-micas/snax-mlir:main
 ```
+
 This will download the image if it is not present on your system yet.
 The repository will be available under `/repo`
 
@@ -34,14 +36,24 @@ pip3 install -e /repo
 ### Building the container locally (optional)
 
 To build the container locally, you can use the following commands:
+
 ```sh
 cd container
 docker build . -t ghcr.io/kuleuven-micas/snax-mlir:main # optional: --build-arg config=path_to_your_hjson_file.hjson
 cd ..
 ```
+
 Then you can run the experiments with the above `docker run` command
 
 Note: leaving out the `config` `--build-arg` will use the default `snitch_cluster` setup.
+
+### A note on github actions
+
+Our github actions use the container build to run tests. The actions always use the last docker build from the `main` branch. Be aware that if you make changes to the Dockerfile in a certain PR, the actions will still run on the `main` Docker build, which may result in errors. Changes to `requirements.txt` are reinstalled before every test, so these are safe to change. The following packages are only defined in the Dockerfile and thus require extra caution when changing:
+
+* [snax-cluster](https://github.com/kuleuven-micas/snitch_cluster) and dependencies (runtime, verilator, runtime, spike)
+* llvm (llvm, clang, lld)
+* standard linux packages
 
 ## Pytorch -> Linalg
 
@@ -53,24 +65,26 @@ The python3.11 installation in the docker container comes with all the requireme
 ```sh
 python3 tests/test_mult.py
 ```
+
 This will output the final MLIR code.
 
-
 All tests can be run using pytest:
+
 ```sh
 pytest tests
 ```
-
 
 ## Linalg -> Snax
 
 ### Run Snax Kernels
 
 Inside the docker container:
+
 ```sh
 cd /kernels/simple_mult
 make allrun
 ```
+
 This will compile `main.c` two different `kernel`s:
 
 1. `baseline.c`: A C implementation of the kernel
@@ -80,13 +94,16 @@ Note that for both kernels, a different lowering path is employed.
 All C code is lowered with the same flow (1):
 
 1. c code input
+
 ```mermaid
 graph LR
     A[Input C code] --> B(clang-12)
     B --> C(lld-12)
     C --> D[RISC-V Executable]
 ```
+
 2. mlir input
+
 ```mermaid
 graph LR
     A[Input MLIR] --> B(mlir-opt-16: preprocessing)
@@ -99,15 +116,15 @@ graph LR
 ```
 
 Note: Due to snitch's dependency on a custom LLVM-12 backend (which does not support LLVM opaque pointers) we are stuck with MLIR version 16.
-Opaque pointers were introduced in LLVM 15, and support for typed pointers is removed in LLVM 17. 
+Opaque pointers were introduced in LLVM 15, and support for typed pointers is removed in LLVM 17.
 More information is available [here](https://llvm.org/docs/OpaquePointers.html).
 However, we also need to use MLIR version 18, as our custom `snax-opt` compiler is built upon xDSL, which is based on the latest version of MLIR-18. This results in a combination of llvm versions 12, 16 and 18.
 To enable the conversions, we use a couple of conversion scripts:
 
 * `tollvm12.py` converts the LLVM output from mlir-translate from version LLVM 16 to LLVM 12
-    * Certain LLVM metadata, introduced by `mlir-translate-16` was only introduced in versions later than LLVM 12, and they would throw an error if they are not removed
+  * Certain LLVM metadata, introduced by `mlir-translate-16` was only introduced in versions later than LLVM 12, and they would throw an error if they are not removed
 * `tomlir16.py` and `tomlir18.py`convert the MLIR code between MLIR 16 and 18, such that we can use our own compiler written based on xDSL.
-    * The main difference between MLIR 16 and 18 is the introduction of MLIR properties, and the difference in spelling of `operandSegmentSizes`
+  * The main difference between MLIR 16 and 18 is the introduction of MLIR properties, and the difference in spelling of `operandSegmentSizes`
 
 ### Inspect traces for snax kernels
 
@@ -117,11 +134,13 @@ The default `allrun` recipe in the makefile runs all examples with a tracer.
 To convert the machine-readable traces to human-readable format, use
 
 Inside the docker container:
+
 ```sh
 cd /kernels/simple_mult
 make allrun # If you haven't ran the kernels before
 make traces
 ```
+
 Human readable traces are put in a `.logs` directory with the same name as the kernel binary.
 Statistics are computed for each section of the program execution.
 
@@ -132,13 +151,14 @@ E.g. calling `mcycle` in a program once will yield two sections, one before the 
 
 Disassembly is the conversion of the compiled binary to human-readable form.
 In this way you can inspect the program the way it is put into the memory.
+
 ```sh
 cd /kernels/simple_mult
 make baseline.o # Make an object file
 /opt/snitch-llvm/bin/llvm-objdump -d baseline.o
 ```
+
 As you can see, disassembly does not require running the program.
 
 Note: The dissassembly might show multiple "sections". In this context, a section is a unit of information in an ELF-file.
 E.g. the `.text` section will container your program and the `.data` section will contain your static data.
-

--- a/compiler/transforms/set_memory_space.py
+++ b/compiler/transforms/set_memory_space.py
@@ -155,7 +155,7 @@ class RealizeMemorySpaceCasts(RewritePattern):
             return
 
         # create memref.dim operations for dynamic dimensions
-        shapes = [x.value.data for x in op.results[0].type.shape.data]
+        shapes = [x.value for x in op.results[0].type.shape.data]
         dyn_operands = []
         for i in range(len(shapes)):
             # Dynamic shapes are represented as -1

--- a/compiler/transforms/set_memory_space.py
+++ b/compiler/transforms/set_memory_space.py
@@ -155,7 +155,7 @@ class RealizeMemorySpaceCasts(RewritePattern):
             return
 
         # create memref.dim operations for dynamic dimensions
-        shapes = [x.value for x in op.results[0].type.shape.data]
+        shapes = [x.data for x in op.results[0].type.shape.data]
         dyn_operands = []
         for i in range(len(shapes)):
             # Dynamic shapes are represented as -1


### PR DESCRIPTION
This PR aims to resolve #52, partly.
When bumping xdsl, the new version is only installed in the docker build test, but other python tests still run on the docker build from the main branch.

I included rules to first update the python requirements from requirements.txt for python tests, such that the correct version of xdsl is used.

This resolves the problem when bumping modules defined in requirements.txt. However, this does not solve the problem for modules only defined in the Dockerfile (such as the snax-cluster).

Additionaly, this also includes the bugfix of the changed IntAttr xdslproject/xdsl#1825