### PR TITLE
add dynamic support to memref-to-snax pass

### DIFF
--- a/compiler/dialects/tsl.py
+++ b/compiler/dialects/tsl.py
@@ -59,9 +59,9 @@ class TiledStridedLayoutAttr(Data[TiledStridedLayout]):
 
         tsl = self.data
 
-        # if the argument passed is a memref, generate shape operation
-        # list by using the dim operation
         if isinstance(memref_op_or_shapes, SSAValue | Operation):
+            # if the argument passed is a memref, generate shape operation
+            # list by using the dim operation
             memref = memref_op_or_shapes
             shapes = []
             for dim in range(tsl.dimension()):
@@ -70,6 +70,7 @@ class TiledStridedLayoutAttr(Data[TiledStridedLayout]):
                 result.extend([dim_index_op, dim_op])
                 shapes.append(dim_op)
         else:
+            # shape ops are already supplied, use them directly
             shapes = memref_op_or_shapes
 
         for dim in range(tsl.dimension()):

--- a/compiler/dialects/tsl.py
+++ b/compiler/dialects/tsl.py
@@ -53,59 +53,58 @@ class TiledStridedLayoutAttr(Data[TiledStridedLayout]):
             and depth. This is used to keep track of which sequence of operations
             was made for which TSL Stride.
         """
-        if isinstance(memref_op_or_shapes, SSAValue | Operation):
-            memref = memref_op_or_shapes
-            shapes = None
-        else:
-            shapes = memref_op_or_shapes
-            memref = None
 
         result: list[Operation] = []
         result_mapping: dict[(int, int), Operation] = {}
 
         tsl = self.data
 
+        # if the argument passed is a memref, generate shape operation
+        # list by using the dim operation
+        if isinstance(memref_op_or_shapes, SSAValue | Operation):
+            memref = memref_op_or_shapes
+            shapes = []
+            for dim in range(tsl.dimension()):
+                dim_index_op = Constant.from_int_and_width(dim, IndexType())
+                dim_op = Dim.from_source_and_index(memref, dim_index_op)
+                result.extend([dim_index_op, dim_op])
+                shapes.append(dim_op)
+        else:
+            shapes = memref_op_or_shapes
+
         for dim in range(tsl.dimension()):
-            for depth in range(tsl.tstrides[dim].depth()):
+            depth = 0  # outermost tile
+            dim_op = shapes.pop(0)
+
+            # static case
+            stride = tsl.get_stride(dim, depth)
+            if stride.bound is not None:
+                bound_op = Constant.from_int_and_width(stride.bound, IndexType())
+                result.append(bound_op)
+                result_mapping[(dim, depth)] = bound_op
+
+            # dynamic case: use the dim_op and divide by product of
+            # all lower tile sizes
+            else:
+                # get the product of all lower tile sizes
+                product_tilebounds = prod(
+                    [stride.bound for _, stride in tsl.tstrides[dim] if stride.bound]
+                )
+                div_op = Constant.from_int_and_width(product_tilebounds, IndexType())
+
+                # divide the size of the memref by the product of all lower tiles
+                bound_op = DivUI(dim_op, div_op, IndexType())
+
+                # add the ops to result
+                result.extend([div_op, bound_op])
+                result_mapping[(dim, depth)] = bound_op
+
+            # inner tile depths are all static by definition of TSL
+            for depth in range(1, tsl.tstrides[dim].depth()):
                 stride = tsl.get_stride(dim, depth)
-
-                # static case
-                if stride.bound is not None:
-                    bound_op = Constant.from_int_and_width(stride.bound, IndexType())
-                    result.append(bound_op)
-                    result_mapping[(dim, depth)] = bound_op
-
-                # dynamic case
-                # to calculate the bound of a dynamic stride,
-                # we must divide the size of the memref by the product
-                # of all lower tile sizes
-                else:
-                    # get the size of the memref
-                    if shapes:  # use shapes if supplied
-                        dim_op = shapes.pop(0)
-                    else:  # else, create own dim op to calculate shape
-                        dim_index_op = Constant.from_int_and_width(dim, IndexType())
-                        dim_op = Dim.from_source_and_index(memref, dim_index_op)
-                        result.extend([dim_index_op, dim_op])
-
-                    # get the product of all lower tile sizes
-                    product_tilebounds = prod(
-                        [
-                            stride.bound
-                            for _, stride in tsl.tstrides[dim]
-                            if stride.bound
-                        ]
-                    )
-                    div_op = Constant.from_int_and_width(
-                        product_tilebounds, IndexType()
-                    )
-
-                    # divide the size of the memref by the product of all lower tiles
-                    bound_op = DivUI(dim_op.result, div_op.result, IndexType())
-
-                    # add the ops to result
-                    result.extend([div_op, bound_op])
-                    result_mapping[(dim, depth)] = bound_op
+                bound_op = Constant.from_int_and_width(stride.bound, IndexType())
+                result.append(bound_op)
+                result_mapping[(dim, depth)] = bound_op
 
         return result, result_mapping
 

--- a/tests/filecheck/transforms/copy_to_dma.mlir
+++ b/tests/filecheck/transforms/copy_to_dma.mlir
@@ -64,47 +64,51 @@
   }) : () -> ()
 }) : () -> ()
 
-//CHECK: "builtin.module"() ({
-//CHECK-NEXT:   "func.func"() <{"sym_name" = "transform_copy", "function_type" = (memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 0 : i32>, memref<8x8xi32, #tsl.tsl<[2, 4] -> (64, 4), [2, 4] -> (128, 16)>, 1 : i32>) -> (), "sym_visibility" = "public"}> ({
-//CHECK-NEXT:   ^0(%arg0 : memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 0 : i32>, %arg1 : memref<8x8xi32, #tsl.tsl<[2, 4] -> (64, 4), [2, 4] -> (128, 16)>, 1 : i32>):
-//CHECK-NEXT:     %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 0 : i32>) -> index
-//CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<8x8xi32, #tsl.tsl<[2, 4] -> (64, 4), [2, 4] -> (128, 16)>, 1 : i32>) -> index
-//CHECK-NEXT:     %2 = "arith.constant"() <{"value" = 2 : index}> : () -> index
-//CHECK-NEXT:     %3 = "arith.constant"() <{"value" = 4 : index}> : () -> index
-//CHECK-NEXT:     %4 = "arith.constant"() <{"value" = 2 : index}> : () -> index
-//CHECK-NEXT:     %5 = "arith.constant"() <{"value" = 4 : index}> : () -> index
-//CHECK-NEXT:     %6 = "arith.constant"() <{"value" = 128 : index}> : () -> index
-//CHECK-NEXT:     %7 = "arith.constant"() <{"value" = 32 : index}> : () -> index
-//CHECK-NEXT:     %8 = "arith.constant"() <{"value" = 128 : index}> : () -> index
-//CHECK-NEXT:     %9 = "arith.constant"() <{"value" = 4 : index}> : () -> index
-//CHECK-NEXT:     %10 = "arith.constant"() <{"value" = 16 : index}> : () -> index
-//CHECK-NEXT:     %11 = "arith.constant"() <{"value" = 128 : index}> : () -> index
-//CHECK-NEXT:     %12 = "arith.constant"() <{"value" = 16 : index}> : () -> index
-//CHECK-NEXT:     %13 = "arith.constant"() <{"value" = 128 : index}> : () -> index
-//CHECK-NEXT:     %14 = "arith.constant"() <{"value" = 4 : index}> : () -> index
-//CHECK-NEXT:     %15 = "arith.constant"() <{"value" = 64 : index}> : () -> index
-//CHECK-NEXT:     %16 = "arith.constant"() <{"value" = 16 : index}> : () -> index
-//CHECK-NEXT:     %17 = "arith.constant"() <{"value" = 0 : index}> : () -> index
-//CHECK-NEXT:     %18 = "arith.constant"() <{"value" = 1 : index}> : () -> index
-//CHECK-NEXT:     "scf.for"(%17, %2, %18) ({
-//CHECK-NEXT:     ^1(%19 : index):
-//CHECK-NEXT:       %20 = "arith.muli"(%19, %10) : (index, index) -> index
-//CHECK-NEXT:       %21 = "arith.addi"(%0, %20) : (index, index) -> index
-//CHECK-NEXT:       %22 = "arith.muli"(%19, %15) : (index, index) -> index
-//CHECK-NEXT:       %23 = "arith.addi"(%1, %22) : (index, index) -> index
-//CHECK-NEXT:       "scf.for"(%17, %4, %18) ({
-//CHECK-NEXT:       ^2(%24 : index):
-//CHECK-NEXT:         %25 = "arith.muli"(%24, %8) : (index, index) -> index
-//CHECK-NEXT:         %26 = "arith.addi"(%21, %25) : (index, index) -> index
-//CHECK-NEXT:         %27 = "arith.muli"(%24, %13) : (index, index) -> index
-//CHECK-NEXT:         %28 = "arith.addi"(%23, %27) : (index, index) -> index
-//CHECK-NEXT:         "func.call"(%26, %28, %16, %7, %12, %5) <{"callee" = @snax_dma_2d_transfer}> : (index, index, index, index, index, index) -> ()
-//CHECK-NEXT:         "scf.yield"() : () -> ()
-//CHECK-NEXT:       }) : (index, index, index) -> ()
-//CHECK-NEXT:       "scf.yield"() : () -> ()
-//CHECK-NEXT:     }) : (index, index, index) -> ()
-//CHECK-NEXT:     "func.return"() : () -> ()
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT:   "func.func"() <{"sym_name" = "snax_dma_2d_transfer", "function_type" = (index, index, index, index, index, index) -> (), "sym_visibility" = "private"}> ({
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT: }) : () -> ()
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "transform_copy", "function_type" = (memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 0 : i32>, memref<8x8xi32, #tsl.tsl<[2, 4] -> (64, 4), [2, 4] -> (128, 16)>, 1 : i32>) -> (), "sym_visibility" = "public"}> ({
+// CHECK-NEXT:   ^0(%arg0 : memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 0 : i32>, %arg1 : memref<8x8xi32, #tsl.tsl<[2, 4] -> (64, 4), [2, 4] -> (128, 16)>, 1 : i32>):
+// CHECK-NEXT:     %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 0 : i32>) -> index
+// CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<8x8xi32, #tsl.tsl<[2, 4] -> (64, 4), [2, 4] -> (128, 16)>, 1 : i32>) -> index
+// CHECK-NEXT:     %2 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+// CHECK-NEXT:     %3 = "memref.dim"(%arg0, %2) : (memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 0 : i32>, index) -> index
+// CHECK-NEXT:     %4 = "arith.constant"() <{"value" = 1 : index}> : () -> index
+// CHECK-NEXT:     %5 = "memref.dim"(%arg0, %4) : (memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 0 : i32>, index) -> index
+// CHECK-NEXT:     %6 = "arith.constant"() <{"value" = 2 : index}> : () -> index
+// CHECK-NEXT:     %7 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+// CHECK-NEXT:     %8 = "arith.constant"() <{"value" = 2 : index}> : () -> index
+// CHECK-NEXT:     %9 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+// CHECK-NEXT:     %10 = "arith.constant"() <{"value" = 128 : index}> : () -> index
+// CHECK-NEXT:     %11 = "arith.constant"() <{"value" = 32 : index}> : () -> index
+// CHECK-NEXT:     %12 = "arith.constant"() <{"value" = 128 : index}> : () -> index
+// CHECK-NEXT:     %13 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+// CHECK-NEXT:     %14 = "arith.constant"() <{"value" = 16 : index}> : () -> index
+// CHECK-NEXT:     %15 = "arith.constant"() <{"value" = 128 : index}> : () -> index
+// CHECK-NEXT:     %16 = "arith.constant"() <{"value" = 16 : index}> : () -> index
+// CHECK-NEXT:     %17 = "arith.constant"() <{"value" = 128 : index}> : () -> index
+// CHECK-NEXT:     %18 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+// CHECK-NEXT:     %19 = "arith.constant"() <{"value" = 64 : index}> : () -> index
+// CHECK-NEXT:     %20 = "arith.constant"() <{"value" = 16 : index}> : () -> index
+// CHECK-NEXT:     %21 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+// CHECK-NEXT:     %22 = "arith.constant"() <{"value" = 1 : index}> : () -> index
+// CHECK-NEXT:     "scf.for"(%21, %6, %22) ({
+// CHECK-NEXT:     ^1(%23 : index):
+// CHECK-NEXT:       %24 = "arith.muli"(%23, %14) : (index, index) -> index
+// CHECK-NEXT:       %25 = "arith.addi"(%0, %24) : (index, index) -> index
+// CHECK-NEXT:       %26 = "arith.muli"(%23, %19) : (index, index) -> index
+// CHECK-NEXT:       %27 = "arith.addi"(%1, %26) : (index, index) -> index
+// CHECK-NEXT:       "scf.for"(%21, %8, %22) ({
+// CHECK-NEXT:       ^2(%28 : index):
+// CHECK-NEXT:         %29 = "arith.muli"(%28, %12) : (index, index) -> index
+// CHECK-NEXT:         %30 = "arith.addi"(%25, %29) : (index, index) -> index
+// CHECK-NEXT:         %31 = "arith.muli"(%28, %17) : (index, index) -> index
+// CHECK-NEXT:         %32 = "arith.addi"(%27, %31) : (index, index) -> index
+// CHECK-NEXT:         "func.call"(%30, %32, %20, %11, %16, %9) <{"callee" = @snax_dma_2d_transfer}> : (index, index, index, index, index, index) -> ()
+// CHECK-NEXT:         "scf.yield"() : () -> ()
+// CHECK-NEXT:       }) : (index, index, index) -> ()
+// CHECK-NEXT:       "scf.yield"() : () -> ()
+// CHECK-NEXT:     }) : (index, index, index) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "snax_dma_2d_transfer", "function_type" = (index, index, index, index, index, index) -> (), "sym_visibility" = "private"}> ({
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/transforms/memref_to_snax.mlir
+++ b/tests/filecheck/transforms/memref_to_snax.mlir
@@ -81,7 +81,7 @@
 
 "builtin.module"() ({
   %0 = "test.op"() : () -> (index)
-  %1 = "memref.alloc"(%0) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (128, 32)>, 1 : i32>
+  %1 = "memref.alloc"(%0) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (?, 32)>, 1 : i32>
 }) : () -> ()
 
 // CHECK: "builtin.module"() ({
@@ -92,9 +92,9 @@
 // CHECK-NEXT:   %4 = "arith.constant"() <{"value" = 4 : index}> : () -> index
 // CHECK-NEXT:   %5 = "arith.divui"(%0, %4) : (index, index) -> index
 // CHECK-NEXT:   %6 = "arith.constant"() <{"value" = 4 : index}> : () -> index
-// CHECK-NEXT:   %7 = "arith.constant"() <{"value" = 128 : index}> : () -> index
+// CHECK-NEXT:   %7 = "arith.constant"() <{"value" = 32 : index}> : () -> index
 // CHECK-NEXT:   %8 = "arith.constant"() <{"value" = 32 : index}> : () -> index
-// CHECK-NEXT:   %9 = "arith.constant"() <{"value" = 128 : index}> : () -> index
+// CHECK-NEXT:   %9 = "arith.muli"(%6, %7) : (index, index) -> index
 // CHECK-NEXT:   %10 = "arith.constant"() <{"value" = 4 : index}> : () -> index
 // CHECK-NEXT:   %11 = "arith.constant"() <{"value" = 16 : index}> : () -> index
 // CHECK-NEXT:   %12 = "arith.constant"() <{"value" = 4 : index}> : () -> index
@@ -109,5 +109,5 @@
 // CHECK-NEXT:   %21 = "arith.addi"(%19, %20) : (index, index) -> index
 // CHECK-NEXT:   %22 = "arith.muli"(%12, %21) : (index, index) -> index
 // CHECK-NEXT:   %23 = "snax.alloc"(%22) <{"memory_space" = 1 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
-// CHECK-NEXT:   %24 = "builtin.unrealized_conversion_cast"(%23) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (128, 32)>, 1 : i32>
+// CHECK-NEXT:   %24 = "builtin.unrealized_conversion_cast"(%23) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (?, 32)>, 1 : i32>
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/transforms/memref_to_snax.mlir
+++ b/tests/filecheck/transforms/memref_to_snax.mlir
@@ -17,14 +17,32 @@
 }) : () -> ()
 
 // CHECK: "builtin.module"() ({
-// CHECK-NEXT:   %0 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+// CHECK-NEXT:   %0 = "arith.constant"() <{"value" = 16 : index}> : () -> index
 // CHECK-NEXT:   %1 = "arith.constant"() <{"value" = 16 : index}> : () -> index
-// CHECK-NEXT:   %2 = "arith.muli"(%1, %0) : (index, index) -> index
-// CHECK-NEXT:   %3 = "arith.constant"() <{"value" = 16 : index}> : () -> index
-// CHECK-NEXT:   %4 = "arith.muli"(%3, %2) : (index, index) -> index
+// CHECK-NEXT:   %2 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+// CHECK-NEXT:   %3 = "arith.muli"(%0, %2) : (index, index) -> index
+// CHECK-NEXT:   %4 = "arith.muli"(%1, %3) : (index, index) -> index
 // CHECK-NEXT:   %5 = "snax.alloc"(%4) <{"memory_space" = 1 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT:   %6 = "builtin.unrealized_conversion_cast"(%5) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<16x16xi32, 1 : i32>
 // CHECK-NEXT: }) : () -> ()
+
+// -----
+
+"builtin.module"() ({
+  %0 = "test.op"() : () -> (index)
+  %1 = "memref.alloc"(%0) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?x16xi32, 1: i32>
+}) : () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   %0 = "test.op"() : () -> index
+// CHECK-NEXT:   %1 = "arith.constant"() <{"value" = 16 : index}> : () -> index
+// CHECK-NEXT:   %2 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+// CHECK-NEXT:   %3 = "arith.muli"(%0, %2) : (index, index) -> index
+// CHECK-NEXT:   %4 = "arith.muli"(%1, %3) : (index, index) -> index
+// CHECK-NEXT:   %5 = "snax.alloc"(%4) <{"memory_space" = 1 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %6 = "builtin.unrealized_conversion_cast"(%5) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<?x16xi32, 1 : i32>
+// CHECK-NEXT: }) : () -> ()
+
 
 // -----
 
@@ -57,4 +75,39 @@
 // CHECK-NEXT:   %21 = "arith.muli"(%11, %20) : (index, index) -> index
 // CHECK-NEXT:   %22 = "snax.alloc"(%21) <{"memory_space" = 1 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT:   %23 = "builtin.unrealized_conversion_cast"(%22) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 1 : i32>
+// CHECK-NEXT: }) : () -> ()
+
+// -----
+
+"builtin.module"() ({
+  %0 = "test.op"() : () -> (index)
+  %1 = "memref.alloc"(%0) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (128, 32)>, 1 : i32>
+}) : () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   %0 = "test.op"() : () -> index
+// CHECK-NEXT:   %1 = "arith.constant"() <{"value" = 8 : index}> : () -> index
+// CHECK-NEXT:   %2 = "arith.constant"() <{"value" = 2 : index}> : () -> index
+// CHECK-NEXT:   %3 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+// CHECK-NEXT:   %4 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+// CHECK-NEXT:   %5 = "arith.divui"(%0, %4) : (index, index) -> index
+// CHECK-NEXT:   %6 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+// CHECK-NEXT:   %7 = "arith.constant"() <{"value" = 128 : index}> : () -> index
+// CHECK-NEXT:   %8 = "arith.constant"() <{"value" = 32 : index}> : () -> index
+// CHECK-NEXT:   %9 = "arith.constant"() <{"value" = 128 : index}> : () -> index
+// CHECK-NEXT:   %10 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+// CHECK-NEXT:   %11 = "arith.constant"() <{"value" = 16 : index}> : () -> index
+// CHECK-NEXT:   %12 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+// CHECK-NEXT:   %13 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+// CHECK-NEXT:   %14 = "arith.muli"(%2, %11) : (index, index) -> index
+// CHECK-NEXT:   %15 = "arith.addi"(%13, %14) : (index, index) -> index
+// CHECK-NEXT:   %16 = "arith.muli"(%3, %10) : (index, index) -> index
+// CHECK-NEXT:   %17 = "arith.addi"(%15, %16) : (index, index) -> index
+// CHECK-NEXT:   %18 = "arith.muli"(%5, %9) : (index, index) -> index
+// CHECK-NEXT:   %19 = "arith.addi"(%17, %18) : (index, index) -> index
+// CHECK-NEXT:   %20 = "arith.muli"(%6, %8) : (index, index) -> index
+// CHECK-NEXT:   %21 = "arith.addi"(%19, %20) : (index, index) -> index
+// CHECK-NEXT:   %22 = "arith.muli"(%12, %21) : (index, index) -> index
+// CHECK-NEXT:   %23 = "snax.alloc"(%22) <{"memory_space" = 1 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %24 = "builtin.unrealized_conversion_cast"(%23) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (128, 32)>, 1 : i32>
 // CHECK-NEXT: }) : () -> ()


### PR DESCRIPTION
This PR adds dynamic support to the memref-to-snax pass. Now memref.allocs with dynamic shapes can also be lowered to snax dialect

The changes necessary are quite minimal, but there are some large diffs due to some refactoring, see my comments