### PR TITLE
compiler: add realize-memref-casts pass

### DIFF
--- a/compiler/dialects/snax.py
+++ b/compiler/dialects/snax.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import cast
 
-from xdsl.dialects.builtin import NoneAttr
 from xdsl.dialects.memref import MemRefType, UnrankedMemrefType
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, result_def
@@ -51,10 +50,6 @@ class ReShuffleOp(IRDLOperation):
     def verify_(self) -> None:
         source = cast(MemRefType[Attribute], self.source.type)
         dest = cast(MemRefType[Attribute], self.dest.type)
-        if source.layout is None or isinstance(source.layout, NoneAttr):
-            raise VerifyException("Expected source to have a layout.")
-        if dest.layout is None or isinstance(dest.layout, NoneAttr):
-            raise VerifyException("Expected destination to have a layout.")
         if source.get_shape() != dest.get_shape():
             raise VerifyException(
                 "Expected source and destination to have the same shape."

--- a/compiler/dialects/snax.py
+++ b/compiler/dialects/snax.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from xdsl.ir import Dialect
-from xdsl.irdl import (
-    IRDLOperation,
-    irdl_op_definition,
-)
+from typing import cast
+
+from xdsl.dialects.builtin import NoneAttr
+from xdsl.dialects.memref import MemRefType, UnrankedMemrefType
+from xdsl.ir import Attribute, Dialect, Operation, SSAValue
+from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, result_def
+from xdsl.utils.exceptions import VerifyException
 
 
 @irdl_op_definition
@@ -15,4 +17,56 @@ class ClusterSyncOp(IRDLOperation):
     name = "snax.cluster_sync_op"
 
 
-Snax = Dialect("snax", [ClusterSyncOp], [])
+@irdl_op_definition
+class ReShuffleOp(IRDLOperation):
+    """ReShuffle operation for memrefs in a snax cluster. This
+    operation is used to change the layout of the memref data"""
+
+    name = "snax.reshuffle"
+
+    source = operand_def(MemRefType[Attribute] | UnrankedMemrefType[Attribute])
+    dest = result_def(MemRefType[Attribute] | UnrankedMemrefType[Attribute])
+
+    def __init__(
+        self,
+        source: SSAValue | Operation,
+        dest: MemRefType[Attribute] | UnrankedMemrefType[Attribute],
+    ):
+        super().__init__(operands=[source], result_types=[dest])
+
+    @staticmethod
+    def from_type_and_target_layout(
+        source: SSAValue | Operation,
+        layout: Attribute,
+    ) -> ReShuffleOp:
+        assert isinstance(source.type, MemRefType)
+        dest = MemRefType(
+            source.type.get_element_type(),
+            shape=source.type.get_shape(),
+            layout=layout,
+            memory_space=source.type.memory_space,
+        )
+        return ReShuffleOp(source, dest)
+
+    def verify_(self) -> None:
+        source = cast(MemRefType[Attribute], self.source.type)
+        dest = cast(MemRefType[Attribute], self.dest.type)
+        if source.layout is None or isinstance(source.layout, NoneAttr):
+            raise VerifyException("Expected source to have a layout.")
+        if dest.layout is None or isinstance(dest.layout, NoneAttr):
+            raise VerifyException("Expected destination to have a layout.")
+        if source.get_shape() != dest.get_shape():
+            raise VerifyException(
+                "Expected source and destination to have the same shape."
+            )
+        if source.get_element_type() != dest.get_element_type():
+            raise VerifyException(
+                "Expected source and destination to have the same element type."
+            )
+        if source.memory_space != dest.memory_space:
+            raise VerifyException(
+                "Expected source and destination to have the same memory space."
+            )
+
+
+Snax = Dialect("snax", [ClusterSyncOp, ReShuffleOp], [])

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -11,6 +11,7 @@ from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
 from compiler.transforms.insert_sync_barrier import InsertSyncBarrier
 from compiler.transforms.linalg_to_library_call import LinalgToLibraryCall
+from compiler.transforms.set_memory_layout import SetMemoryLayout
 from compiler.transforms.set_memory_space import (
     RealizeMemorySpaceCastsPass,
     SetMemorySpace,
@@ -41,6 +42,7 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(DispatchKernels.name, lambda: DispatchKernels)
         super().register_pass(LinalgToLibraryCall.name, lambda: LinalgToLibraryCall)
         super().register_pass(SetMemorySpace.name, lambda: SetMemorySpace)
+        super().register_pass(SetMemoryLayout.name, lambda: SetMemoryLayout)
         super().register_pass(
             RealizeMemorySpaceCastsPass.name, lambda: RealizeMemorySpaceCastsPass
         )

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -11,11 +11,9 @@ from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
 from compiler.transforms.insert_sync_barrier import InsertSyncBarrier
 from compiler.transforms.linalg_to_library_call import LinalgToLibraryCall
+from compiler.transforms.realize_memref_casts import RealizeMemrefCastsPass
 from compiler.transforms.set_memory_layout import SetMemoryLayout
-from compiler.transforms.set_memory_space import (
-    RealizeMemorySpaceCastsPass,
-    SetMemorySpace,
-)
+from compiler.transforms.set_memory_space import SetMemorySpace
 from compiler.transforms.snax_copy_to_dma import SNAXCopyToDMA
 from compiler.transforms.snax_to_func import SNAXToFunc
 
@@ -43,14 +41,14 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(LinalgToLibraryCall.name, lambda: LinalgToLibraryCall)
         super().register_pass(SetMemorySpace.name, lambda: SetMemorySpace)
         super().register_pass(SetMemoryLayout.name, lambda: SetMemoryLayout)
-        super().register_pass(
-            RealizeMemorySpaceCastsPass.name, lambda: RealizeMemorySpaceCastsPass
-        )
         super().register_pass(InsertSyncBarrier.name, lambda: InsertSyncBarrier)
         super().register_pass(DispatchRegions.name, lambda: DispatchRegions)
         super().register_pass(SNAXCopyToDMA.name, lambda: SNAXCopyToDMA)
         super().register_pass(SNAXToFunc.name, lambda: SNAXToFunc)
         super().register_pass(ClearMemorySpace.name, lambda: ClearMemorySpace)
+        super().register_pass(
+            RealizeMemrefCastsPass.name, lambda: RealizeMemrefCastsPass
+        )
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -11,7 +11,10 @@ from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
 from compiler.transforms.insert_sync_barrier import InsertSyncBarrier
 from compiler.transforms.linalg_to_library_call import LinalgToLibraryCall
-from compiler.transforms.set_memory_space import SetMemorySpace
+from compiler.transforms.set_memory_space import (
+    RealizeMemorySpaceCastsPass,
+    SetMemorySpace,
+)
 from compiler.transforms.snax_copy_to_dma import SNAXCopyToDMA
 from compiler.transforms.snax_to_func import SNAXToFunc
 
@@ -38,6 +41,9 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(DispatchKernels.name, lambda: DispatchKernels)
         super().register_pass(LinalgToLibraryCall.name, lambda: LinalgToLibraryCall)
         super().register_pass(SetMemorySpace.name, lambda: SetMemorySpace)
+        super().register_pass(
+            RealizeMemorySpaceCastsPass.name, lambda: RealizeMemorySpaceCastsPass
+        )
         super().register_pass(InsertSyncBarrier.name, lambda: InsertSyncBarrier)
         super().register_pass(DispatchRegions.name, lambda: DispatchRegions)
         super().register_pass(SNAXCopyToDMA.name, lambda: SNAXCopyToDMA)

--- a/compiler/transforms/realize_memref_casts.py
+++ b/compiler/transforms/realize_memref_casts.py
@@ -1,0 +1,128 @@
+from xdsl.dialects import arith, builtin, func, linalg, memref
+from xdsl.dialects.memref import MemorySpaceCast
+from xdsl.ir import MLContext, Operation, OpResult
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+from compiler.dialects.snax import ReShuffleOp
+
+
+def is_cast_op(op: Operation) -> bool:
+    return isinstance(op, MemorySpaceCast) or isinstance(op, ReShuffleOp)
+
+
+class RealizeMemrefCasts(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(
+        self, op: MemorySpaceCast | ReShuffleOp, rewriter: PatternRewriter
+    ):
+        # if the casting is not used anymore (perhaps made useless by previous
+        # cast realizations), we do not need to do anything. dce will remove it later
+        if not op.dest.uses:
+            return
+
+        # due to previous passes, it is common for multiple memref casting
+        # ops to be chained together. For now all the transformations are handled
+        # by the DMA which can access all memory spaces, and handle all transformations
+        # so we can fuse all the casting operations together.
+
+        # keep track of ops to add
+        ops_to_add = []
+
+        # if the source of the memref cast is another reshuffle op,
+        # combine them all together
+        source_op = op
+        while isinstance(source_op.source, OpResult) and isinstance(
+            source_op.source.op, MemorySpaceCast | ReShuffleOp
+        ):
+            source_op = source_op.source.op
+
+        # now perform casting by inserting memref copies and allocs
+        source_type = source_op.source.type
+        assert isinstance(source_type, memref.MemRefType)
+        dest_type = op.dest.type
+        assert isinstance(dest_type, memref.MemRefType)
+
+        # create allocation
+
+        # create memref.dim operations for dynamic dimensions
+        shapes = [x.data for x in dest_type.shape.data]
+        dyn_operands = []
+        for i in range(len(shapes)):
+            # Dynamic shapes are represented as -1
+            if shapes[i] == -1:
+                ## create dim op
+                index = arith.Constant.from_int_and_width(i, builtin.IndexType())
+                dim_op = memref.Dim.from_source_and_index(
+                    source_op.source, index.result
+                )
+                ops_to_add.extend([index, dim_op])
+                dyn_operands.append(dim_op)
+
+        # create alloc op
+        alloc_op = memref.Alloc.get(
+            dest_type.get_element_type(),
+            64,  # default 64 alignment
+            dest_type.get_shape(),
+            dynamic_sizes=dyn_operands,
+            layout=dest_type.layout,
+            memory_space=dest_type.memory_space,
+        )
+        ops_to_add.append(alloc_op)
+
+        # Insert copy ops if newly allocated memref is used as
+        # input or output, list to visit all uses of allocated memrefs:
+        uses = [x.operation for x in op.dest.uses]
+
+        # insert "copy to" for first use as input
+        # walk parent op in order to find first use as input
+        for use_op in op.parent.walk():
+            if use_op not in uses:
+                continue
+            # check if input
+            is_input = False
+            if not isinstance(use_op, linalg.Generic):
+                # don't know if input or output, default to yes
+                is_input = True
+            else:
+                is_input = op.results[0] in use_op.inputs
+            if is_input:
+                # insert copy op
+                copy_op = memref.CopyOp(source_op.source, op.dest)
+                rewriter.insert_op_before(copy_op, use_op)
+                break
+
+        # insert "copy from" for last use as output
+        # walk parent op in reverse order to find last use as output
+        for use_op in op.parent.walk(reverse=True):
+            if use_op not in uses:
+                continue
+            # check if input
+            is_output = False
+            if isinstance(use_op, linalg.Generic):
+                is_output = op.results[0] in use_op.outputs
+            elif isinstance(use_op, func.Return):
+                is_output = False
+            else:
+                # don't know if input or output, default to yes
+                is_output = True
+            if is_output:
+                # insert copy op
+                copy_op = memref.CopyOp(op.dest, source_op.source)
+                rewriter.insert_op_after(copy_op, use_op)
+                break
+
+        # insert all ops
+        rewriter.replace_matched_op(ops_to_add)
+
+
+class RealizeMemrefCastsPass(ModulePass):
+    name = "realize-memref-casts"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(RealizeMemrefCasts(), walk_reverse=True).rewrite_module(op)

--- a/compiler/transforms/set_memory_layout.py
+++ b/compiler/transforms/set_memory_layout.py
@@ -1,0 +1,99 @@
+from xdsl.dialects import builtin, linalg
+from xdsl.ir import MLContext
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+from compiler.dialects.snax import ReShuffleOp
+from compiler.dialects.tsl import TiledStridedLayoutAttr
+from compiler.ir.tsl import Stride, TiledStride, TiledStridedLayout
+
+
+class AddMemoryLayout(RewritePattern):
+    """
+    This class represents a rewrite pattern for adding memory layout to a
+    linalg operation. The implementation is very naive. It imposes a specific
+    memory layout on the input and output of the linalg operation dispatched
+    to snax_qgemm by inserting reshuffling ops. In the future, the memory
+    layout will be selected in a more automatic way.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, linalg_op: linalg.Generic, rewriter: PatternRewriter):
+        # check if operation is dispatched via library call
+        if linalg_op.library_call is None:
+            return
+        else:
+            library_call = linalg_op.library_call.data
+
+        # check for library call
+        if library_call == "snax_qgemm":
+            tsl_input_a = TiledStridedLayoutAttr(
+                TiledStridedLayout(
+                    [
+                        TiledStride([Stride(None, None), Stride(8, 8)]),
+                        TiledStride([Stride(256, None), Stride(1, 8)]),
+                    ]
+                )
+            )
+
+            ## tsl b has an offset of 64 to not collide with the banks of a
+            tsl_input_b = TiledStridedLayoutAttr(
+                TiledStridedLayout(
+                    [
+                        TiledStride([Stride(256, None), Stride(1, 8)]),
+                        TiledStride([Stride(None, None), Stride(8, 8)]),
+                    ],
+                    offset=64,
+                )
+            )
+
+            tsl_output = TiledStridedLayoutAttr(
+                TiledStridedLayout(
+                    [
+                        TiledStride([Stride(256, None), Stride(4, 8)]),
+                        TiledStride([Stride(None, None), Stride(32, 8)]),
+                    ]
+                )
+            )
+
+            # insert reshuffling ops
+            new_input_a = ReShuffleOp.from_type_and_target_layout(
+                linalg_op.inputs[0], tsl_input_a
+            )
+
+            new_input_b = ReShuffleOp.from_type_and_target_layout(
+                linalg_op.inputs[1], tsl_input_b
+            )
+
+            new_output = ReShuffleOp.from_type_and_target_layout(
+                linalg_op.outputs[0], tsl_output
+            )
+
+            new_linalg_op = linalg.Generic(
+                inputs=[new_input_a, new_input_b, *linalg_op.inputs[2:]],
+                outputs=[new_output],
+                body=rewriter.move_region_contents_to_new_regions(linalg_op.regions[0]),
+                indexing_maps=linalg_op.indexing_maps,
+                iterator_types=linalg_op.iterator_types,
+                doc=linalg_op.doc,
+                library_call=linalg_op.library_call,
+            )
+
+            rewriter.insert_op_before_matched_op([new_input_a, new_input_b, new_output])
+            rewriter.replace_op(linalg_op, new_linalg_op)
+
+        pass
+
+
+class SetMemoryLayout(ModulePass):
+    name = "set-memory-layout"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(AddMemoryLayout(), apply_recursively=False).rewrite_module(
+            op
+        )

--- a/compiler/transforms/set_memory_space.py
+++ b/compiler/transforms/set_memory_space.py
@@ -330,4 +330,10 @@ class SetMemorySpace(ModulePass):
         PatternRewriteWalker(InitMemRefAllocMemorySpace()).rewrite_module(op)
         PatternRewriteWalker(InitLinalgMemorySpace()).rewrite_module(op)
         PatternRewriteWalker(HandleFuncReturns()).rewrite_module(op)
+
+
+class RealizeMemorySpaceCastsPass(ModulePass):
+    name = "realize-memory-space-casts"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         PatternRewriteWalker(RealizeMemorySpaceCasts()).rewrite_module(op)

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -107,7 +107,7 @@ MLIRPREPROC3FLAGS += --mlir-print-local-scope
 
 # SNAX opt
 
-SNAXOPTFLAGS = -p set-memory-space,insert-sync-barrier,dispatch-regions,dispatch-kernels,linalg-to-library-call,snax-copy-to-dma,snax-to-func,clear-memory-space
+SNAXOPTFLAGS = -p set-memory-space,realize-memory-space-casts,insert-sync-barrier,dispatch-regions,dispatch-kernels,linalg-to-library-call,snax-copy-to-dma,snax-to-func,clear-memory-space
 
 %.snax-opt.mlir: %.preprocfinal.mlir
 	$(SNAXOPT) $(SNAXOPTFLAGS) -o $@ $<

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -107,7 +107,7 @@ MLIRPREPROC3FLAGS += --mlir-print-local-scope
 
 # SNAX opt
 
-SNAXOPTFLAGS = -p set-memory-space,realize-memory-space-casts,insert-sync-barrier,dispatch-regions,dispatch-kernels,linalg-to-library-call,snax-copy-to-dma,snax-to-func,clear-memory-space
+SNAXOPTFLAGS = -p set-memory-space,realize-memref-casts,insert-sync-barrier,dispatch-regions,dispatch-kernels,linalg-to-library-call,snax-copy-to-dma,snax-to-func,clear-memory-space
 
 %.snax-opt.mlir: %.preprocfinal.mlir
 	$(SNAXOPT) $(SNAXOPTFLAGS) -o $@ $<

--- a/tests/dialects/test_snax.py
+++ b/tests/dialects/test_snax.py
@@ -1,0 +1,70 @@
+import pytest
+from xdsl.dialects import builtin
+from xdsl.dialects.builtin import StridedLayoutAttr, i32, i64
+from xdsl.dialects.memref import MemRefType
+from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.test_value import TestSSAValue
+
+from compiler.dialects.snax import ReShuffleOp
+
+
+def test_memref_memory_space_cast():
+    layout_1 = StridedLayoutAttr(strides=(2, 4, 6), offset=8)
+    layout_2 = StridedLayoutAttr(strides=(2, 8, 16), offset=4)
+
+    source_type = MemRefType(
+        i32, [10, 2], layout=layout_1, memory_space=builtin.IntegerAttr(1, i32)
+    )
+    source_ssa = TestSSAValue(source_type)
+
+    dest_type = MemRefType(i32, [10, 2], memory_space=builtin.IntegerAttr(1, i32))
+
+    reshuffle_op = ReShuffleOp(source_ssa, dest_type)
+
+    assert reshuffle_op.source is source_ssa
+    assert reshuffle_op.dest.type is dest_type
+
+    dest_type_other_element = MemRefType(
+        i64, [10, 2], layout=layout_2, memory_space=builtin.IntegerAttr(1, i32)
+    )
+
+    with pytest.raises(
+        VerifyException,
+        match="Expected source and destination to have the same element type.",
+    ):
+        ReShuffleOp(source_ssa, dest_type_other_element).verify()
+
+    dest_type_other_shape = MemRefType(
+        i32, [10, 4], layout=layout_2, memory_space=builtin.IntegerAttr(1, i32)
+    )
+
+    with pytest.raises(
+        VerifyException, match="Expected source and destination to have the same shape."
+    ):
+        ReShuffleOp(source_ssa, dest_type_other_shape).verify()
+
+    dest_type_other_space = MemRefType(
+        i32, [10, 2], layout=layout_2, memory_space=builtin.IntegerAttr(2, i32)
+    )
+
+    with pytest.raises(
+        VerifyException,
+        match="Expected source and destination to have the same memory space.",
+    ):
+        ReShuffleOp(source_ssa, dest_type_other_space).verify()
+
+    type_nolayout = MemRefType(i32, [10, 2], memory_space=builtin.IntegerAttr(1, i32))
+    ssa_nolayout = TestSSAValue(type_nolayout)
+
+    with pytest.raises(VerifyException, match="Expected source to have a layout."):
+        ReShuffleOp(ssa_nolayout, dest_type).verify()
+
+    with pytest.raises(VerifyException, match="Expected destination to have a layout."):
+        ReShuffleOp(source_ssa, type_nolayout).verify()
+
+    # Test helper function
+    reshuffle_op = ReShuffleOp.from_type_and_target_layout(source_ssa, layout_2)
+
+    assert reshuffle_op.source is source_ssa
+    assert isinstance(reshuffle_op.dest.type, MemRefType)
+    assert reshuffle_op.dest.type.layout is layout_2

--- a/tests/dialects/test_snax.py
+++ b/tests/dialects/test_snax.py
@@ -54,13 +54,7 @@ def test_memref_memory_space_cast():
         ReShuffleOp(source_ssa, dest_type_other_space).verify()
 
     type_nolayout = MemRefType(i32, [10, 2], memory_space=builtin.IntegerAttr(1, i32))
-    ssa_nolayout = TestSSAValue(type_nolayout)
-
-    with pytest.raises(VerifyException, match="Expected source to have a layout."):
-        ReShuffleOp(ssa_nolayout, dest_type).verify()
-
-    with pytest.raises(VerifyException, match="Expected destination to have a layout."):
-        ReShuffleOp(source_ssa, type_nolayout).verify()
+    TestSSAValue(type_nolayout)
 
     # Test helper function
     reshuffle_op = ReShuffleOp.from_type_and_target_layout(source_ssa, layout_2)

--- a/tests/filecheck/dialects/snax/snax_ops.mlir
+++ b/tests/filecheck/dialects/snax/snax_ops.mlir
@@ -1,0 +1,13 @@
+// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_SINGLETRIP
+
+"builtin.module"() ({
+  %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, 1 : i32>
+  %1 = "snax.reshuffle"(%0) : (memref<8x8xi32, strided<[1, 8]>, 1 : i32>) -> memref<8x8xi32, strided<[1, 16]>, 1 : i32>
+}) : () -> ()
+
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, 1 : i32>
+// CHECK-NEXT:   %1 = "snax.reshuffle"(%0) : (memref<8x8xi32, strided<[1, 8]>, 1 : i32>) -> memref<8x8xi32, strided<[1, 16]>, 1 : i32>
+// CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -9,6 +9,6 @@ config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {snax_src}"])
 config.suffixes = ['.test', '.mlir', '.py']
 
 config.substitutions.append(('XDSL_PARSING_DIAG', "./compiler/snax-opt %s --print-op-generic --parsing-diagnostics --split-input-file | filecheck %s"))
-config.substitutions.append(('XDSL_ROUNDTRIP', "./compiler/snax-opt %s --print-op-generic --split-input-file | ./compiler/snax-opt --split-input-file | filecheck %s"))
+config.substitutions.append(('XDSL_ROUNDTRIP', "./compiler/snax-opt %s --print-op-generic --split-input-file | ./compiler/snax-opt --print-op-generic --split-input-file | filecheck %s"))
 config.substitutions.append(('XDSL_SINGLETRIP', "./compiler/snax-opt %s --print-op-generic --split-input-file | filecheck %s"))
 config.substitutions.append(("XDSL_GENERIC_ROUNDTRIP", "./compiler/snax-opt %s --print-op-generic --split-input-file | filecheck %s --check-prefix=CHECK-GENERIC"))

--- a/tests/filecheck/transforms/realize-memory-space-casts.mlir
+++ b/tests/filecheck/transforms/realize-memory-space-casts.mlir
@@ -1,0 +1,130 @@
+// RUN: ./compiler/snax-opt --split-input-file %s -p realize-memory-space-casts --print-op-generic | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+  ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
+    %0 = "memref.memory_space_cast"(%arg0) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+    %1 = "memref.memory_space_cast"(%arg1) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+    %2 = "memref.memory_space_cast"(%arg2) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+    "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+    ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+      %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+      "linalg.yield"(%3) : (i32) -> ()
+    }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+// CHECK-NEXT:   ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
+// CHECK-NEXT:     %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %1 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %2 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "memref.copy"(%arg1, %1) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+// CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%3) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "memref.copy"(%2, %arg2) : (memref<64xi32, 1 : i32>, memref<64xi32, 0 : i32>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()
+
+// -----
+
+"builtin.module"() ({
+  "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+  ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
+    %0 = "memref.memory_space_cast"(%arg0) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+    %1 = "memref.memory_space_cast"(%arg1) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+    %2 = "memref.memory_space_cast"(%arg2) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+    "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+    ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+      %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+      "linalg.yield"(%3) : (i32) -> ()
+    }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+    "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+    ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
+      %4 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
+      "linalg.yield"(%4) : (i32) -> ()
+    }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+// CHECK-NEXT:   ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
+// CHECK-NEXT:     %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %1 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %2 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "memref.copy"(%arg1, %1) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+// CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%3) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
+// CHECK-NEXT:       %4 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%4) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "memref.copy"(%2, %arg2) : (memref<64xi32, 1 : i32>, memref<64xi32, 0 : i32>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()
+
+// -----
+
+"builtin.module"() ({
+  "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+  ^0(%arg0 : memref<?xi32, 0 : i32>, %arg1 : memref<?xi32, 0 : i32>, %arg2 : memref<?xi32, 0 : i32>):
+    %0 = "memref.memory_space_cast"(%arg0) : (memref<?xi32, 0 : i32>) -> memref<?xi32, 1 : i32>
+    %1 = "memref.memory_space_cast"(%arg1) : (memref<?xi32, 0 : i32>) -> memref<?xi32, 1 : i32>
+    %2 = "memref.memory_space_cast"(%arg2) : (memref<?xi32, 0 : i32>) -> memref<?xi32, 1 : i32>
+    "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+    ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+      %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+      "linalg.yield"(%3) : (i32) -> ()
+    }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
+    "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+    ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
+      %4 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
+      "linalg.yield"(%4) : (i32) -> ()
+    }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+// CHECK-NEXT:   ^0(%arg0 : memref<?xi32, 0 : i32>, %arg1 : memref<?xi32, 0 : i32>, %arg2 : memref<?xi32, 0 : i32>):
+// CHECK-NEXT:     %0 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+// CHECK-NEXT:     %1 = "memref.dim"(%arg0, %0) : (memref<?xi32, 0 : i32>, index) -> index
+// CHECK-NEXT:     %2 = "memref.alloc"(%1) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
+// CHECK-NEXT:     %3 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+// CHECK-NEXT:     %4 = "memref.dim"(%arg1, %3) : (memref<?xi32, 0 : i32>, index) -> index
+// CHECK-NEXT:     %5 = "memref.alloc"(%4) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
+// CHECK-NEXT:     %6 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+// CHECK-NEXT:     %7 = "memref.dim"(%arg2, %6) : (memref<?xi32, 0 : i32>, index) -> index
+// CHECK-NEXT:     %8 = "memref.alloc"(%7) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
+// CHECK-NEXT:     "memref.copy"(%arg0, %2) : (memref<?xi32, 0 : i32>, memref<?xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "memref.copy"(%arg1, %5) : (memref<?xi32, 0 : i32>, memref<?xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "linalg.generic"(%2, %5, %8) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+// CHECK-NEXT:       %9 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%9) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "linalg.generic"(%2, %5, %8) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
+// CHECK-NEXT:       %10 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%10) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "memref.copy"(%8, %arg2) : (memref<?xi32, 1 : i32>, memref<?xi32, 0 : i32>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/transforms/realize-memref-casts.mlir
+++ b/tests/filecheck/transforms/realize-memref-casts.mlir
@@ -1,4 +1,54 @@
-// RUN: ./compiler/snax-opt --split-input-file %s -p realize-memory-space-casts --print-op-generic | filecheck %s
+// RUN: ./compiler/snax-opt --split-input-file %s -p realize-memref-casts --print-op-generic | filecheck %s
+
+"builtin.module"() ({
+  %0 = "test.op"() : () -> (memref<64xi32, 0 : i32>)
+  %1 = "memref.memory_space_cast"(%0) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+  "test.op"(%1) : (memref<64xi32, 1 : i32>) -> ()
+}): () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   %0 = "test.op"() : () -> memref<64xi32, 0 : i32>
+// CHECK-NEXT:   %1 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:   "memref.copy"(%0, %1) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:   "test.op"(%1) : (memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:   "memref.copy"(%1, %0) : (memref<64xi32, 1 : i32>, memref<64xi32, 0 : i32>) -> ()
+// CHECK-NEXT: }) : () -> ()
+
+// -----
+
+"builtin.module"() ({
+  %0 = "test.op"() : () -> (memref<64xi32, 1 : i32>)
+  %1 = "snax.reshuffle"(%0) : (memref<64xi32, 1 : i32>) -> memref<64xi32, strided<[1, 8]>, 1 : i32>
+  "test.op"(%1) : (memref<64xi32, strided<[1, 8]>, 1 : i32>) -> ()
+}): () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   %0 = "test.op"() : () -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:   %1 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, strided<[1, 8]>, 1 : i32>
+// CHECK-NEXT:   "memref.copy"(%0, %1) : (memref<64xi32, 1 : i32>, memref<64xi32, strided<[1, 8]>, 1 : i32>) -> ()
+// CHECK-NEXT:   "test.op"(%1) : (memref<64xi32, strided<[1, 8]>, 1 : i32>) -> ()
+// CHECK-NEXT:   "memref.copy"(%1, %0) : (memref<64xi32, strided<[1, 8]>, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT: }) : () -> ()
+
+// -----
+
+"builtin.module"() ({
+  %0 = "test.op"() : () -> (memref<64xi32, 0 : i32>)
+  %1 = "memref.memory_space_cast"(%0) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+  %2 = "snax.reshuffle"(%1) : (memref<64xi32, 1 : i32>) -> memref<64xi32, strided<[1, 8]>, 1 : i32>
+  "test.op"(%2) : (memref<64xi32, strided<[1, 8]>, 1 : i32>) -> ()
+}): () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   %0 = "test.op"() : () -> memref<64xi32, 0 : i32>
+// CHECK-NEXT:   %1 = "memref.memory_space_cast"(%0) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:   %2 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, strided<[1, 8]>, 1 : i32>
+// CHECK-NEXT:   "memref.copy"(%0, %2) : (memref<64xi32, 0 : i32>, memref<64xi32, strided<[1, 8]>, 1 : i32>) -> ()
+// CHECK-NEXT:   "test.op"(%2) : (memref<64xi32, strided<[1, 8]>, 1 : i32>) -> ()
+// CHECK-NEXT:   "memref.copy"(%2, %0) : (memref<64xi32, strided<[1, 8]>, 1 : i32>, memref<64xi32, 0 : i32>) -> ()
+// CHECK-NEXT: }) : () -> ()
+
+// -----
 
 "builtin.module"() ({
   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
@@ -21,8 +71,8 @@
 // CHECK-NEXT:     %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
 // CHECK-NEXT:     %1 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
 // CHECK-NEXT:     %2 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
-// CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
 // CHECK-NEXT:     "memref.copy"(%arg1, %1) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
 // CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
 // CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
 // CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
@@ -61,8 +111,8 @@
 // CHECK-NEXT:     %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
 // CHECK-NEXT:     %1 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
 // CHECK-NEXT:     %2 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
-// CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
 // CHECK-NEXT:     "memref.copy"(%arg1, %1) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
 // CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
 // CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
 // CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
@@ -112,8 +162,8 @@
 // CHECK-NEXT:     %6 = "arith.constant"() <{"value" = 0 : index}> : () -> index
 // CHECK-NEXT:     %7 = "memref.dim"(%arg2, %6) : (memref<?xi32, 0 : i32>, index) -> index
 // CHECK-NEXT:     %8 = "memref.alloc"(%7) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
-// CHECK-NEXT:     "memref.copy"(%arg0, %2) : (memref<?xi32, 0 : i32>, memref<?xi32, 1 : i32>) -> ()
 // CHECK-NEXT:     "memref.copy"(%arg1, %5) : (memref<?xi32, 0 : i32>, memref<?xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "memref.copy"(%arg0, %2) : (memref<?xi32, 0 : i32>, memref<?xi32, 1 : i32>) -> ()
 // CHECK-NEXT:     "linalg.generic"(%2, %5, %8) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
 // CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
 // CHECK-NEXT:       %9 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
@@ -128,3 +178,64 @@
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }) : () -> ()
 // CHECK-NEXT: }) : () -> ()
+
+// -----
+
+"builtin.module"() ({
+  "func.func"() <{"sym_name" = "mnist", "function_type" = (memref<?x128xi8, 0 : i32>, memref<128x128xi8, 0 : i32>, memref<?x128xi32, 0 : i32>) -> memref<?x128xi32, 0 : i32>}> ({
+  ^0(%arg0 : memref<?x128xi8, 0 : i32>, %arg1 : memref<128x128xi8, 0 : i32>, %arg2 : memref<?x128xi32, 0 : i32>):
+    %0 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
+    %1 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
+    %2 = "memref.memory_space_cast"(%arg0) : (memref<?x128xi8, 0 : i32>) -> memref<?x128xi8, 1 : i32>
+    %3 = "memref.memory_space_cast"(%arg1) : (memref<128x128xi8, 0 : i32>) -> memref<128x128xi8, 1 : i32>
+    %4 = "memref.memory_space_cast"(%arg2) : (memref<?x128xi32, 0 : i32>) -> memref<?x128xi32, 1 : i32>
+    %5 = "snax.reshuffle"(%2) : (memref<?x128xi8, 1 : i32>) -> memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, 1 : i32>
+    %6 = "snax.reshuffle"(%3) : (memref<128x128xi8, 1 : i32>) -> memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8), offset: 64>, 1 : i32>
+    %7 = "snax.reshuffle"(%4) : (memref<?x128xi32, 1 : i32>) -> memref<?x128xi32, #tsl.tsl<[?, 8] -> (256, 4), [?, 8] -> (?, 32)>, 1 : i32>
+    "linalg.generic"(%5, %6, %0, %1, %7) <{"indexing_maps" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>], "iterator_types" = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>], "operandSegmentSizes" = array<i32: 4, 1>}> ({
+    ^1(%arg3 : i8, %arg4 : i8, %arg5 : i32, %arg6 : i32, %arg7 : i32):
+      %8 = "arith.extsi"(%arg3) : (i8) -> i32
+      %9 = "arith.subi"(%8, %arg5) : (i32, i32) -> i32
+      %10 = "arith.extsi"(%arg4) : (i8) -> i32
+      %11 = "arith.subi"(%10, %arg6) : (i32, i32) -> i32
+      %12 = "arith.muli"(%9, %11) : (i32, i32) -> i32
+      %13 = "arith.addi"(%arg7, %12) : (i32, i32) -> i32
+      "linalg.yield"(%13) : (i32) -> ()
+    }) {"library_call" = "snax_qgemm"} : (memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, 1 : i32>, memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8), offset: 64>, 1 : i32>, i32, i32, memref<?x128xi32, #tsl.tsl<[?, 8] -> (256, 4), [?, 8] -> (?, 32)>, 1 : i32>) -> ()
+    "func.return"(%arg2) : (memref<?x128xi32, 0 : i32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:  "func.func"() <{"sym_name" = "mnist", "function_type" = (memref<?x128xi8, 0 : i32>, memref<128x128xi8, 0 : i32>, memref<?x128xi32, 0 : i32>) -> memref<?x128xi32, 0 : i32>}> ({
+// CHECK-NEXT:  ^0(%arg0 : memref<?x128xi8, 0 : i32>, %arg1 : memref<128x128xi8, 0 : i32>, %arg2 : memref<?x128xi32, 0 : i32>):
+// CHECK-NEXT:    %0 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
+// CHECK-NEXT:    %1 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
+// CHECK-NEXT:    %2 = "memref.memory_space_cast"(%arg0) : (memref<?x128xi8, 0 : i32>) -> memref<?x128xi8, 1 : i32>
+// CHECK-NEXT:    %3 = "memref.memory_space_cast"(%arg1) : (memref<128x128xi8, 0 : i32>) -> memref<128x128xi8, 1 : i32>
+// CHECK-NEXT:    %4 = "memref.memory_space_cast"(%arg2) : (memref<?x128xi32, 0 : i32>) -> memref<?x128xi32, 1 : i32>
+// CHECK-NEXT:    %5 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+// CHECK-NEXT:    %6 = "memref.dim"(%arg0, %5) : (memref<?x128xi8, 0 : i32>, index) -> index
+// CHECK-NEXT:    %7 = "memref.alloc"(%6) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, 1 : i32>
+// CHECK-NEXT:    %8 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8), offset: 64>, 1 : i32>
+// CHECK-NEXT:    %9 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+// CHECK-NEXT:    %10 = "memref.dim"(%arg2, %9) : (memref<?x128xi32, 0 : i32>, index) -> index
+// CHECK-NEXT:    %11 = "memref.alloc"(%10) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?x128xi32, #tsl.tsl<[?, 8] -> (256, 4), [?, 8] -> (?, 32)>, 1 : i32>
+// CHECK-NEXT:    "memref.copy"(%arg1, %8) : (memref<128x128xi8, 0 : i32>, memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8), offset: 64>, 1 : i32>) -> ()
+// CHECK-NEXT:    "memref.copy"(%arg0, %7) : (memref<?x128xi8, 0 : i32>, memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, 1 : i32>) -> ()
+// CHECK-NEXT:    "linalg.generic"(%7, %8, %0, %1, %11) <{"indexing_maps" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>], "iterator_types" = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>], "operandSegmentSizes" = array<i32: 4, 1>}> ({
+// CHECK-NEXT:    ^1(%arg3 : i8, %arg4 : i8, %arg5 : i32, %arg6 : i32, %arg7 : i32):
+// CHECK-NEXT:      %12 = "arith.extsi"(%arg3) : (i8) -> i32
+// CHECK-NEXT:      %13 = "arith.subi"(%12, %arg5) : (i32, i32) -> i32
+// CHECK-NEXT:      %14 = "arith.extsi"(%arg4) : (i8) -> i32
+// CHECK-NEXT:      %15 = "arith.subi"(%14, %arg6) : (i32, i32) -> i32
+// CHECK-NEXT:      %16 = "arith.muli"(%13, %15) : (i32, i32) -> i32
+// CHECK-NEXT:      %17 = "arith.addi"(%arg7, %16) : (i32, i32) -> i32
+// CHECK-NEXT:      "linalg.yield"(%17) : (i32) -> ()
+// CHECK-NEXT:    }) {"library_call" = "snax_qgemm"} : (memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, 1 : i32>, memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8), offset: 64>, 1 : i32>, i32, i32, memref<?x128xi32, #tsl.tsl<[?, 8] -> (256, 4), [?, 8] -> (?, 32)>, 1 : i32>) -> ()
+// CHECK-NEXT:    "memref.copy"(%11, %arg2) : (memref<?x128xi32, #tsl.tsl<[?, 8] -> (256, 4), [?, 8] -> (?, 32)>, 1 : i32>, memref<?x128xi32, 0 : i32>) -> ()
+// CHECK-NEXT:    "func.return"(%arg2) : (memref<?x128xi32, 0 : i32>) -> ()
+// CHECK-NEXT:  }) : () -> ()
+// CHECK-NEXT:}) : () -> ()
+
+

--- a/tests/filecheck/transforms/set-memory-layout.mlir
+++ b/tests/filecheck/transforms/set-memory-layout.mlir
@@ -1,0 +1,43 @@
+// RUN: ./compiler/snax-opt --split-input-file %s -p set-memory-layout --print-op-generic | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{"sym_name" = "mnist", "function_type" = (memref<?x128xi8, 1 : i32>, memref<128x128xi8, 1 : i32>, memref<?x128xi32, 1 : i32>) -> memref<?x128xi32, 1 : i32>}> ({
+  ^0(%arg0 : memref<?x128xi8, 1 : i32>, %arg1 : memref<128x128xi8, 1 : i32>, %arg2 : memref<?x128xi32, 1 : i32>):
+    %0 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
+    %1 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
+    "linalg.generic"(%arg0, %arg1, %0, %1, %arg2) <{"indexing_maps" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>], "iterator_types" = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>], "operandSegmentSizes" = array<i32: 4, 1>}> ({
+    ^1(%arg3 : i8, %arg4 : i8, %arg5 : i32, %arg6 : i32, %arg7 : i32):
+      %2 = "arith.extsi"(%arg3) : (i8) -> i32
+      %3 = "arith.subi"(%2, %arg5) : (i32, i32) -> i32
+      %4 = "arith.extsi"(%arg4) : (i8) -> i32
+      %5 = "arith.subi"(%4, %arg6) : (i32, i32) -> i32
+      %6 = "arith.muli"(%3, %5) : (i32, i32) -> i32
+      %7 = "arith.addi"(%arg7, %6) : (i32, i32) -> i32
+      "linalg.yield"(%7) : (i32) -> ()
+    }) {"library_call" = "snax_qgemm"} : (memref<?x128xi8, 1 : i32>, memref<128x128xi8, 1 : i32>, i32, i32, memref<?x128xi32, 1 : i32>) -> ()
+    "func.return"(%arg2) : (memref<?x128xi32, 1 : i32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "mnist", "function_type" = (memref<?x128xi8, 1 : i32>, memref<128x128xi8, 1 : i32>, memref<?x128xi32, 1 : i32>) -> memref<?x128xi32, 1 : i32>}> ({
+// CHECK-NEXT:   ^0(%arg0 : memref<?x128xi8, 1 : i32>, %arg1 : memref<128x128xi8, 1 : i32>, %arg2 : memref<?x128xi32, 1 : i32>):
+// CHECK-NEXT:     %0 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
+// CHECK-NEXT:     %1 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
+// CHECK-NEXT:     %2 = "snax.reshuffle"(%arg0) : (memref<?x128xi8, 1 : i32>) -> memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, 1 : i32>
+// CHECK-NEXT:     %3 = "snax.reshuffle"(%arg1) : (memref<128x128xi8, 1 : i32>) -> memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8), offset: 64>, 1 : i32>
+// CHECK-NEXT:     %4 = "snax.reshuffle"(%arg2) : (memref<?x128xi32, 1 : i32>) -> memref<?x128xi32, #tsl.tsl<[?, 8] -> (256, 4), [?, 8] -> (?, 32)>, 1 : i32>
+// CHECK-NEXT:     "linalg.generic"(%2, %3, %0, %1, %4) <{"indexing_maps" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>], "iterator_types" = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>], "operandSegmentSizes" = array<i32: 4, 1>}> ({
+// CHECK-NEXT:     ^1(%arg3 : i8, %arg4 : i8, %arg5 : i32, %arg6 : i32, %arg7 : i32):
+// CHECK-NEXT:       %5 = "arith.extsi"(%arg3) : (i8) -> i32
+// CHECK-NEXT:       %6 = "arith.subi"(%5, %arg5) : (i32, i32) -> i32
+// CHECK-NEXT:       %7 = "arith.extsi"(%arg4) : (i8) -> i32
+// CHECK-NEXT:       %8 = "arith.subi"(%7, %arg6) : (i32, i32) -> i32
+// CHECK-NEXT:       %9 = "arith.muli"(%6, %8) : (i32, i32) -> i32
+// CHECK-NEXT:       %10 = "arith.addi"(%arg7, %9) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%10) : (i32) -> ()
+// CHECK-NEXT:     }) {"library_call" = "snax_qgemm"} : (memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, 1 : i32>, memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8), offset: 64>, 1 : i32>, i32, i32, memref<?x128xi32, #tsl.tsl<[?, 8] -> (256, 4), [?, 8] -> (?, 32)>, 1 : i32>) -> ()
+// CHECK-NEXT:     "func.return"(%arg2) : (memref<?x128xi32, 1 : i32>) -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()
+

--- a/tests/filecheck/transforms/set-memory-space.mlir
+++ b/tests/filecheck/transforms/set-memory-space.mlir
@@ -48,23 +48,20 @@
   }) : () -> ()
 }) : () -> ()
 
-//CHECK: "builtin.module"() ({
-//CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
-//CHECK-NEXT:   ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
-//CHECK-NEXT:     %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     %1 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     %2 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "memref.copy"(%arg1, %1) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
-//CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
-//CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
-//CHECK-NEXT:       "linalg.yield"(%3) : (i32) -> ()
-//CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "memref.copy"(%2, %arg2) : (memref<64xi32, 1 : i32>, memref<64xi32, 0 : i32>) -> ()
-//CHECK-NEXT:     "func.return"() : () -> ()
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT: }) : () -> ()
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+// CHECK-NEXT:   ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
+// CHECK-NEXT:     %0 = "memref.memory_space_cast"(%arg0) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %1 = "memref.memory_space_cast"(%arg1) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %2 = "memref.memory_space_cast"(%arg2) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+// CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%3) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()
 
 // -----
 
@@ -86,28 +83,25 @@
 }) : () -> ()
 
 
-//CHECK: "builtin.module"() ({
-//CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
-//CHECK-NEXT:   ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
-//CHECK-NEXT:     %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     %1 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     %2 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64xi32, 1 : i32>
-//CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "memref.copy"(%arg1, %1) : (memref<64xi32, 0 : i32>, memref<64xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
-//CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
-//CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
-//CHECK-NEXT:       "linalg.yield"(%3) : (i32) -> ()
-//CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
-//CHECK-NEXT:     ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
-//CHECK-NEXT:       %4 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
-//CHECK-NEXT:       "linalg.yield"(%4) : (i32) -> ()
-//CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "memref.copy"(%2, %arg2) : (memref<64xi32, 1 : i32>, memref<64xi32, 0 : i32>) -> ()
-//CHECK-NEXT:     "func.return"() : () -> ()
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT: }) : () -> ()
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>, memref<64xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+// CHECK-NEXT:   ^0(%arg0 : memref<64xi32, 0 : i32>, %arg1 : memref<64xi32, 0 : i32>, %arg2 : memref<64xi32, 0 : i32>):
+// CHECK-NEXT:     %0 = "memref.memory_space_cast"(%arg0) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %1 = "memref.memory_space_cast"(%arg1) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     %2 = "memref.memory_space_cast"(%arg2) : (memref<64xi32, 0 : i32>) -> memref<64xi32, 1 : i32>
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+// CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%3) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
+// CHECK-NEXT:       %4 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%4) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>, memref<64xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()
 
 // -----
 
@@ -128,31 +122,22 @@
   }) : () -> ()
 }) : () -> ()
 
-//CHECK: "builtin.module"() ({
-//CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
-//CHECK-NEXT:   ^0(%arg0 : memref<?xi32, 0 : i32>, %arg1 : memref<?xi32, 0 : i32>, %arg2 : memref<?xi32, 0 : i32>):
-//CHECK-NEXT:     %0 = "arith.constant"() <{"value" = 0 : index}> : () -> index
-//CHECK-NEXT:     %1 = "memref.dim"(%arg0, %0) : (memref<?xi32, 0 : i32>, index) -> index
-//CHECK-NEXT:     %2 = "memref.alloc"(%1) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
-//CHECK-NEXT:     %3 = "arith.constant"() <{"value" = 0 : index}> : () -> index
-//CHECK-NEXT:     %4 = "memref.dim"(%arg1, %3) : (memref<?xi32, 0 : i32>, index) -> index
-//CHECK-NEXT:     %5 = "memref.alloc"(%4) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
-//CHECK-NEXT:     %6 = "arith.constant"() <{"value" = 0 : index}> : () -> index
-//CHECK-NEXT:     %7 = "memref.dim"(%arg2, %6) : (memref<?xi32, 0 : i32>, index) -> index
-//CHECK-NEXT:     %8 = "memref.alloc"(%7) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xi32, 1 : i32>
-//CHECK-NEXT:     "memref.copy"(%arg0, %2) : (memref<?xi32, 0 : i32>, memref<?xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "memref.copy"(%arg1, %5) : (memref<?xi32, 0 : i32>, memref<?xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "linalg.generic"(%2, %5, %8) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
-//CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
-//CHECK-NEXT:       %9 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
-//CHECK-NEXT:       "linalg.yield"(%9) : (i32) -> ()
-//CHECK-NEXT:     }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "linalg.generic"(%2, %5, %8) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
-//CHECK-NEXT:     ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
-//CHECK-NEXT:       %10 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
-//CHECK-NEXT:       "linalg.yield"(%10) : (i32) -> ()
-//CHECK-NEXT:     }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
-//CHECK-NEXT:     "memref.copy"(%8, %arg2) : (memref<?xi32, 1 : i32>, memref<?xi32, 0 : i32>) -> ()
-//CHECK-NEXT:     "func.return"() : () -> ()
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT: }) : () -> ()
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>, memref<?xi32, 0 : i32>) -> (), "sym_visibility" = "public"}> ({
+// CHECK-NEXT:   ^0(%arg0 : memref<?xi32, 0 : i32>, %arg1 : memref<?xi32, 0 : i32>, %arg2 : memref<?xi32, 0 : i32>):
+// CHECK-NEXT:     %0 = "memref.memory_space_cast"(%arg0) : (memref<?xi32, 0 : i32>) -> memref<?xi32, 1 : i32>
+// CHECK-NEXT:     %1 = "memref.memory_space_cast"(%arg1) : (memref<?xi32, 0 : i32>) -> memref<?xi32, 1 : i32>
+// CHECK-NEXT:     %2 = "memref.memory_space_cast"(%arg2) : (memref<?xi32, 0 : i32>) -> memref<?xi32, 1 : i32>
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^1(%arg3 : i32, %arg4 : i32, %arg5 : i32):
+// CHECK-NEXT:       %3 = "arith.muli"(%arg3, %arg4) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%3) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "linalg.generic"(%0, %1, %2) <{"indexing_maps" = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], "iterator_types" = [#linalg.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:     ^2(%arg3_1 : i32, %arg4_1 : i32, %arg5_1 : i32):
+// CHECK-NEXT:       %4 = "arith.muli"(%arg3_1, %arg4_1) : (i32, i32) -> i32
+// CHECK-NEXT:       "linalg.yield"(%4) : (i32) -> ()
+// CHECK-NEXT:     }) : (memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>, memref<?xi32, 1 : i32>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()


### PR DESCRIPTION
This PR implements the `realize-memref-casts` pass.
This pass replaces the previous `realize-memory-space-casts` pass, and now includes both `memory_space_cast` and `snax_reshuffle` operations.
The cast transformations are handled by allocating new memrefs in the target layout space and inserting `memref.copy`s, assuming the transformation is handled by further lowering passes.