### PR TITLE
mlperf tiny: Lower to object file

### DIFF
--- a/.github/workflows/build-run-mlperf-tiny.yml
+++ b/.github/workflows/build-run-mlperf-tiny.yml
@@ -28,20 +28,20 @@ jobs:
       - name: Anomaly detection
         run: |
           export PATH=/opt/python3.11/bin:$PATH
-          make ad01_int8.snax-opt.mlir
+          make ad01_int8.o
         working-directory: kernels/mlperf_tiny_ad01
       - name: Image classfication
         run: |
           export PATH=/opt/python3.11/bin:$PATH
-          make pretrainedResnet_quant.snax-opt.mlir
+          make pretrainedResnet_quant.o
         working-directory: kernels/mlperf_tiny_ic
       - name: Visual Wake Words
         run: |
           export PATH=/opt/python3.11/bin:$PATH
-          make vww_96_int8.snax-opt.mlir
+          make vww_96_int8.o
         working-directory: kernels/mlperf_tiny_vww
       - name: Keyword spotting
         run: |
           export PATH=/opt/python3.11/bin:$PATH
-          make kws_ref_model.snax-opt.mlir
+          make kws_ref_model.o
         working-directory: kernels/mlperf_tiny_kws

--- a/.github/workflows/build-run-mlperf-tiny.yml
+++ b/.github/workflows/build-run-mlperf-tiny.yml
@@ -25,23 +25,43 @@ jobs:
       - name: Reinstall pip modules from requirements
         run: |
           /opt/python3.11/bin/python3 -m pip install -r requirements.txt
-      - name: Anomaly detection
+      - name: Anomaly detection (snax)
         run: |
           export PATH=/opt/python3.11/bin:$PATH
           make ad01_int8.o
         working-directory: kernels/mlperf_tiny_ad01
-      - name: Image classfication
+      - name: Anomaly detection (vanilla)
+        run: |
+          export PATH=/opt/python3.11/bin:$PATH
+          make ad01_int8.no-snax-opt.o
+        working-directory: kernels/mlperf_tiny_ad01
+      - name: Image classfication (snax)
         run: |
           export PATH=/opt/python3.11/bin:$PATH
           make pretrainedResnet_quant.o
         working-directory: kernels/mlperf_tiny_ic
-      - name: Visual Wake Words
+      - name: Image classfication (vanilla)
+        run: |
+          export PATH=/opt/python3.11/bin:$PATH
+          make pretrainedResnet_quant.no-snax-opt.o
+        working-directory: kernels/mlperf_tiny_ic
+      - name: Visual Wake Words (snax)
         run: |
           export PATH=/opt/python3.11/bin:$PATH
           make vww_96_int8.o
         working-directory: kernels/mlperf_tiny_vww
-      - name: Keyword spotting
+      - name: Visual Wake Words (vanilla)
+        run: |
+          export PATH=/opt/python3.11/bin:$PATH
+          make vww_96_int8.no-snax-opt.o
+        working-directory: kernels/mlperf_tiny_vww
+      - name: Keyword spotting (snax)
         run: |
           export PATH=/opt/python3.11/bin:$PATH
           make kws_ref_model.o
+        working-directory: kernels/mlperf_tiny_kws
+      - name: Keyword spotting (vanilla)
+        run: |
+          export PATH=/opt/python3.11/bin:$PATH
+          make kws_ref_model.no-snax-opt.o
         working-directory: kernels/mlperf_tiny_kws

--- a/compiler/transforms/linalg_to_library_call.py
+++ b/compiler/transforms/linalg_to_library_call.py
@@ -1,4 +1,5 @@
 from xdsl.dialects import builtin, func, linalg
+from xdsl.dialects.memref import Cast, MemRefType
 from xdsl.ir import MLContext
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -26,16 +27,60 @@ class AddExternalFunc(RewritePattern):
             if op.library_call is None:
                 continue
 
-            func_call = func.Call(op.library_call.data, op.operands, [])
+            # all memref arguments must be cast to a new memref with a dynamic shape
+            # to avoid type mismatching for multiple function calls with different
+            # argument shapes
+            cast_ops_to_insert = []
+            operands = []
+            for operand in op.operands:
+                if isinstance(operand.type, MemRefType):
+                    new_type = MemRefType(
+                        operand.type.element_type,
+                        [-1] * len(operand.type.shape),
+                        operand.type.layout,
+                        operand.type.memory_space,
+                    )
+                    cast = Cast.get(operand, new_type)
+                    cast_ops_to_insert.append(cast)
+                    operands.append(cast)
+                else:
+                    operands.append(operand)
+
+            func_call = func.Call(op.library_call.data, operands, [])
 
             # Replace op with function call
-            rewriter.replace_op(op, func_call)
+            rewriter.replace_op(op, [*cast_ops_to_insert, func_call])
 
             # Insert external function definition
