### PR TITLE
add memory layout pass

### DIFF
--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -11,6 +11,7 @@ from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
 from compiler.transforms.insert_sync_barrier import InsertSyncBarrier
 from compiler.transforms.linalg_to_library_call import LinalgToLibraryCall
+from compiler.transforms.set_memory_layout import SetMemoryLayout
 from compiler.transforms.set_memory_space import (
     RealizeMemorySpaceCastsPass,
     SetMemorySpace,
@@ -41,6 +42,7 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(DispatchKernels.name, lambda: DispatchKernels)
         super().register_pass(LinalgToLibraryCall.name, lambda: LinalgToLibraryCall)
         super().register_pass(SetMemorySpace.name, lambda: SetMemorySpace)
+        super().register_pass(SetMemoryLayout.name, lambda: SetMemoryLayout)
         super().register_pass(
             RealizeMemorySpaceCastsPass.name, lambda: RealizeMemorySpaceCastsPass
         )

--- a/compiler/transforms/set_memory_layout.py
+++ b/compiler/transforms/set_memory_layout.py
@@ -8,7 +8,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 
-from compiler.dialects.snax import ReShuffleOp
+from compiler.dialects.snax import LayoutCast
 from compiler.dialects.tsl import TiledStridedLayoutAttr
 from compiler.ir.tsl import Stride, TiledStride, TiledStridedLayout
 
@@ -62,15 +62,15 @@ class AddMemoryLayout(RewritePattern):
             )
 
             # insert reshuffling ops
