### PR TITLE
split up cast realization pass

### DIFF
--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -11,7 +11,10 @@ from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
 from compiler.transforms.insert_sync_barrier import InsertSyncBarrier
 from compiler.transforms.linalg_to_library_call import LinalgToLibraryCall
-from compiler.transforms.set_memory_space import SetMemorySpace
+from compiler.transforms.set_memory_space import (
+    RealizeMemorySpaceCastsPass,
+    SetMemorySpace,
+)
 from compiler.transforms.snax_copy_to_dma import SNAXCopyToDMA
 from compiler.transforms.snax_to_func import SNAXToFunc
 
@@ -38,6 +41,9 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(DispatchKernels.name, lambda: DispatchKernels)
         super().register_pass(LinalgToLibraryCall.name, lambda: LinalgToLibraryCall)
         super().register_pass(SetMemorySpace.name, lambda: SetMemorySpace)
+        super().register_pass(
+            RealizeMemorySpaceCastsPass.name, lambda: RealizeMemorySpaceCastsPass
+        )
         super().register_pass(InsertSyncBarrier.name, lambda: InsertSyncBarrier)
         super().register_pass(DispatchRegions.name, lambda: DispatchRegions)
         super().register_pass(SNAXCopyToDMA.name, lambda: SNAXCopyToDMA)

--- a/compiler/transforms/set_memory_space.py
+++ b/compiler/transforms/set_memory_space.py
@@ -330,4 +330,10 @@ class SetMemorySpace(ModulePass):
         PatternRewriteWalker(InitMemRefAllocMemorySpace()).rewrite_module(op)
         PatternRewriteWalker(InitLinalgMemorySpace()).rewrite_module(op)
         PatternRewriteWalker(HandleFuncReturns()).rewrite_module(op)
+
+
+class RealizeMemorySpaceCastsPass(ModulePass):
+    name = "realize-memory-space-casts"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         PatternRewriteWalker(RealizeMemorySpaceCasts()).rewrite_module(op)

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -107,7 +107,7 @@ MLIRPREPROC3FLAGS += --mlir-print-local-scope
 
 # SNAX opt
 
-SNAXOPTFLAGS = -p set-memory-space,insert-sync-barrier,dispatch-regions,dispatch-kernels,linalg-to-library-call,snax-copy-to-dma,snax-to-func,clear-memory-space
+SNAXOPTFLAGS = -p set-memory-space,realize-memory-space-casts,insert-sync-barrier,dispatch-regions,dispatch-kernels,linalg-to-library-call,snax-copy-to-dma,snax-to-func,clear-memory-space
 
 %.snax-opt.mlir: %.preprocfinal.mlir
 	$(SNAXOPT) $(SNAXOPTFLAGS) -o $@ $<