+
+            # the memref arguments must be changed to dynamic shapes
+            # for the input types
+            input_types = [arg.type for arg in op.inputs]
+            for i, input_type in enumerate(input_types):
+                if isinstance(input_type, MemRefType):
+                    input_types[i] = MemRefType(
+                        input_type.element_type,
+                        [-1] * len(input_type.shape),
+                        input_type.layout,
+                        input_type.memory_space,
+                    )
+            # do the same for output types
+            output_types = [res.type for res in op.outputs]
+            for i, output_type in enumerate(output_types):
+                if isinstance(output_type, MemRefType):
+                    output_types[i] = MemRefType(
+                        output_type.element_type,
+                        [-1] * len(output_type.shape),
+                        output_type.layout,
+                        output_type.memory_space,
+                    )
+
+            # both inputs and outputs are passed as inputs for the external function
+            # (pass allocated output memref by reference to the external function)
             func_op = func.FuncOp.external(
                 func_call.callee.string_value(),
-                [arg.type for arg in func_call.arguments],
-                [res.type for res in func_call.results],
+                [*input_types, *output_types],
+                [],
             )
 
             SymbolTable.insert_or_update(module, func_op)

--- a/compiler/transforms/set_memory_space.py
+++ b/compiler/transforms/set_memory_space.py
@@ -83,7 +83,7 @@ class InitMemRefGlobalMemorySpace(RewritePattern):
         )
 
         # create new get_global op
-        new_op = memref.GetGlobal.get(op.name, new_memref_type)
+        new_op = memref.GetGlobal.get(str(op.name_)[1:], new_memref_type)
 
         # replace op
         rewriter.replace_matched_op(new_op)

--- a/compiler/transforms/set_memory_space.py
+++ b/compiler/transforms/set_memory_space.py
@@ -83,7 +83,7 @@ class InitMemRefGlobalMemorySpace(RewritePattern):
         )
 
         # create new get_global op
-        new_op = memref.GetGlobal.get(str(op.name_)[1:], new_memref_type)
+        new_op = memref.GetGlobal.get(op.name_.root_reference.data, new_memref_type)
 
         # replace op
         rewriter.replace_matched_op(new_op)

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -112,6 +112,9 @@ SNAXOPTFLAGS = -p set-memory-space,insert-sync-barrier,dispatch-regions,dispatch
 %.snax-opt.mlir: %.preprocfinal.mlir
 	$(SNAXOPT) $(SNAXOPTFLAGS) -o $@ $<
 
+%.postproc.mlir: %.snax-opt.mlir
+	cat $< | sed 's/arith.maximumf/arith.maxf/g' | sed 's/arith.minimumf/arith.minf/g' > $@
+
 # MLIR
 
 MLIROPTFLAGS =
@@ -128,7 +131,7 @@ MLIROPTFLAGS += --convert-cf-to-llvm=index-bitwidth=32
 MLIROPTFLAGS += --convert-arith-to-llvm=index-bitwidth=32
 MLIROPTFLAGS += --reconcile-unrealized-casts
 
-%.ll.mlir: %.snax-opt.mlir
+%.ll.mlir: %.postproc.mlir
 	$(MLIROPT) $(MLIROPTFLAGS) -o $@ $<
 
 %.ll: %.ll.mlir

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -135,6 +135,10 @@ MLIROPTFLAGS += --finalize-memref-to-llvm='use-generic-functions index-bitwidth=
 MLIROPTFLAGS += --canonicalize
 MLIROPTFLAGS += --reconcile-unrealized-casts
 
+# Bypass snax-opt
+%.no-snax-opt.ll.mlir: %.preproc3.mlir
+	$(MLIROPT) $(MLIROPTFLAGS) -o $@ $<
+
 %.ll.mlir: %.postproc.mlir
 	$(MLIROPT) $(MLIROPTFLAGS) -o $@ $<
 

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -115,7 +115,8 @@ SNAXOPTFLAGS = -p set-memory-space,insert-sync-barrier,dispatch-regions,dispatch
 %.postproc.mlir: %.snax-opt.mlir
 	cat $< | sed 's/arith.maximumf/arith.maxf/g' | sed 's/arith.minimumf/arith.minf/g' > $@
 
-# MLIR
+# Lower everithing to LLVM, loosely based on:
+# https://github.com/llvm/llvm-project/blob/main/mlir/test/lib/Dialect/LLVM/TestLowerToLLVM.cpp
 
 MLIROPTFLAGS =
 MLIROPTFLAGS += --convert-linalg-to-loops

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -120,15 +120,18 @@ SNAXOPTFLAGS = -p set-memory-space,insert-sync-barrier,dispatch-regions,dispatch
 MLIROPTFLAGS =
 MLIROPTFLAGS += --convert-linalg-to-loops
 MLIROPTFLAGS += --convert-scf-to-cf
+MLIROPTFLAGS += --lower-affine
 MLIROPTFLAGS += --canonicalize
 MLIROPTFLAGS += --cse
 MLIROPTFLAGS += --convert-math-to-llvm
 MLIROPTFLAGS += --llvm-request-c-wrappers
