### PR TITLE
Enable transformations from other layouts

### DIFF
--- a/compiler/dialects/tsl.py
+++ b/compiler/dialects/tsl.py
@@ -141,8 +141,8 @@ class TiledStridedLayoutAttr(Data[TiledStridedLayout]):
         )
         result.append(max_stride_op)
 
-        # assign strides left to right
-        for dim in range(tsl.dimension()):
+        # assign strides right to left
+        for dim in reversed(range(tsl.dimension())):
             # assign strides from innermost to outermost
             for depth in reversed(range(tsl.tstrides[dim].depth())):
                 stride = tsl.get_stride(dim, depth)

--- a/kernels/transform_copy/Makefile
+++ b/kernels/transform_copy/Makefile
@@ -7,6 +7,8 @@ include ../../runtime/Makefile.rules
 
 TESTS =
 TESTS += transform_copy.x
+TESTS += transform_from_none.x
+TESTS += transform_from_strided.x
 TESTS += $(patsubst %_gen.preprocfinal.mlir,%_gen.x,$(wildcard *_gen.preprocfinal.mlir))
 
 CFLAGS += -std=gnu11

--- a/kernels/transform_copy/gendata.py
+++ b/kernels/transform_copy/gendata.py
@@ -50,3 +50,7 @@ if __name__ == "__main__":
     variables = {"A": A, "B": B}
     create_header("transform_copy/data.h", array_size, variables)
     create_data("transform_copy/data.c", array_size, variables)
+    create_header("transform_from_none/data.h", array_size, variables)
+    create_data("transform_from_none/data.c", array_size, variables)
+    create_header("transform_from_strided/data.h", array_size, variables)
+    create_data("transform_from_strided/data.c", array_size, variables)

