### PR TITLE
dialect: (snax) add reshuffle op

### DIFF
--- a/compiler/dialects/snax.py
+++ b/compiler/dialects/snax.py
@@ -17,11 +17,11 @@ class ClusterSyncOp(IRDLOperation):
 
 
 @irdl_op_definition
-class ReShuffleOp(IRDLOperation):
-    """ReShuffle operation for memrefs in a snax cluster. This
+class LayoutCast(IRDLOperation):
+    """LayoutCast operation for memrefs in a snax cluster. This
     operation is used to change the layout of the memref data"""
 
-    name = "snax.reshuffle"
+    name = "snax.layout_cast"
 
     source = operand_def(MemRefType[Attribute] | UnrankedMemrefType[Attribute])
     dest = result_def(MemRefType[Attribute] | UnrankedMemrefType[Attribute])
@@ -37,7 +37,7 @@ class ReShuffleOp(IRDLOperation):
     def from_type_and_target_layout(
         source: SSAValue | Operation,
         layout: Attribute,
-    ) -> ReShuffleOp:
+    ) -> LayoutCast:
         assert isinstance(source.type, MemRefType)
         dest = MemRefType(
             source.type.get_element_type(),
@@ -45,7 +45,7 @@ class ReShuffleOp(IRDLOperation):
             layout=layout,
             memory_space=source.type.memory_space,
         )
-        return ReShuffleOp(source, dest)
+        return LayoutCast(source, dest)
 
     def verify_(self) -> None:
         source = cast(MemRefType[Attribute], self.source.type)
@@ -64,4 +64,4 @@ class ReShuffleOp(IRDLOperation):
             )
 
 
-Snax = Dialect("snax", [ClusterSyncOp, ReShuffleOp], [])
+Snax = Dialect("snax", [ClusterSyncOp, LayoutCast], [])

--- a/compiler/dialects/snax.py
+++ b/compiler/dialects/snax.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import cast
 
-from xdsl.dialects.builtin import NoneAttr
 from xdsl.dialects.memref import MemRefType, UnrankedMemrefType
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, result_def
@@ -51,10 +50,6 @@ class ReShuffleOp(IRDLOperation):
     def verify_(self) -> None:
         source = cast(MemRefType[Attribute], self.source.type)
         dest = cast(MemRefType[Attribute], self.dest.type)
-        if source.layout is None or isinstance(source.layout, NoneAttr):
-            raise VerifyException("Expected source to have a layout.")
-        if dest.layout is None or isinstance(dest.layout, NoneAttr):
-            raise VerifyException("Expected destination to have a layout.")
         if source.get_shape() != dest.get_shape():
             raise VerifyException(
                 "Expected source and destination to have the same shape."

--- a/compiler/dialects/snax.py
+++ b/compiler/dialects/snax.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from xdsl.ir import Dialect
-from xdsl.irdl import (
-    IRDLOperation,
-    irdl_op_definition,
-)
+from typing import cast
+
+from xdsl.dialects.builtin import NoneAttr
+from xdsl.dialects.memref import MemRefType, UnrankedMemrefType
+from xdsl.ir import Attribute, Dialect, Operation, SSAValue
+from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, result_def
+from xdsl.utils.exceptions import VerifyException
 
 
 @irdl_op_definition
@@ -15,4 +17,56 @@ class ClusterSyncOp(IRDLOperation):
     name = "snax.cluster_sync_op"
 
 
-Snax = Dialect("snax", [ClusterSyncOp], [])
+@irdl_op_definition
+class ReShuffleOp(IRDLOperation):
+    """ReShuffle operation for memrefs in a snax cluster. This
+    operation is used to change the layout of the memref data"""
+
+    name = "snax.reshuffle"
+
+    source = operand_def(MemRefType[Attribute] | UnrankedMemrefType[Attribute])
+    dest = result_def(MemRefType[Attribute] | UnrankedMemrefType[Attribute])
+
+    def __init__(
+        self,
+        source: SSAValue | Operation,
+        dest: MemRefType[Attribute] | UnrankedMemrefType[Attribute],
+    ):
+        super().__init__(operands=[source], result_types=[dest])
+
+    @staticmethod
+    def from_type_and_target_layout(
+        source: SSAValue | Operation,
+        layout: Attribute,
+    ) -> ReShuffleOp:
+        assert isinstance(source.type, MemRefType)
+        dest = MemRefType(
+            source.type.get_element_type(),
+            shape=source.type.get_shape(),
+            layout=layout,
+            memory_space=source.type.memory_space,
+        )
+        return ReShuffleOp(source, dest)
+
+    def verify_(self) -> None:
+        source = cast(MemRefType[Attribute], self.source.type)
+        dest = cast(MemRefType[Attribute], self.dest.type)
+        if source.layout is None or isinstance(source.layout, NoneAttr):
+            raise VerifyException("Expected source to have a layout.")
+        if dest.layout is None or isinstance(dest.layout, NoneAttr):
+            raise VerifyException("Expected destination to have a layout.")
+        if source.get_shape() != dest.get_shape():
+            raise VerifyException(
+                "Expected source and destination to have the same shape."
+            )
+        if source.get_element_type() != dest.get_element_type():
+            raise VerifyException(
+                "Expected source and destination to have the same element type."
+            )
+        if source.memory_space != dest.memory_space:
+            raise VerifyException(
+                "Expected source and destination to have the same memory space."
+            )
+
+
+Snax = Dialect("snax", [ClusterSyncOp, ReShuffleOp], [])

--- a/tests/dialects/test_snax.py
+++ b/tests/dialects/test_snax.py
@@ -1,0 +1,70 @@
+import pytest
+from xdsl.dialects import builtin
+from xdsl.dialects.builtin import StridedLayoutAttr, i32, i64
+from xdsl.dialects.memref import MemRefType
+from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.test_value import TestSSAValue
+
+from compiler.dialects.snax import ReShuffleOp
+
+
+def test_memref_memory_space_cast():
+    layout_1 = StridedLayoutAttr(strides=(2, 4, 6), offset=8)
+    layout_2 = StridedLayoutAttr(strides=(2, 8, 16), offset=4)
+
+    source_type = MemRefType(
+        i32, [10, 2], layout=layout_1, memory_space=builtin.IntegerAttr(1, i32)
+    )
+    source_ssa = TestSSAValue(source_type)
+
+    dest_type = MemRefType(i32, [10, 2], memory_space=builtin.IntegerAttr(1, i32))
+
+    reshuffle_op = ReShuffleOp(source_ssa, dest_type)
+
+    assert reshuffle_op.source is source_ssa
+    assert reshuffle_op.dest.type is dest_type
+
+    dest_type_other_element = MemRefType(
+        i64, [10, 2], layout=layout_2, memory_space=builtin.IntegerAttr(1, i32)
+    )
+
+    with pytest.raises(
+        VerifyException,
+        match="Expected source and destination to have the same element type.",
+    ):
+        ReShuffleOp(source_ssa, dest_type_other_element).verify()
+
+    dest_type_other_shape = MemRefType(
+        i32, [10, 4], layout=layout_2, memory_space=builtin.IntegerAttr(1, i32)
+    )
+
+    with pytest.raises(
+        VerifyException, match="Expected source and destination to have the same shape."
+    ):
+        ReShuffleOp(source_ssa, dest_type_other_shape).verify()
+
+    dest_type_other_space = MemRefType(
+        i32, [10, 2], layout=layout_2, memory_space=builtin.IntegerAttr(2, i32)
+    )
+
+    with pytest.raises(
+        VerifyException,
+        match="Expected source and destination to have the same memory space.",
+    ):
+        ReShuffleOp(source_ssa, dest_type_other_space).verify()
+
+    type_nolayout = MemRefType(i32, [10, 2], memory_space=builtin.IntegerAttr(1, i32))
+    ssa_nolayout = TestSSAValue(type_nolayout)
+
+    with pytest.raises(VerifyException, match="Expected source to have a layout."):
+        ReShuffleOp(ssa_nolayout, dest_type).verify()
+
+    with pytest.raises(VerifyException, match="Expected destination to have a layout."):
+        ReShuffleOp(source_ssa, type_nolayout).verify()
+
+    # Test helper function
+    reshuffle_op = ReShuffleOp.from_type_and_target_layout(source_ssa, layout_2)
+
+    assert reshuffle_op.source is source_ssa
+    assert isinstance(reshuffle_op.dest.type, MemRefType)
+    assert reshuffle_op.dest.type.layout is layout_2

--- a/tests/dialects/test_snax.py
+++ b/tests/dialects/test_snax.py
@@ -5,7 +5,7 @@ from xdsl.dialects.memref import MemRefType
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.test_value import TestSSAValue
 
-from compiler.dialects.snax import ReShuffleOp
+from compiler.dialects.snax import LayoutCast
 
 
 def test_memref_memory_space_cast():
@@ -19,10 +19,10 @@ def test_memref_memory_space_cast():
 
     dest_type = MemRefType(i32, [10, 2], memory_space=builtin.IntegerAttr(1, i32))
 
-    reshuffle_op = ReShuffleOp(source_ssa, dest_type)
+    memory_layout_cast = LayoutCast(source_ssa, dest_type)
 
-    assert reshuffle_op.source is source_ssa
-    assert reshuffle_op.dest.type is dest_type
+    assert memory_layout_cast.source is source_ssa
+    assert memory_layout_cast.dest.type is dest_type
 
     dest_type_other_element = MemRefType(
         i64, [10, 2], layout=layout_2, memory_space=builtin.IntegerAttr(1, i32)
@@ -32,7 +32,7 @@ def test_memref_memory_space_cast():
         VerifyException,
         match="Expected source and destination to have the same element type.",
     ):
-        ReShuffleOp(source_ssa, dest_type_other_element).verify()
+        LayoutCast(source_ssa, dest_type_other_element).verify()
 
     dest_type_other_shape = MemRefType(
         i32, [10, 4], layout=layout_2, memory_space=builtin.IntegerAttr(1, i32)
@@ -41,7 +41,7 @@ def test_memref_memory_space_cast():
     with pytest.raises(
         VerifyException, match="Expected source and destination to have the same shape."
     ):
-        ReShuffleOp(source_ssa, dest_type_other_shape).verify()
+        LayoutCast(source_ssa, dest_type_other_shape).verify()
 
     dest_type_other_space = MemRefType(
         i32, [10, 2], layout=layout_2, memory_space=builtin.IntegerAttr(2, i32)
@@ -51,14 +51,14 @@ def test_memref_memory_space_cast():
         VerifyException,
         match="Expected source and destination to have the same memory space.",
     ):
-        ReShuffleOp(source_ssa, dest_type_other_space).verify()
+        LayoutCast(source_ssa, dest_type_other_space).verify()
 
     type_nolayout = MemRefType(i32, [10, 2], memory_space=builtin.IntegerAttr(1, i32))
     TestSSAValue(type_nolayout)
 
     # Test helper function
-    reshuffle_op = ReShuffleOp.from_type_and_target_layout(source_ssa, layout_2)
+    memory_layout_cast = LayoutCast.from_type_and_target_layout(source_ssa, layout_2)
 
-    assert reshuffle_op.source is source_ssa
-    assert isinstance(reshuffle_op.dest.type, MemRefType)
-    assert reshuffle_op.dest.type.layout is layout_2
+    assert memory_layout_cast.source is source_ssa
+    assert isinstance(memory_layout_cast.dest.type, MemRefType)
+    assert memory_layout_cast.dest.type.layout is layout_2

--- a/tests/dialects/test_snax.py
+++ b/tests/dialects/test_snax.py
@@ -54,13 +54,7 @@ def test_memref_memory_space_cast():
         ReShuffleOp(source_ssa, dest_type_other_space).verify()
 
     type_nolayout = MemRefType(i32, [10, 2], memory_space=builtin.IntegerAttr(1, i32))
-    ssa_nolayout = TestSSAValue(type_nolayout)
-
-    with pytest.raises(VerifyException, match="Expected source to have a layout."):
-        ReShuffleOp(ssa_nolayout, dest_type).verify()
-
-    with pytest.raises(VerifyException, match="Expected destination to have a layout."):
-        ReShuffleOp(source_ssa, type_nolayout).verify()
+    TestSSAValue(type_nolayout)
 
     # Test helper function
     reshuffle_op = ReShuffleOp.from_type_and_target_layout(source_ssa, layout_2)

--- a/tests/filecheck/dialects/snax/snax_ops.mlir
+++ b/tests/filecheck/dialects/snax/snax_ops.mlir
@@ -1,0 +1,13 @@
+// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_SINGLETRIP
+
+"builtin.module"() ({
+  %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, 1 : i32>
+  %1 = "snax.reshuffle"(%0) : (memref<8x8xi32, strided<[1, 8]>, 1 : i32>) -> memref<8x8xi32, strided<[1, 16]>, 1 : i32>
+}) : () -> ()
+
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, 1 : i32>
+// CHECK-NEXT:   %1 = "snax.reshuffle"(%0) : (memref<8x8xi32, strided<[1, 8]>, 1 : i32>) -> memref<8x8xi32, strided<[1, 16]>, 1 : i32>
+// CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/snax/snax_ops.mlir
+++ b/tests/filecheck/dialects/snax/snax_ops.mlir
@@ -3,11 +3,11 @@
 
 "builtin.module"() ({
   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, 1 : i32>
-  %1 = "snax.reshuffle"(%0) : (memref<8x8xi32, strided<[1, 8]>, 1 : i32>) -> memref<8x8xi32, strided<[1, 16]>, 1 : i32>
+  %1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, 1 : i32>) -> memref<8x8xi32, strided<[1, 16]>, 1 : i32>
 }) : () -> ()
 
 
 // CHECK: "builtin.module"() ({
 // CHECK-NEXT:   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, 1 : i32>
-// CHECK-NEXT:   %1 = "snax.reshuffle"(%0) : (memref<8x8xi32, strided<[1, 8]>, 1 : i32>) -> memref<8x8xi32, strided<[1, 16]>, 1 : i32>
+// CHECK-NEXT:   %1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, 1 : i32>) -> memref<8x8xi32, strided<[1, 16]>, 1 : i32>
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -9,6 +9,6 @@ config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {snax_src}"])
 config.suffixes = ['.test', '.mlir', '.py']
 
 config.substitutions.append(('XDSL_PARSING_DIAG', "./compiler/snax-opt %s --print-op-generic --parsing-diagnostics --split-input-file | filecheck %s"))
-config.substitutions.append(('XDSL_ROUNDTRIP', "./compiler/snax-opt %s --print-op-generic --split-input-file | ./compiler/snax-opt --split-input-file | filecheck %s"))
+config.substitutions.append(('XDSL_ROUNDTRIP', "./compiler/snax-opt %s --print-op-generic --split-input-file | ./compiler/snax-opt --print-op-generic --split-input-file | filecheck %s"))
 config.substitutions.append(('XDSL_SINGLETRIP', "./compiler/snax-opt %s --print-op-generic --split-input-file | filecheck %s"))
 config.substitutions.append(("XDSL_GENERIC_ROUNDTRIP", "./compiler/snax-opt %s --print-op-generic --split-input-file | filecheck %s --check-prefix=CHECK-GENERIC"))


### PR DESCRIPTION
This PR adds the reshuffle op.
This is meant to be an equivalent to how we use `memory_space_cast`, by casting a specific memref to another memref with a different layout. Note that this operation does not create a copy. The copies/actual transformation is realized by a following pass. How the reshuffling is performed can vary. 