### PR TITLE
fix simple_copy kernel

### DIFF
--- a/kernels/simple_copy/main.c
+++ b/kernels/simple_copy/main.c
@@ -5,6 +5,9 @@
 #include <snrt.h>
 #include <stdint.h>
 
+void _mlir_ciface_simple_copy(OneDMemrefI32_t *memrefA,
+                              OneDMemrefI32_t *memrefB);
+
 int main() {
 
   // create memref object for A

--- a/runtime/include/snax_rt.h
+++ b/runtime/include/snax_rt.h
@@ -26,6 +26,7 @@ void _mlir_ciface_snax_cluster_hw_barrier() {
 void _mlir_ciface_snax_dma_1d_transfer(size_t *source, size_t *destination,
                                        size_t size) {
   snrt_dma_start_1d((void *)destination, (void *)source, size * sizeof(size_t));
+  snrt_dma_wait_all();
   return;
 }
 


### PR DESCRIPTION
This PR fixes the `simple_copy` kernel for LLVM17.

Apperantly, the turbo-charged blazingly quick llvm17 code is so fast that the kernel starts checking the result before the DMA transfer is finished. For this reason, i suggest simply inserting a dma wait by default in the runtime. This can later be optimized such that we only wait for DMA results when we need them, but no system like that is in place right now.