--- a/tests/filecheck/transforms/realize-memory-space-casts.mlir
+++ b/tests/filecheck/transforms/realize-memory-space-casts.mlir
@@ -1,0 +1,130 @@
+// RUN: ./compiler/snax-opt --split-input-file %s -p realize-memory-space-casts --print-op-generic | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+  ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
+    %0 = "memref.memory_space_cast"(%arg0) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+    %1 = "memref.memory_space_cast"(%arg1) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+    %2 = "memref.memory_space_cast"(%arg2) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+    "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+    ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+      %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+      "linalg.yield"(%3) : (i32) -> ()
+    }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+// CHECK-NEXT:   ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
+// CHECK-NEXT:     %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %1 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %2 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "memref.copy"(%arg1, %1) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+// CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%3) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "memref.copy"(%2, %arg2) : (memref<64xi32, 1 : i32>, memref<64xi32, 0 : i32>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()
+
+// -----
+
+"builtin.module"() ({
+  "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+  ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
+    %0 = "memref.memory_space_cast"(%arg0) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+    %1 = "memref.memory_space_cast"(%arg1) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+    %2 = "memref.memory_space_cast"(%arg2) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+    "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+    ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+      %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+      "linalg.yield"(%3) : (i32) -> ()
+    }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+    "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+    ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
+      %4 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
+      "linalg.yield"(%4) : (i32) -> ()
+    }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+// CHECK-NEXT:   ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
+// CHECK-NEXT:     %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %1 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %2 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "memref.copy"(%arg1, %1) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+// CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%3) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
+// CHECK-NEXT:       %4 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%4) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "memref.copy"(%2, %arg2) : (memref<64xi32, 1 : i32>, memref<64xi32, 0 : i32>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()
+
+// -----
+
+"builtin.module"() ({
+  "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+  ^0(%arg0 : memref<?xi32, 0 : i32>, %arg1 : memref<?xi32, 0 : i32>, %arg2 : memref<?xi32, 0 : i32>):
+    %0 = "memref.memory_space_cast"(%arg0) : (memref<?xi32, 0 : i32>) -> memref<?xi32, 1 : i32>
+    %1 = "memref.memory_space_cast"(%arg1) : (memref<?xi32, 0 : i32>) -> memref<?xi32, 1 : i32>
+    %2 = "memref.memory_space_cast"(%arg2) : (memref<?xi32, 0 : i32>) -> memref<?xi32, 1 : i32>
+    "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+    ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+      %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+      "linalg.yield"(%3) : (i32) -> ()
+    }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
+    "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+    ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
+      %4 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
+      "linalg.yield"(%4) : (i32) -> ()
+    }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+// CHECK-NEXT:   ^0(%arg0 : memref<?xi32, 0 : i32>, %arg1 : memref<?xi32, 0 : i32>, %arg2 : memref<?xi32, 0 : i32>):
+// CHECK-NEXT:     %0 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+// CHECK-NEXT:     %1 = "memref.dim"(%arg0, %0) : (memref<?xi32, 0 : i32>, index) -> index
+// CHECK-NEXT:     %2 = "memref.alloc"(%1) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
+// CHECK-NEXT:     %3 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+// CHECK-NEXT:     %4 = "memref.dim"(%arg1, %3) : (memref<?xi32, 0 : i32>, index) -> index
+// CHECK-NEXT:     %5 = "memref.alloc"(%4) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
+// CHECK-NEXT:     %6 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+// CHECK-NEXT:     %7 = "memref.dim"(%arg2, %6) : (memref<?xi32, 0 : i32>, index) -> index
+// CHECK-NEXT:     %8 = "memref.alloc"(%7) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
+// CHECK-NEXT:     "memref.copy"(%arg0, %2) : (memref<?xi32, 0 : i32>, memref<?xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "memref.copy"(%arg1, %5) : (memref<?xi32, 0 : i32>, memref<?xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "linalg.generic"(%2, %5, %8) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+// CHECK-NEXT:       %9 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%9) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "linalg.generic"(%2, %5, %8) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
+// CHECK-NEXT:       %10 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%10) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "memref.copy"(%8, %arg2) : (memref<?xi32, 1 : i32>, memref<?xi32, 0 : i32>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/transforms/set-memory-space.mlir
+++ b/tests/filecheck/transforms/set-memory-space.mlir
@@ -48,23 +48,20 @@
   }) : () -> ()
 }) : () -> ()
 
-//CHECK: "builtin.module"() ({
-//CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
-//CHECK-NEXT:   ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
-//CHECK-NEXT:     %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     %1 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     %2 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "memref.copy"(%arg1, %1) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
-//CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
-//CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
-//CHECK-NEXT:       "linalg.yield"(%3) : (i32) -> ()
-//CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "memref.copy"(%2, %arg2) : (memref<64xi32, 1 : i32>, memref<64xi32, 0 : i32>) -> ()
-//CHECK-NEXT:     "func.return"() : () -> ()
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT: }) : () -> ()
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+// CHECK-NEXT:   ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
+// CHECK-NEXT:     %0 = "memref.memory_space_cast"(%arg0) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %1 = "memref.memory_space_cast"(%arg1) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %2 = "memref.memory_space_cast"(%arg2) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+// CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%3) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()
 
 // -----
 
@@ -86,28 +83,25 @@
 }) : () -> ()
 
 
