### PR TITLE
add kernel_type util

### DIFF
--- a/compiler/util/kernel_type.py
+++ b/compiler/util/kernel_type.py
@@ -25,6 +25,19 @@ class InputException(KernelException):
 
 
 class KernelType(Enum):
+    """
+    Enumeration representing different types of kernel operations of a
+    linalg generic body.
+
+    Attributes:
+        MUL (str): Represents a multiplication operation.
+            out = a * b
+        MAC (str): Represents a multiply-accumulate operation.
+            out += a * b
+        QMAC (str): Represents a quantized multiply-accumulate operation.
+            out += (a - zp_a) * (b - zp_b)
+    """
+
     MUL = "mul"
     MAC = "mac"
     QMAC = "qmac"
@@ -201,6 +214,8 @@ class KernelType(Enum):
             return None
 
         # make sure yield_op is produced by other op before parsing
+        # if not, the kernel is empty (just linalg yield), and
+        # yielded_op.op would result in an AttributeError
         yielded_op = yield_op.operands[0]
         if not isinstance(yielded_op, OpResult):
             return None

--- a/compiler/util/kernel_type.py
+++ b/compiler/util/kernel_type.py
@@ -6,10 +6,21 @@ from xdsl.ir import Block, Operation, OpResult, SSAValue
 
 
 class KernelException(Exception):
+    """
+    A KernelException is raised by the parsing functions if the provided
+    operation does not match the expected operation type in the kernel.
+    """
+
     pass
 
 
 class InputException(KernelException):
+    """
+    A InputException is a specific case of parsing error, when we fail to
+    match given operands to the inputs of the kernel. The current parsing
+    strategy is therefore not necessarily incorrect, just incomplete.
+    """
+
     pass
 
 
@@ -106,59 +117,51 @@ class KernelType(Enum):
     def parse_inputs(linalg_op: linalg.Generic) -> tuple[linalg.YieldOp, dict]:
         """
         Parses the inputs of a linalg operation and returns the yield operation
-        of the linalg body and a dictionary of input types. The dictionary of
-        input types is used to match the block arguments (scalars) to the actual
-        input types of the linalg.Generic (shaped memrefs).
+        of the linalg body and a dictionary of operand types. The dictionary of
+        operand types is used to match the block arguments (scalars) to the actual
+        operand types of the linalg.Generic (shaped memrefs).
 
         Args:
             linalg_op (linalg.Generic): The linalg operation.
 
         Returns:
             tuple[linalg.YieldOp, dict]: The yield operation and a
-            dictionary of input types.
+            dictionary of operand types.
 
         Raises:
             KernelException: If the number of shaped inputs is incorrect for binary ops.
-            KernelException: If the last op of the linalg block is not a yield op.
-            KernelException: If the yield op does not return exactly one result.
-            KernelException: If the yield op operand is not the result of another op.
+            KernelException: If number of outputs is incorrect for binary ops.
         """
 
         linalg_block: Block = linalg_op.body.block
-        input_types: list = [o.type for o in linalg_op.operands]
+        operand_types: list = [o.type for o in linalg_op.operands]
 
-        # the inputs of the linalg block are scalars, but to detect
-        # the kernel type, we need to know if the inputs of the linalg
+        # the operand of the linalg block are scalars, but to detect
+        # the kernel type, we need to know if the operand of the linalg
         # block are tensors or scalars, therefore we generate a dictionary
         # of the input types of the linalg
-        types = dict(zip(linalg_block.args, input_types))
+        types = dict(zip(linalg_block.args, operand_types))
 
-        # this check counts the number of inputs which are shaped inputs
+        # this check counts the number of operand which are shaped operand
         # for all the kernels there may be three shaped operands
-        # (input a, input b, output c)  other inputs may be integer types used for
+        # (input a, input b, output c)  other operands may be integer types used for
         # constant values, such as zero-point offsets
         if len([type for type in types.values() if isinstance(type, ShapedType)]) != 3:
-            raise KernelException("Wrong number of shaped inputs")
+            raise KernelException("Wrong number of shaped operands")
 
-        # last op of the linalg block should be a yield op
-        yield_op = linalg_block.last_op
-        if not isinstance(yield_op, linalg.YieldOp):
-            raise KernelException("Last op of linalg block is not a yield op")
-        # yield op should have one result, which is produced by an op
-        if len(yield_op.operands) != 1:
-            raise KernelException("Yield op does not have one operand")
-        if not isinstance(yield_op.operands[0], OpResult):
-            raise KernelException("Yield op operand is not an op result")
+        # there should only be one output and it should be shaped
+        if len(linalg_op.outputs) != 1:
+            raise KernelException("Wrong number of outputs")
 
         # input parsing successful, we can return the computed types
         # for further checking