-MLIROPTFLAGS += --finalize-memref-to-llvm='use-generic-functions index-bitwidth=32'
-MLIROPTFLAGS += --convert-func-to-llvm='index-bitwidth=32'
+MLIROPTFLAGS += --expand-strided-metadata
 MLIROPTFLAGS += --convert-index-to-llvm=index-bitwidth=32
 MLIROPTFLAGS += --convert-cf-to-llvm=index-bitwidth=32
 MLIROPTFLAGS += --convert-arith-to-llvm=index-bitwidth=32
+MLIROPTFLAGS += --convert-func-to-llvm='index-bitwidth=32'
+MLIROPTFLAGS += --finalize-memref-to-llvm='use-generic-functions index-bitwidth=32'
+MLIROPTFLAGS += --canonicalize
 MLIROPTFLAGS += --reconcile-unrealized-casts
 
 %.ll.mlir: %.postproc.mlir

--- a/tests/filecheck/transforms/linalg-to-library-call.mlir
+++ b/tests/filecheck/transforms/linalg-to-library-call.mlir
@@ -14,11 +14,16 @@
   }) {"library_call" = "snax_hwpe_mult"} : (memref<64xi32>, memref<64xi32>, memref<64xi32>) -> ()
 }) : () -> ()
 
-
 //CHECK: "builtin.module"() ({
 //CHECK-NEXT:   %0, %1, %2, %3 = "test.op"() : () -> (memref<64xi32>, memref<64xi32>, memref<64xi32>, memref<64xi32>)
-//CHECK-NEXT:   "func.call"(%0, %1, %2) <{"callee" = @snax_hwpe_mult}> : (memref<64xi32>, memref<64xi32>, memref<64xi32>) -> ()
-//CHECK-NEXT:   "func.call"(%1, %2, %3) <{"callee" = @snax_hwpe_mult}> : (memref<64xi32>, memref<64xi32>, memref<64xi32>) -> ()
-//CHECK-NEXT:   "func.func"() <{"sym_name" = "snax_hwpe_mult", "function_type" = (memref<64xi32>, memref<64xi32>, memref<64xi32>) -> (), "sym_visibility" = "private"}> ({
+//CHECK-NEXT:   %4 = "memref.cast"(%0) : (memref<64xi32>) -> memref<?xi32>
+//CHECK-NEXT:   %5 = "memref.cast"(%1) : (memref<64xi32>) -> memref<?xi32>
+//CHECK-NEXT:   %6 = "memref.cast"(%2) : (memref<64xi32>) -> memref<?xi32>
+//CHECK-NEXT:   "func.call"(%4, %5, %6) <{"callee" = @snax_hwpe_mult}> : (memref<?xi32>, memref<?xi32>, memref<?xi32>) -> ()
+//CHECK-NEXT:   %7 = "memref.cast"(%1) : (memref<64xi32>) -> memref<?xi32>
+//CHECK-NEXT:   %8 = "memref.cast"(%2) : (memref<64xi32>) -> memref<?xi32>
+//CHECK-NEXT:   %9 = "memref.cast"(%3) : (memref<64xi32>) -> memref<?xi32>
+//CHECK-NEXT:   "func.call"(%7, %8, %9) <{"callee" = @snax_hwpe_mult}> : (memref<?xi32>, memref<?xi32>, memref<?xi32>) -> ()
+//CHECK-NEXT:   "func.func"() <{"sym_name" = "snax_hwpe_mult", "function_type" = (memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (), "sym_visibility" = "private"}> ({
 //CHECK-NEXT:   }) : () -> ()
 //CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/transforms/set-memory-space.mlir
+++ b/tests/filecheck/transforms/set-memory-space.mlir
@@ -5,7 +5,7 @@
 }) : () -> ()
 
 //CHECK: "builtin.module"() ({
-//CHECK-NEXT:   %0 = "memref.get_global"() <{"name" = @memref.get_global}> : () -> memref<640xi32, 0 : i32>
+//CHECK-NEXT:   %0 = "memref.get_global"() <{"name" = @constant}> : () -> memref<640xi32, 0 : i32>
 //CHECK-NEXT: }) : () -> ()
 
 // -----


### PR DESCRIPTION
This clears the pipeline to go directly to a RISC-V object file, yet networks are not actually run yet.
* A small error was found in the emission of `memref.get_global`s , where `name` and not `name_` was passed to the newly created op.
* There was a function call mismatch, where emitted function calls and declarations were incompatible with the shapes of various different calls. This was solved by declaring the functions with dynamic shapes and inserting casts to dynamic shapes.
* A pass (in the makefile) was integrated (with sed) to deal with minf, maxf to minimumf, maximumf conversion
* The `--clear-memory-space` pass was altered to only remove TSL layout attributes, other layout info is untouched.
* `--lower-affine` and `--expand-strided-metadata` passes were added to lower to LLVM dialect, otherwise unrealized_conversion_casts remain.
* A vanilla pipeline was added for each mlperf tiny benchmark that does not rely on snax-opt to compile (these object_files are also not run yet)