-//CHECK: "builtin.module"() ({
-//CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
-//CHECK-NEXT:   ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
-//CHECK-NEXT:     %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     %1 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     %2 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "memref.copy"(%arg1, %1) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
-//CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
-//CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
-//CHECK-NEXT:       "linalg.yield"(%3) : (i32) -> ()
-//CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
-//CHECK-NEXT:     ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
-//CHECK-NEXT:       %4 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
-//CHECK-NEXT:       "linalg.yield"(%4) : (i32) -> ()
-//CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "memref.copy"(%2, %arg2) : (memref<64xi32, 1 : i32>, memref<64xi32, 0 : i32>) -> ()
-//CHECK-NEXT:     "func.return"() : () -> ()
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT: }) : () -> ()
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+// CHECK-NEXT:   ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
+// CHECK-NEXT:     %0 = "memref.memory_space_cast"(%arg0) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %1 = "memref.memory_space_cast"(%arg1) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %2 = "memref.memory_space_cast"(%arg2) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+// CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%3) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
+// CHECK-NEXT:       %4 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%4) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()
 
 // -----
 
@@ -128,31 +122,22 @@
   }) : () -> ()
 }) : () -> ()
 
-//CHECK: "builtin.module"() ({
-//CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
-//CHECK-NEXT:   ^0(%arg0 : memref<?xi32, 0 : i32>, %arg1 : memref<?xi32, 0 : i32>, %arg2 : memref<?xi32, 0 : i32>):
-//CHECK-NEXT:     %0 = "arith.constant"() <{"value" = 0 : index}> : () -> index
-//CHECK-NEXT:     %1 = "memref.dim"(%arg0, %0) : (memref<?xi32, 0 : i32>, index) -> index
-//CHECK-NEXT:     %2 = "memref.alloc"(%1) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
-//CHECK-NEXT:     %3 = "arith.constant"() <{"value" = 0 : index}> : () -> index
-//CHECK-NEXT:     %4 = "memref.dim"(%arg1, %3) : (memref<?xi32, 0 : i32>, index) -> index
-//CHECK-NEXT:     %5 = "memref.alloc"(%4) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
-//CHECK-NEXT:     %6 = "arith.constant"() <{"value" = 0 : index}> : () -> index
-//CHECK-NEXT:     %7 = "memref.dim"(%arg2, %6) : (memref<?xi32, 0 : i32>, index) -> index
-//CHECK-NEXT:     %8 = "memref.alloc"(%7) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
-//CHECK-NEXT:     "memref.copy"(%arg0, %2) : (memref<?xi32, 0 : i32>, memref<?xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "memref.copy"(%arg1, %5) : (memref<?xi32, 0 : i32>, memref<?xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "linalg.generic"(%2, %5, %8) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
-//CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
-//CHECK-NEXT:       %9 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
-//CHECK-NEXT:       "linalg.yield"(%9) : (i32) -> ()
-//CHECK-NEXT:     }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "linalg.generic"(%2, %5, %8) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
-//CHECK-NEXT:     ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
-//CHECK-NEXT:       %10 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
-//CHECK-NEXT:       "linalg.yield"(%10) : (i32) -> ()
-//CHECK-NEXT:     }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "memref.copy"(%8, %arg2) : (memref<?xi32, 1 : i32>, memref<?xi32, 0 : i32>) -> ()
-//CHECK-NEXT:     "func.return"() : () -> ()
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT: }) : () -> ()
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+// CHECK-NEXT:   ^0(%arg0 : memref<?xi32, 0 : i32>, %arg1 : memref<?xi32, 0 : i32>, %arg2 : memref<?xi32, 0 : i32>):
+// CHECK-NEXT:     %0 = "memref.memory_space_cast"(%arg0) : (memref<?xi32, 0 : i32>) -> memref<?xi32, 1 : i32>
+// CHECK-NEXT:     %1 = "memref.memory_space_cast"(%arg1) : (memref<?xi32, 0 : i32>) -> memref<?xi32, 1 : i32>
+// CHECK-NEXT:     %2 = "memref.memory_space_cast"(%arg2) : (memref<?xi32, 0 : i32>) -> memref<?xi32, 1 : i32>
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+// CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%3) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
+// CHECK-NEXT:       %4 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%4) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()


### PR DESCRIPTION
This PR splits up the set-memory-layout pass into two:

1. `set-memory-layout`: insert casts
2. `realize-memory-space-casts`

This is because we want to do stuff inbetween the two passes as well. 
For example, based on the layer to which an accelerator is dispatched, we can decide to which memory space it will be cast. After this, we decide on a given memory layout. After this, we can realize the memory space casts and reshuffling operations at once.