-            new_input_a = ReShuffleOp.from_type_and_target_layout(
+            new_input_a = LayoutCast.from_type_and_target_layout(
                 linalg_op.inputs[0], tsl_input_a
             )
 
-            new_input_b = ReShuffleOp.from_type_and_target_layout(
+            new_input_b = LayoutCast.from_type_and_target_layout(
                 linalg_op.inputs[1], tsl_input_b
             )
 
-            new_output = ReShuffleOp.from_type_and_target_layout(
+            new_output = LayoutCast.from_type_and_target_layout(
                 linalg_op.outputs[0], tsl_output
             )
 

--- a/compiler/transforms/set_memory_layout.py
+++ b/compiler/transforms/set_memory_layout.py
@@ -26,7 +26,8 @@ class AddMemoryLayout(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, linalg_op: linalg.Generic, rewriter: PatternRewriter):
-        # check if operation is dispatched via library call
+        # check if operation is dispatched via library call, as set by e.g.
+        # the dispatch-kernels pass
         if linalg_op.library_call is None:
             return
         else:

--- a/compiler/transforms/set_memory_layout.py
+++ b/compiler/transforms/set_memory_layout.py
@@ -18,8 +18,10 @@ class AddMemoryLayout(RewritePattern):
     This class represents a rewrite pattern for adding memory layout to a
     linalg operation. The implementation is very naive. It imposes a specific
     memory layout on the input and output of the linalg operation dispatched
-    to snax_qgemm by inserting reshuffling ops. In the future, the memory
+    to snax_qgemm by inserting layout_cast ops. In the future, the memory
     layout will be selected in a more automatic way.
+
+    Note: currently, only snax_qgemm is supported.
     """
 
     @op_type_rewrite_pattern
@@ -61,7 +63,7 @@ class AddMemoryLayout(RewritePattern):
                 )
             )
 
-            # insert reshuffling ops
+            # insert layout_cast ops
             new_input_a = LayoutCast.from_type_and_target_layout(
                 linalg_op.inputs[0], tsl_input_a
             )

--- a/compiler/transforms/set_memory_layout.py
+++ b/compiler/transforms/set_memory_layout.py
@@ -1,0 +1,99 @@
+from xdsl.dialects import builtin, linalg
+from xdsl.ir import MLContext
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+from compiler.dialects.snax import ReShuffleOp
+from compiler.dialects.tsl import TiledStridedLayoutAttr
+from compiler.ir.tsl import Stride, TiledStride, TiledStridedLayout
+
+
+class AddMemoryLayout(RewritePattern):
+    """
+    This class represents a rewrite pattern for adding memory layout to a
+    linalg operation. The implementation is very naive. It imposes a specific
+    memory layout on the input and output of the linalg operation dispatched
+    to snax_qgemm by inserting reshuffling ops. In the future, the memory
+    layout will be selected in a more automatic way.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, linalg_op: linalg.Generic, rewriter: PatternRewriter):
+        # check if operation is dispatched via library call
+        if linalg_op.library_call is None:
+            return
+        else:
+            library_call = linalg_op.library_call.data
+
+        # check for library call
+        if library_call == "snax_qgemm":
+            tsl_input_a = TiledStridedLayoutAttr(
+                TiledStridedLayout(
+                    [
+                        TiledStride([Stride(None, None), Stride(8, 8)]),
+                        TiledStride([Stride(256, None), Stride(1, 8)]),
+                    ]
+                )
+            )
+
+            ## tsl b has an offset of 64 to not collide with the banks of a
+            tsl_input_b = TiledStridedLayoutAttr(
+                TiledStridedLayout(
+                    [
+                        TiledStride([Stride(256, None), Stride(1, 8)]),
+                        TiledStride([Stride(None, None), Stride(8, 8)]),
+                    ],
+                    offset=64,
+                )
+            )
+
+            tsl_output = TiledStridedLayoutAttr(
+                TiledStridedLayout(
+                    [
+                        TiledStride([Stride(256, None), Stride(4, 8)]),
+                        TiledStride([Stride(None, None), Stride(32, 8)]),
+                    ]
+                )
+            )
+
+            # insert reshuffling ops
+            new_input_a = ReShuffleOp.from_type_and_target_layout(
+                linalg_op.inputs[0], tsl_input_a
+            )
+
+            new_input_b = ReShuffleOp.from_type_and_target_layout(
+                linalg_op.inputs[1], tsl_input_b
+            )
+
+            new_output = ReShuffleOp.from_type_and_target_layout(
+                linalg_op.outputs[0], tsl_output
+            )
+
+            new_linalg_op = linalg.Generic(
+                inputs=[new_input_a, new_input_b, *linalg_op.inputs[2:]],
+                outputs=[new_output],
+                body=rewriter.move_region_contents_to_new_regions(linalg_op.regions[0]),
+                indexing_maps=linalg_op.indexing_maps,
+                iterator_types=linalg_op.iterator_types,
+                doc=linalg_op.doc,
+                library_call=linalg_op.library_call,
+            )
+
+            rewriter.insert_op_before_matched_op([new_input_a, new_input_b, new_output])
+            rewriter.replace_op(linalg_op, new_linalg_op)
+
+        pass
+
+
+class SetMemoryLayout(ModulePass):
+    name = "set-memory-layout"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(AddMemoryLayout(), apply_recursively=False).rewrite_module(
+            op
+        )

--- a/tests/filecheck/transforms/set-memory-layout.mlir
+++ b/tests/filecheck/transforms/set-memory-layout.mlir
@@ -24,9 +24,9 @@
 // CHECK-NEXT:   ^0(%arg0 : memref<?x128xi8, 1 : i32>, %arg1 : memref<128x128xi8, 1 : i32>, %arg2 : memref<?x128xi32, 1 : i32>):
 // CHECK-NEXT:     %0 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
 // CHECK-NEXT:     %1 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
-// CHECK-NEXT:     %2 = "snax.reshuffle"(%arg0) : (memref<?x128xi8, 1 : i32>) -> memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, 1 : i32>
-// CHECK-NEXT:     %3 = "snax.reshuffle"(%arg1) : (memref<128x128xi8, 1 : i32>) -> memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8), offset: 64>, 1 : i32>
-// CHECK-NEXT:     %4 = "snax.reshuffle"(%arg2) : (memref<?x128xi32, 1 : i32>) -> memref<?x128xi32, #tsl.tsl<[?, 8] -> (256, 4), [?, 8] -> (?, 32)>, 1 : i32>
+// CHECK-NEXT:     %2 = "snax.layout_cast"(%arg0) : (memref<?x128xi8, 1 : i32>) -> memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, 1 : i32>
+// CHECK-NEXT:     %3 = "snax.layout_cast"(%arg1) : (memref<128x128xi8, 1 : i32>) -> memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8), offset: 64>, 1 : i32>
+// CHECK-NEXT:     %4 = "snax.layout_cast"(%arg2) : (memref<?x128xi32, 1 : i32>) -> memref<?x128xi32, #tsl.tsl<[?, 8] -> (256, 4), [?, 8] -> (?, 32)>, 1 : i32>
 // CHECK-NEXT:     "linalg.generic"(%2, %3, %0, %1, %4) <{"indexing_maps" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>], "iterator_types" = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>], "operandSegmentSizes" = array<i32: 4, 1>}> ({
 // CHECK-NEXT:     ^1(%arg3 : i8, %arg4 : i8, %arg5 : i32, %arg6 : i32, %arg7 : i32):
 // CHECK-NEXT:       %5 = "arith.extsi"(%arg3) : (i8) -> i32

--- a/tests/filecheck/transforms/set-memory-layout.mlir
+++ b/tests/filecheck/transforms/set-memory-layout.mlir
@@ -1,0 +1,43 @@
+// RUN: ./compiler/snax-opt --split-input-file %s -p set-memory-layout --print-op-generic | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{"sym_name" = "mnist", "function_type" = (memref<?x128xi8, 1 : i32>, memref<128x128xi8, 1 : i32>, memref<?x128xi32, 1 : i32>) -> memref<?x128xi32, 1 : i32>}> ({
+  ^0(%arg0 : memref<?x128xi8, 1 : i32>, %arg1 : memref<128x128xi8, 1 : i32>, %arg2 : memref<?x128xi32, 1 : i32>):
+    %0 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
+    %1 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
+    "linalg.generic"(%arg0, %arg1, %0, %1, %arg2) <{"indexing_maps" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>], "iterator_types" = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>], "operandSegmentSizes" = array<i32: 4, 1>}> ({
+    ^1(%arg3 : i8, %arg4 : i8, %arg5 : i32, %arg6 : i32, %arg7 : i32):
+      %2 = "arith.extsi"(%arg3) : (i8) -> i32
+      %3 = "arith.subi"(%2, %arg5) : (i32, i32) -> i32
+      %4 = "arith.extsi"(%arg4) : (i8) -> i32
+      %5 = "arith.subi"(%4, %arg6) : (i32, i32) -> i32
+      %6 = "arith.muli"(%3, %5) : (i32, i32) -> i32
+      %7 = "arith.addi"(%arg7, %6) : (i32, i32) -> i32
+      "linalg.yield"(%7) : (i32) -> ()
+    }) {"library_call" = "snax_qgemm"} : (memref<?x128xi8, 1 : i32>, memref<128x128xi8, 1 : i32>, i32, i32, memref<?x128xi32, 1 : i32>) -> ()
+    "func.return"(%arg2) : (memref<?x128xi32, 1 : i32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "mnist", "function_type" = (memref<?x128xi8, 1 : i32>, memref<128x128xi8, 1 : i32>, memref<?x128xi32, 1 : i32>) -> memref<?x128xi32, 1 : i32>}> ({
+// CHECK-NEXT:   ^0(%arg0 : memref<?x128xi8, 1 : i32>, %arg1 : memref<128x128xi8, 1 : i32>, %arg2 : memref<?x128xi32, 1 : i32>):
+// CHECK-NEXT:     %0 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
+// CHECK-NEXT:     %1 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
+// CHECK-NEXT:     %2 = "snax.reshuffle"(%arg0) : (memref<?x128xi8, 1 : i32>) -> memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, 1 : i32>
+// CHECK-NEXT:     %3 = "snax.reshuffle"(%arg1) : (memref<128x128xi8, 1 : i32>) -> memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8), offset: 64>, 1 : i32>
+// CHECK-NEXT:     %4 = "snax.reshuffle"(%arg2) : (memref<?x128xi32, 1 : i32>) -> memref<?x128xi32, #tsl.tsl<[?, 8] -> (256, 4), [?, 8] -> (?, 32)>, 1 : i32>
+// CHECK-NEXT:     "linalg.generic"(%2, %3, %0, %1, %4) <{"indexing_maps" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>], "iterator_types" = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>], "operandSegmentSizes" = array<i32: 4, 1>}> ({
+// CHECK-NEXT:     ^1(%arg3 : i8, %arg4 : i8, %arg5 : i32, %arg6 : i32, %arg7 : i32):
+// CHECK-NEXT:       %5 = "arith.extsi"(%arg3) : (i8) -> i32
+// CHECK-NEXT:       %6 = "arith.subi"(%5, %arg5) : (i32, i32) -> i32
+// CHECK-NEXT:       %7 = "arith.extsi"(%arg4) : (i8) -> i32
+// CHECK-NEXT:       %8 = "arith.subi"(%7, %arg6) : (i32, i32) -> i32
+// CHECK-NEXT:       %9 = "arith.muli"(%6, %8) : (i32, i32) -> i32
+// CHECK-NEXT:       %10 = "arith.addi"(%arg7, %9) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%10) : (i32) -> ()
+// CHECK-NEXT:     }) {"library_call" = "snax_qgemm"} : (memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, 1 : i32>, memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8), offset: 64>, 1 : i32>, i32, i32, memref<?x128xi32, #tsl.tsl<[?, 8] -> (256, 4), [?, 8] -> (?, 32)>, 1 : i32>) -> ()
+// CHECK-NEXT:     "func.return"(%arg2) : (memref<?x128xi32, 1 : i32>) -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()
+


### PR DESCRIPTION
This PR implements an initial pass for enforcing memory layouts when operations are disptached to certain accelerators. Currently, the implementation is very naive. It imposes a specific memory layout on the input and output of the linalg operation dispatched to snax_qgemm by inserting layout casting ops. In the future, the memory layout will be selected in a more intelligent, automatic way.