-        return (yield_op, types)
+        return (linalg_block.last_op, types)
 
     @staticmethod
     def match_inputs(a: Operation, b: Operation, types: dict):
         """
         Matches the operands a and b with the input types of the linalg kernel.
-        This is mainly used as a check to see if we have reachted the top
+        This is mainly used as a check to see if we have reached the top
         of the computation graph in the linalg kernel.
 
         Args:
@@ -197,10 +200,15 @@ class KernelType(Enum):
         except KernelException:
             return None
 
+        # make sure yield_op is produced by other op before parsing
+        yielded_op = yield_op.operands[0]
+        if not isinstance(yielded_op, OpResult):
+            return None
+
         # check: MUL
         # a = b * c
         try:
-            val_a, val_b = KernelType.parse_mult(yield_op.operands[0].op)
+            val_a, val_b = KernelType.parse_mult(yielded_op.op)
             KernelType.match_inputs(val_a, val_b, types)
             return KernelType.MUL
         except KernelException:
@@ -209,7 +217,7 @@ class KernelType(Enum):
         # check: MAC \ QMAC
         # a += c * d (or a += (c - zp_c) * (d - zp_d))
         try:
-            val_a, val_b = KernelType.parse_add(yield_op.operands[0].op)
+            val_a, val_b = KernelType.parse_add(yielded_op.op)
             # one of the values is the accumulation
             # (the last argument of the linalg block),
             # the other one is the multiplication of c and d

--- a/compiler/util/kernel_type.py
+++ b/compiler/util/kernel_type.py
@@ -1,0 +1,240 @@
+from enum import Enum
+
+from xdsl.dialects import arith, linalg
+from xdsl.dialects.builtin import ShapedType
+from xdsl.ir import Block, Operation, OpResult, SSAValue
+
+
+class KernelException(Exception):
+    pass
+
+
+class InputException(KernelException):
+    pass
+
+
+class KernelType(Enum):
+    MUL = "mul"
+    MAC = "mac"
+    QMAC = "qmac"
+
+    @staticmethod
+    def parse_mult(op: Operation) -> tuple[Operation, Operation]:
+        """
+        Parses a multiplication operation and returns the two operands.
+
+        Args:
+            op (Operation): The multiplication operation.
+
+        Returns:
+            tuple[Operation, Operation]: The two operands of the
+            multiplication operation.
+
+        Raises:
+            KernelException: If the provided operation is not a multiplication.
+        """
+
+        # check if op is a multiplication
+        if not isinstance(op, arith.Muli):
+            raise KernelException("not a multiplication")
+
+        # get operands
+        a = op.lhs
+        b = op.rhs
+        return a, b
+
+    @staticmethod
+    def parse_add(op: Operation) -> tuple[Operation | SSAValue, Operation | SSAValue]:
+        """
+        Parses an addition operation and returns the two operands.
+
+        Args:
+            op (Operation): The addition operation.
+
+        Returns:
+            tuple[Operation | SSAValue, Operation | SSAValue]: The two operands
+            of the addition operation.
+
+        Raises:
+            KernelException: If the provided operation is not an addition.
+        """
+
+        # check if op is a multiplication
+        if not isinstance(op, arith.Addi):
+            raise KernelException("not an addition")
+
+        # get operands
+        a = op.lhs
+        b = op.rhs
+        return a, b
+
+    @staticmethod
+    def parse_zpa(op: Operation) -> tuple[Operation | SSAValue, Operation | SSAValue]:
+        """
+        Parses a zero point adjustment operation and returns the two operands.
+        A zero point adjustment operation is a subtraction operation, where
+        the right operand is a zero point offset and the left operand is the
+        input tensor. Before the subtraction, the input tensor may be sign
+        extended to avoid overflow.
+
+        Args:
+            op (Operation): The subtraction operation.
+
+        Returns:
+            tuple[Operation | SSAValue, Operation | SSAValue]: The two operands
+            of the subtraction operation.
+
+        Raises:
+            KernelException: If the provided operation is not a subtraction.
+        """
+
+        # check if op is a subtraction
+        if not isinstance(op, arith.Subi):
+            raise KernelException
+
+        # get operands
+        value = op.lhs
+        adjustment = op.rhs
+
+        # additional sign extension possible
+        while isinstance(value, OpResult) and isinstance(value.op, arith.ExtSIOp):
+            value = value.op.operands[0]
+
+        return value, adjustment
+
+    @staticmethod
+    def parse_inputs(linalg_op: linalg.Generic) -> tuple[linalg.YieldOp, dict]:
+        """
+        Parses the inputs of a linalg operation and returns the yield operation
+        of the linalg body and a dictionary of input types. The dictionary of
+        input types is used to match the block arguments (scalars) to the actual
+        input types of the linalg.Generic (shaped memrefs).
+
+        Args:
+            linalg_op (linalg.Generic): The linalg operation.
+
+        Returns:
+            tuple[linalg.YieldOp, dict]: The yield operation and a
+            dictionary of input types.
+
+        Raises:
+            KernelException: If the number of shaped inputs is incorrect for binary ops.
+            KernelException: If the last op of the linalg block is not a yield op.
+            KernelException: If the yield op does not return exactly one result.
+            KernelException: If the yield op operand is not the result of another op.
+        """
+
+        linalg_block: Block = linalg_op.body.block
+        input_types: list = [o.type for o in linalg_op.operands]
+
+        # the inputs of the linalg block are scalars, but to detect
+        # the kernel type, we need to know if the inputs of the linalg
+        # block are tensors or scalars, therefore we generate a dictionary
+        # of the input types of the linalg
+        types = dict(zip(linalg_block.args, input_types))
+
+        # this check counts the number of inputs which are shaped inputs
+        # for all the kernels there may be three shaped operands
+        # (input a, input b, output c)  other inputs may be integer types used for
+        # constant values, such as zero-point offsets
+        if len([type for type in types.values() if isinstance(type, ShapedType)]) != 3:
+            raise KernelException("Wrong number of shaped inputs")
+
+        # last op of the linalg block should be a yield op
+        yield_op = linalg_block.last_op
+        if not isinstance(yield_op, linalg.YieldOp):
+            raise KernelException("Last op of linalg block is not a yield op")
+        # yield op should have one result, which is produced by an op
+        if len(yield_op.operands) != 1:
+            raise KernelException("Yield op does not have one operand")
+        if not isinstance(yield_op.operands[0], OpResult):
+            raise KernelException("Yield op operand is not an op result")
+
+        # input parsing successful, we can return the computed types
+        # for further checking
+        return (yield_op, types)
+
+    @staticmethod
+    def match_inputs(a: Operation, b: Operation, types: dict):
+        """
+        Matches the operands a and b with the input types of the linalg kernel.
+        This is mainly used as a check to see if we have reachted the top
+        of the computation graph in the linalg kernel.
+
+        Args:
+            a (Operation): The first operand.
+            b (Operation): The second operand.
+            types (dict): The dictionary of input types.
+
+        Raises:
+            InputException: If operand a is not a shaped input.
+            InputException: If operand b is not a shaped input.
+        """
+        # check if the operands a and b are shaped inputs of the linalg kernel
+        if a not in types or not isinstance(types[a], ShapedType):
+            raise InputException("Operand a is not a shaped input")
+        if b not in types or not isinstance(types[b], ShapedType):
+            raise InputException("Operand b is not a shaped input")
+
+        # matching successful, return
+        return
+
+    @staticmethod
+    def get_kernel(linalg_op: linalg.Generic):
+        """
+        Determines the kernel type of a linalg operation.
+
+        Args:
+            linalg_op (linalg.Generic): The linalg operation.
+
+        Returns:
+            KernelType | None: The kernel type if it matches any of the
+            supported types, None otherwise.
+        """
+
+        try:
+            yield_op, types = KernelType.parse_inputs(linalg_op)
+        except KernelException:
+            return None
+
+        # check: MUL
+        # a = b * c
+        try:
+            val_a, val_b = KernelType.parse_mult(yield_op.operands[0].op)
+            KernelType.match_inputs(val_a, val_b, types)
+            return KernelType.MUL
+        except KernelException:
+            pass
+
+        # check: MAC \ QMAC
+        # a += c * d (or a += (c - zp_c) * (d - zp_d))
+        try:
+            val_a, val_b = KernelType.parse_add(yield_op.operands[0].op)
+            # one of the values is the accumulation
+            # (the last argument of the linalg block),
+            # the other one is the multiplication of c and d
+            accumulation = linalg_op.body.block.args[-1]
+            mult_op = val_b if val_a is accumulation else val_a
+            if not isinstance(mult_op, OpResult):
+                raise KernelException
+            mult_op = mult_op.op
+
+            val_c, val_d = KernelType.parse_mult(mult_op)
+
+            try:
+                # for successful input match, return MAC
+                KernelType.match_inputs(val_c, val_d, types)
+                return KernelType.MAC
+
+            except InputException:
+                # maybe additional zero-point adjustment for QMAC
+                if not isinstance(val_c, OpResult) or not isinstance(val_d, OpResult):
+                    raise KernelException
+                val_c_zp, zp_c = KernelType.parse_zpa(val_c.op)
+                val_d_zp, zp_d = KernelType.parse_zpa(val_d.op)
+                KernelType.match_inputs(val_c_zp, val_d_zp, types)
+                return KernelType.QMAC
+        except KernelException:
+            pass
+
+        return None

--- a/tests/util/test_kernel_type.py
+++ b/tests/util/test_kernel_type.py
@@ -127,7 +127,7 @@ def test_parse_zpa():
         KernelType.parse_zpa(add)
 
 
-def test_parse_inputs(linalg_empty, linalg_mult):
+def test_parse_inputs(linalg_mult):
     yield_op, types = KernelType.parse_inputs(linalg_mult)
     assert isinstance(yield_op, linalg.YieldOp)
     assert isinstance(types, dict)
@@ -138,9 +138,6 @@ def test_parse_inputs(linalg_empty, linalg_mult):
     assert isinstance(types[operands[2]], int)
     assert isinstance(types[operands[3]], int)
     assert isinstance(types[operands[4]], memref.MemRefType)
-
-    with pytest.raises(KernelException):
-        KernelType.parse_inputs(linalg_empty)
 
 
 def test_match_inputs(linalg_mult):

--- a/tests/util/test_kernel_type.py
+++ b/tests/util/test_kernel_type.py
@@ -1,0 +1,161 @@
+import pytest
+from xdsl.builder import Builder
+from xdsl.dialects import arith, linalg, memref
+from xdsl.dialects.builtin import AffineMapAttr, IndexType
+from xdsl.ir.affine import AffineMap
+from xdsl.utils.test_value import TestSSAValue
+
+from compiler.util.kernel_type import InputException, KernelException, KernelType
+
+
+@pytest.fixture()
+def linalg_operands():
+    mem_a = memref.Alloc.get(IndexType(), shape=[8, 8])
+    mem_b = memref.Alloc.get(IndexType(), shape=[8, 8])
+    mem_c = memref.Alloc.get(IndexType(), shape=[8, 8])
+    const_a = arith.Constant(IndexType(), 1)
+    const_b = arith.Constant(IndexType(), 1)
+    inputs = [mem_a, mem_b, const_a, const_b]
+    outputs = [mem_c]
+
+    # indexing maps and iterators do not matter for kernel detection,
+    # they are just needed to construct the linalg op
+    indexing_map = AffineMap.identity(2)
+    indexing_maps = [AffineMapAttr(indexing_map)] * 5
+    iterator_types = [linalg.IteratorTypeAttr(linalg.IteratorType.PARALLEL)] * 2
+
+    return inputs, outputs, indexing_maps, iterator_types
+
+
+@pytest.fixture()
+def linalg_empty(linalg_operands):
+    @Builder.implicit_region([IndexType()] * 5)
+    def body(args):
+        linalg.YieldOp(args[0])
+
+    inputs, outputs, imap, itype = linalg_operands
+    linalg_op = linalg.Generic(inputs, outputs, body, imap, itype)
+    return linalg_op
+
+
+@pytest.fixture()
+def linalg_mult(linalg_operands):
+    @Builder.implicit_region([IndexType()] * 5)
+    def body(args):
+        a, b = args[0:2]
+        d = arith.Muli(a, b)
+        linalg.YieldOp(d)
+
+    inputs, outputs, imap, itype = linalg_operands
+    linalg_op = linalg.Generic(inputs, outputs, body, imap, itype)
+    return linalg_op
+
+
+@pytest.fixture()
+def linalg_mac(linalg_operands):
+    @Builder.implicit_region([IndexType()] * 5)
+    def body(args):
+        a, b = args[0:2]
+        acc = args[-1]
+        d = arith.Muli(a, b)
+        e = arith.Addi(d, acc)
+        linalg.YieldOp(e)
+
+    inputs, outputs, imap, itype = linalg_operands
+    linalg_op = linalg.Generic(inputs, outputs, body, imap, itype)
+    return linalg_op
+
+
+@pytest.fixture()
+def linalg_qmac(linalg_operands):
+    @Builder.implicit_region([IndexType()] * 5)
+    def body(args):
+        a, b, azp, bzp = args[0:4]
+        acc = args[-1]
+        a_ext = arith.ExtSIOp(a, IndexType())
+        b_ext = arith.ExtSIOp(b, IndexType())
+        a_zpa = arith.Subi(a_ext, azp)
+        b_zpa = arith.Subi(b_ext, bzp)
+        b = arith.Muli(a_zpa, b_zpa)
+        result = arith.Addi(b, acc)
+        linalg.YieldOp(result)
+
+    inputs, outputs, imap, itype = linalg_operands
+    linalg_op = linalg.Generic(inputs, outputs, body, imap, itype)
+    return linalg_op
+
+
+def test_parse_mult():
+    a = TestSSAValue(IndexType())
+    b = TestSSAValue(IndexType())
+    mult = arith.Muli(a, b)
+    add = arith.Addi(a, b)
+    res_a, res_b = KernelType.parse_mult(mult)
+    assert res_a is a
+    assert res_b is b
+    with pytest.raises(KernelException):
+        KernelType.parse_mult(add)
+
+
+def test_parse_add():
+    a = TestSSAValue(IndexType())
+    b = TestSSAValue(IndexType())
+    mult = arith.Muli(a, b)
+    add = arith.Addi(a, b)
+    res_a, res_b = KernelType.parse_add(add)
+    assert res_a is a
+    assert res_b is b
+    with pytest.raises(KernelException):
+        KernelType.parse_add(mult)
+
+
+def test_parse_zpa():
+    a = TestSSAValue(IndexType())
+    a_se = arith.ExtSIOp(a, IndexType())
+    b = TestSSAValue(IndexType())
+    zp1 = arith.Subi(a, b)
+    zp2 = arith.Subi(a_se, b)
+    res_a, res_b = KernelType.parse_zpa(zp1)
+    assert res_a is a
+    assert res_b is b
+    res_a, res_b = KernelType.parse_zpa(zp2)
+    assert res_a is a
+    assert res_b is b
+
+    add = arith.Addi(a, b)
+    with pytest.raises(KernelException):
+        KernelType.parse_zpa(add)
+
+
+def test_parse_inputs(linalg_empty, linalg_mult):
+    yield_op, types = KernelType.parse_inputs(linalg_mult)
+    assert isinstance(yield_op, linalg.YieldOp)
+    assert isinstance(types, dict)
+    assert len(types.keys()) == 5
+    operands = linalg_mult.body.block.args
+    assert isinstance(types[operands[0]], memref.MemRefType)
+    assert isinstance(types[operands[1]], memref.MemRefType)
+    assert isinstance(types[operands[2]], int)
+    assert isinstance(types[operands[3]], int)
+    assert isinstance(types[operands[4]], memref.MemRefType)
+
+    with pytest.raises(KernelException):
+        KernelType.parse_inputs(linalg_empty)
+
+
+def test_match_inputs(linalg_mult):
+    linalg_op = linalg_mult
+    a, b = linalg_op.body.block.args[0:2]
+    _, types = KernelType.parse_inputs(linalg_op)
+    assert KernelType.match_inputs(a, b, types) is None
+    a = TestSSAValue(IndexType())
+    b = TestSSAValue(IndexType())
+    with pytest.raises(InputException):
+        KernelType.match_inputs(a, b, types)
+
+
+def test_get_type(linalg_empty, linalg_mult, linalg_mac, linalg_qmac):
+    assert KernelType.get_kernel(linalg_empty) is None
+    assert KernelType.get_kernel(linalg_mult) == KernelType.MUL
+    assert KernelType.get_kernel(linalg_mac) == KernelType.MAC
+    assert KernelType.get_kernel(linalg_qmac) == KernelType.QMAC


### PR DESCRIPTION
This PR inits the kernel_type util

The Kernel Type is an enum, to classify different kernels of a linalg body. For now, the code can classify the following kernels:

- MUL
- MAC
- QMAC

however, extending for other types of kernels should be easy with the implemented structure.

These changes pave the way for linalg.generic matching.

The Enum has a lot of functions. The most important one is `get_kernel`, where we identify the kernel type based on linalg operation as input. All of the other functions are helper parser functions to perform this identification.