--- a/kernels/transform_copy/main.c
+++ b/kernels/transform_copy/main.c
@@ -52,8 +52,8 @@ int main() {
   for (int i = 0; i < N; i++) {
     int32_t error = memrefB.aligned_data[i] - B[i];
     if (error != 0) {
-      printf("Error at %d: expected %d, got %d\n", i, B[i],
-             memrefB.aligned_data[i]);
+      printf("Error at %d (%p): expected %d, got %d\n", i,
+             &memrefB.aligned_data[i], B[i], memrefB.aligned_data[i]);
       nerr += 1;
     }
   }

--- a/kernels/transform_copy/transform_copy.preprocfinal.mlir
+++ b/kernels/transform_copy/transform_copy.preprocfinal.mlir
@@ -1,6 +1,6 @@
 builtin.module {
-  func.func public @transform_copy(%arg0 : memref<?x?xi32, #tsl.tsl<[?, 4] -> (16, 4), [?, 4] -> (?, ?)>, 0 : i32>, %arg1 : memref<?x?xi32, #tsl.tsl<[?, 4] -> (?, 4), [?, 4] -> (?, 16)>, 1 : i32>) {
-    "memref.copy"(%arg0, %arg1) : (memref<?x?xi32, #tsl.tsl<[?, 4] -> (16, 4), [?, 4] -> (?, ?)>, 0 : i32>, memref<?x?xi32, #tsl.tsl<[?, 4] -> (?, 4), [?, 4] -> (?, 16)>, 1 : i32>) -> ()
+  func.func public @transform_copy(%arg0 : memref<?x?xi32, #tsl.tsl<[?, 4] -> (?, ?), [?, 4] -> (16, 4)>, 0 : i32>, %arg1 : memref<?x?xi32, #tsl.tsl<[?, 4] -> (?, 16), [?, 4] -> (?, 4)>, 1 : i32>) {
+    "memref.copy"(%arg0, %arg1) : (memref<?x?xi32, #tsl.tsl<[?, 4] -> (?, ?), [?, 4] -> (16, 4)>, 0 : i32>, memref<?x?xi32, #tsl.tsl<[?, 4] -> (?, 16), [?, 4] -> (?, 4)>, 1 : i32>) -> ()
     func.return
   }
 }

--- a/kernels/transform_copy/transform_from_none.preprocfinal.mlir
+++ b/kernels/transform_copy/transform_from_none.preprocfinal.mlir
@@ -1,0 +1,6 @@
+builtin.module {
+  func.func public @transform_copy(%arg0 : memref<?x?xi32, 0 : i32>, %arg1 : memref<?x?xi32, #tsl.tsl<[?, 4] -> (?, 16), [?, 4] -> (?, 4)>, 1 : i32>) {
+    "memref.copy"(%arg0, %arg1) : (memref<?x?xi32, 0 : i32>, memref<?x?xi32, #tsl.tsl<[?, 4] -> (?, 16), [?, 4] -> (?, 4)>, 1 : i32>) -> ()
+    func.return
+  }
+}

--- a/kernels/transform_copy/transform_from_strided.preprocfinal.mlir
+++ b/kernels/transform_copy/transform_from_strided.preprocfinal.mlir
@@ -1,0 +1,7 @@
+builtin.module {
+  func.func public @transform_copy(%arg0 : memref<?x?xi32, strided<[?, 4], offset: 0>, 0 : i32>, %arg1 : memref<?x?xi32, #tsl.tsl<[?, 4] -> (?, 16), [?, 4] -> (?, 4)>, 1 : i32>) {
+    "memref.copy"(%arg0, %arg1) : (memref<?x?xi32, strided<[?, 4], offset: 0>, 0 : i32>, memref<?x?xi32, #tsl.tsl<[?, 4] -> (?, 16), [?, 4] -> (?, 4)>, 1 : i32>) -> ()
+    func.return
+  }
+}
+

--- a/tests/filecheck/transforms/copy_to_dma.mlir
+++ b/tests/filecheck/transforms/copy_to_dma.mlir
@@ -74,31 +74,31 @@
 //CHECK-NEXT:     %4 = "arith.constant"() <{"value" = 2 : index}> : () -> index
 //CHECK-NEXT:     %5 = "arith.constant"() <{"value" = 4 : index}> : () -> index
 //CHECK-NEXT:     %6 = "arith.constant"() <{"value" = 128 : index}> : () -> index
-//CHECK-NEXT:     %7 = "arith.constant"() <{"value" = 4 : index}> : () -> index
-//CHECK-NEXT:     %8 = "arith.constant"() <{"value" = 16 : index}> : () -> index
-//CHECK-NEXT:     %9 = "arith.constant"() <{"value" = 32 : index}> : () -> index
-//CHECK-NEXT:     %10 = "arith.constant"() <{"value" = 128 : index}> : () -> index
+//CHECK-NEXT:     %7 = "arith.constant"() <{"value" = 32 : index}> : () -> index
+//CHECK-NEXT:     %8 = "arith.constant"() <{"value" = 128 : index}> : () -> index
+//CHECK-NEXT:     %9 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+//CHECK-NEXT:     %10 = "arith.constant"() <{"value" = 16 : index}> : () -> index
 //CHECK-NEXT:     %11 = "arith.constant"() <{"value" = 128 : index}> : () -> index
-//CHECK-NEXT:     %12 = "arith.constant"() <{"value" = 4 : index}> : () -> index
-//CHECK-NEXT:     %13 = "arith.constant"() <{"value" = 64 : index}> : () -> index
-//CHECK-NEXT:     %14 = "arith.constant"() <{"value" = 16 : index}> : () -> index
-//CHECK-NEXT:     %15 = "arith.constant"() <{"value" = 128 : index}> : () -> index
+//CHECK-NEXT:     %12 = "arith.constant"() <{"value" = 16 : index}> : () -> index
+//CHECK-NEXT:     %13 = "arith.constant"() <{"value" = 128 : index}> : () -> index
+//CHECK-NEXT:     %14 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+//CHECK-NEXT:     %15 = "arith.constant"() <{"value" = 64 : index}> : () -> index
 //CHECK-NEXT:     %16 = "arith.constant"() <{"value" = 16 : index}> : () -> index
 //CHECK-NEXT:     %17 = "arith.constant"() <{"value" = 0 : index}> : () -> index
 //CHECK-NEXT:     %18 = "arith.constant"() <{"value" = 1 : index}> : () -> index
 //CHECK-NEXT:     "scf.for"(%17, %2, %18) ({
 //CHECK-NEXT:     ^1(%19 : index):
-//CHECK-NEXT:       %20 = "arith.muli"(%19, %8) : (index, index) -> index
+//CHECK-NEXT:       %20 = "arith.muli"(%19, %10) : (index, index) -> index
 //CHECK-NEXT:       %21 = "arith.addi"(%0, %20) : (index, index) -> index
-//CHECK-NEXT:       %22 = "arith.muli"(%19, %13) : (index, index) -> index
+//CHECK-NEXT:       %22 = "arith.muli"(%19, %15) : (index, index) -> index
 //CHECK-NEXT:       %23 = "arith.addi"(%1, %22) : (index, index) -> index
 //CHECK-NEXT:       "scf.for"(%17, %4, %18) ({
 //CHECK-NEXT:       ^2(%24 : index):
-//CHECK-NEXT:         %25 = "arith.muli"(%24, %10) : (index, index) -> index
+//CHECK-NEXT:         %25 = "arith.muli"(%24, %8) : (index, index) -> index
 //CHECK-NEXT:         %26 = "arith.addi"(%21, %25) : (index, index) -> index
-//CHECK-NEXT:         %27 = "arith.muli"(%24, %15) : (index, index) -> index
+//CHECK-NEXT:         %27 = "arith.muli"(%24, %13) : (index, index) -> index
 //CHECK-NEXT:         %28 = "arith.addi"(%23, %27) : (index, index) -> index
-//CHECK-NEXT:         "func.call"(%26, %28, %16, %9, %14, %5) <{"callee" = @snax_dma_2d_transfer}> : (index, index, index, index, index, index) -> ()
+//CHECK-NEXT:         "func.call"(%26, %28, %16, %7, %12, %5) <{"callee" = @snax_dma_2d_transfer}> : (index, index, index, index, index, index) -> ()
 //CHECK-NEXT:         "scf.yield"() : () -> ()
 //CHECK-NEXT:       }) : (index, index, index) -> ()
 //CHECK-NEXT:       "scf.yield"() : () -> ()


### PR DESCRIPTION
building on top of #79, this extends the snax-copy-to-dma pass to apply transformations from `tsl->tsl` to `nonetype->tsl`, `strided->tsl` and the other way around