### PR TITLE
fix tsl parsing error

### DIFF
--- a/compiler/parser/tsl_parser.py
+++ b/compiler/parser/tsl_parser.py
@@ -19,16 +19,16 @@ class TSLParser(BaseParser):
             return v
         self.raise_error("Expected an integer literal or `?`" + context_msg)
 
-    def _parse_stride(self) -> list[int]:
+    def _parse_step(self) -> list[int]:
         """
-        strides ::== `(` stride (`,` stride)* `)`
+        steps ::== `(` steps (`,` steps)* `)`
         """
         self._parse_token(Token.Kind.L_PAREN, "Expected opening bracket")
-        strides: list[int] = []
+        steps: list[int] = []
         while not self._parse_optional_token(Token.Kind.R_PAREN):
-            strides.append(self._parse_int_or_question())
+            steps.append(self._parse_int_or_question())
             self._parse_optional_token(Token.Kind.COMMA)
-        return strides
+        return steps
 
     def _parse_bound(self) -> list[int]:
         """
@@ -47,12 +47,12 @@ class TSLParser(BaseParser):
         """
         bounds = self._parse_bound()
         self._parse_token(Token.Kind.ARROW, "Expected arrow")
-        strides = self._parse_stride()
-        if len(strides) != len(bounds):
-            raise ParseError("Expected same number of strides and bounds")
+        steps = self._parse_step()
+        if len(steps) != len(bounds):
+            raise ParseError("Expected same number of steps and bounds")
         # construct the tiledstrides
         return TiledStride(
-            [Stride(stride, bound) for stride, bound in zip(strides, bounds)]
+            [Stride(stride, bound) for stride, bound in zip(steps, bounds)]
         )
 
     def parse(self) -> TiledStridedLayout:

--- a/compiler/parser/tsl_parser.py
+++ b/compiler/parser/tsl_parser.py
@@ -52,10 +52,7 @@ class TSLParser(BaseParser):
             raise ParseError("Expected same number of strides and bounds")
         # construct the tiledstrides
         return TiledStride(
-            [
-                Stride(stride, bound)
-                for stride, bound in zip(reversed(strides), reversed(bounds))
-            ]
+            [Stride(stride, bound) for stride, bound in zip(strides, bounds)]
         )
 
     def parse(self) -> TiledStridedLayout:

--- a/compiler/parser/tsl_parser.py
+++ b/compiler/parser/tsl_parser.py
@@ -51,9 +51,7 @@ class TSLParser(BaseParser):
         if len(steps) != len(bounds):
             raise ParseError("Expected same number of steps and bounds")
         # construct the tiledstrides
-        return TiledStride(
-            [Stride(stride, bound) for stride, bound in zip(steps, bounds)]
-        )
+        return TiledStride([Stride(step, bound) for step, bound in zip(steps, bounds)])
 
     def parse(self) -> TiledStridedLayout:
         """

--- a/tests/filecheck/dialects/tsl/tsl.mlir
+++ b/tests/filecheck/dialects/tsl/tsl.mlir
@@ -1,4 +1,5 @@
 // RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_SINGLETRIP
 
 //CHECK: module
 "builtin.module"() ({

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -10,4 +10,5 @@ config.suffixes = ['.test', '.mlir', '.py']
 
 config.substitutions.append(('XDSL_PARSING_DIAG', "./compiler/snax-opt %s --print-op-generic --parsing-diagnostics --split-input-file | filecheck %s"))
 config.substitutions.append(('XDSL_ROUNDTRIP', "./compiler/snax-opt %s --print-op-generic --split-input-file | ./compiler/snax-opt --split-input-file | filecheck %s"))
+config.substitutions.append(('XDSL_SINGLETRIP', "./compiler/snax-opt %s --print-op-generic --split-input-file | filecheck %s"))
 config.substitutions.append(("XDSL_GENERIC_ROUNDTRIP", "./compiler/snax-opt %s --print-op-generic --split-input-file | filecheck %s --check-prefix=CHECK-GENERIC"))


### PR DESCRIPTION
The TSL still had a reverse operation when parsing the strides and bounds, interpreting the innermost strides as the outermost ones. The filecheck tests did not catch this error because the XDSL roundtrip parses and prints the IR twice, putting the steps and bounds back in their correct order 😒 


Additionaly i also renamed some functions, to be more consistent with the naming of:
A `Stride` consists of a `step` and a `bound`