### PR TITLE
Extend TSL classes

### DIFF
--- a/compiler/ir/tsl/tiled_stride.py
+++ b/compiler/ir/tsl/tiled_stride.py
@@ -28,6 +28,32 @@ class TiledStride:
     def __init__(self, strides: list[Stride]):
         self.strides = list(strides)
 
+    @staticmethod
+    def from_stride(
+        simple_stride: int | None, tile_bounds: list[int | None]
+    ) -> TiledStride:
+        """Create a TiledStride representation from a simple stride
+        (not tiled), and a given set of tile bounds
+
+        Args:
+            simple_stride (int | None): The stride for the innermost tile
+            tile_bounds (List[int | None]): A list of tile bounds
+
+        Returns:
+            TiledStride: A TiledStride object
+        """
+
+        # the step for the innermost stride is the simple stride
+        # the step for the other strides can be calculated using
+        # the previous step and the current bound
+        steps = [simple_stride]
+        for bound in reversed(tile_bounds[1:]):
+            steps = [bound * steps[0] if bound and steps[0] else None, *steps]
+
+        return TiledStride(
+            [Stride(step, bound) for step, bound in zip(steps, tile_bounds)]
+        )
+
     def __str__(self) -> str:
         strides = ", ".join(
             str(stride.step) if stride.step else "?" for stride in self.strides
@@ -77,3 +103,7 @@ class TiledStride:
             return self.strides[depth]
         except IndexError:
             return None
+
+    def tile_bounds(self) -> list[int]:
+        """Get the bounds of the tiles of the Tiled Stride"""
+        return [stride.bound for stride in self.strides]

--- a/compiler/ir/tsl/tiled_strided_layout.py
+++ b/compiler/ir/tsl/tiled_strided_layout.py
@@ -25,6 +25,25 @@ class TiledStridedLayout:
         self.tstrides = tstrides
         self.offset = offset
 
+    @staticmethod
+    def from_strides(
+        strides: list[int], tile_bounds: list[int], offset: int = 0
+    ) -> TiledStridedLayout:
+        """Create a TiledStridedLayout from a list of strides and tile bounds
+
+        Args:
+            strides (List[int]): A list of strides
+            tile_bounds (List[int]): A list of tile bounds
+
+        Returns:
+            TiledStridedLayout: A TiledStridedLayout object
+        """
+        tstrides = [
+            TiledStride.from_stride(stride, bounds)
+            for stride, bounds in zip(strides, tile_bounds)
+        ]
+        return TiledStridedLayout(tstrides, offset=offset)
+
     def __str__(self) -> str:
         result = ", ".join(map(str, self.tstrides))
         if self.offset != 0:
@@ -79,6 +98,12 @@ class TiledStridedLayout:
         result = result.flatten()
         return result
 
+    def tile_bounds(self) -> list[list[int]]:
+        """
+        Returns a list of tile bounds for each dimension.
+        """
+        return [stride.tile_bounds() for stride in self.tstrides]
+
     def self_overlaps(self) -> bool:
         """Check if the Tiled Strided Layout contains overlapping elements"""
         (
@@ -95,6 +120,10 @@ class TiledStridedLayout:
 
         all_values = self.all_values()
         return np.max(all_values) == len(all_values) - 1
+
+    def equal_tile_bounds(self, other: TiledStridedLayout) -> bool:
+        """Check if the Tiled Strided Layout has the same tile bounds as another"""
+        return self.tile_bounds() == other.tile_bounds()
 
     def largest_common_contiguous_block(
         self, other: TiledStridedLayout, starting_stride: int = 1

--- a/tests/ir/tsl/test_tiled_stride.py
+++ b/tests/ir/tsl/test_tiled_stride.py
@@ -28,6 +28,16 @@ def test_tiled_stride_constructor(example_strides, example_tiled_strides):
     assert tiledStride2.strides[2] == stride1
 
 
+def test_tiled_stride_from_stride():
+    tiledStride1 = TiledStride.from_stride(1, [4, 6])
+    tiledStride2 = TiledStride.from_stride(24, [2, 6, 4])
+    assert tiledStride1.strides[0] == Stride(6, 4)
+    assert tiledStride1.strides[1] == Stride(1, 6)
+    assert tiledStride2.strides[0] == Stride(24 * 4 * 6, 2)
+    assert tiledStride2.strides[1] == Stride(24 * 4, 6)
+    assert tiledStride2.strides[2] == Stride(24, 4)
+
+
 def test_tiled_stride_depth(example_tiled_strides):
     tiledStride1, tiledStride2, tiledStride3 = example_tiled_strides
     assert tiledStride1.depth() == 2
@@ -52,3 +62,10 @@ def test_tiled_stride_iter(example_strides, example_tiled_strides):
         assert isinstance(depth, int)
         assert isinstance(stride, Stride)
         assert stride == strides[depth]
+
+
+def test_tiled_stride_tile_bounds(example_tiled_strides):
+    tiledStride1, tiledStride2, tiledStride3 = example_tiled_strides
+    assert tiledStride1.tile_bounds() == [6, 4]
+    assert tiledStride2.tile_bounds() == [2, 6, 4]
+    assert tiledStride3.tile_bounds() == [None, 4]

--- a/tests/ir/tsl/test_tiled_strided_layout.py
+++ b/tests/ir/tsl/test_tiled_strided_layout.py
@@ -36,6 +36,19 @@ def test_tsl_constructor(example_tsl):
     assert isinstance(tsl.tstrides[1], TiledStride)
 
 
+def test_tsl_from_strides():
+    strides = [None, 1]
+    tile_bounds = [[16, 4], [16, 4]]
+    tsl_constructor = TiledStridedLayout(
+        [
+            TiledStride([Stride(None, 16), Stride(None, 4)]),
+            TiledStride([Stride(4, 16), Stride(1, 4)]),
+        ]
+    )
+    tsl_from_strides = TiledStridedLayout.from_strides(strides, tile_bounds)
+    assert tsl_constructor == tsl_from_strides
+
+
 def test_tsl_str(example_tsl):
     tsl, tsl2 = example_tsl
     assert str(tsl) == "[2, 4] -> (32, 4), [2, 4] -> (16, 1), offset: 5"
@@ -59,6 +72,11 @@ def test_tsl_all_values(example_tsl):
     assert set(tsl.all_values()) == set(range(64))
     with pytest.raises(ValueError):
         tsl2.all_values()
+
+
+def test_tsl_tile_bounds(example_tsl):
+    tsl, _ = example_tsl
+    assert tsl.tile_bounds() == [[2, 4], [2, 4]]
 
 
 def test_tsl_self_overlaps(example_tsl):
@@ -101,6 +119,12 @@ def test_tsl_is_dense(example_tsl):
     tsl2 = TiledStridedLayout([tiledStride1, tiledStride2])
 
     assert not tsl2.is_dense()
+
+
+def test_tsl_equal_tile_bounds(example_tsl):
+    tsl, tsl2 = example_tsl
+    assert tsl.equal_tile_bounds(tsl)
+    assert not tsl.equal_tile_bounds(tsl2)
 
 
 def test_tsl_largest_common_contiguous_block():


### PR DESCRIPTION
This PR extends the tsl with some useful functions necessary for better transformation support.
The algorithm to transform layouts only works from tsl -> tsl.
For memrefs with no layout or a simple stridedlayoutattr, it would therefore be useful to create tsl representations
of these layouts to still be able to use the current transformation algorithm

