### PR TITLE
snax.alloc: add alignment property

### DIFF
--- a/compiler/dialects/snax.py
+++ b/compiler/dialects/snax.py
@@ -112,7 +112,7 @@ class Alloc(IRDLOperation):
         descriptor = LLVMMemrefDescriptor.from_rank_and_integer_type(rank, integer_type)
 
         if not alignment:
-            alignment = IntegerAttr(1, IndexType())
+            alignment = IntegerAttr(1, IntegerType(64))
 
         super().__init__(
             operands=[size],

--- a/compiler/dialects/snax.py
+++ b/compiler/dialects/snax.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from typing import cast
 
-from xdsl.dialects.builtin import IndexType, IntegerType, NoneAttr, i32
+from xdsl.dialects.builtin import (
+    AnyIntegerAttr,
+    IndexType,
+    IntegerAttr,
+    IntegerType,
+    NoneAttr,
+    i32,
+)
 from xdsl.dialects.llvm import LLVMStructType
 from xdsl.dialects.memref import MemRefType, UnrankedMemrefType
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
@@ -91,21 +98,26 @@ class Alloc(IRDLOperation):
     size: Operand = operand_def(IntegerType | IndexType)
     result: OpResult = result_def(LLVMStructType)
     memory_space: Attribute | None = opt_prop_def(Attribute)
+    alignment: AnyIntegerAttr | None = opt_prop_def(AnyIntegerAttr)
 
     def __init__(
         self,
         rank: int,
         size: SSAValue | Operation,
         memory_space: Attribute = NoneAttr(),
+        alignment: AnyIntegerAttr = None,
         integer_type: IntegerType = i32,
     ):
         # output type is llvm struct memref descriptor
         descriptor = LLVMMemrefDescriptor.from_rank_and_integer_type(rank, integer_type)
 
+        if not alignment:
+            alignment = IntegerAttr(1, IndexType())
+
         super().__init__(
             operands=[size],
             result_types=[descriptor.descriptor],
-            properties={"memory_space": memory_space},
+            properties={"memory_space": memory_space, "alignment": alignment},
         )
 
     def verify_(self) -> None:

--- a/compiler/transforms/memref_to_snax.py
+++ b/compiler/transforms/memref_to_snax.py
@@ -114,7 +114,11 @@ class AllocOpRewrite(RewritePattern):
 
         # create snax alloc op
         snax_alloc = snax.Alloc(
-            memref_type.get_num_dims(), total_size_op, memory_space, element_type
+            memref_type.get_num_dims(),
+            total_size_op,
+            memory_space,
+            alloc_op.alignment,
+            element_type,
         )
         conversion_cast_op = UnrealizedConversionCastOp.get([snax_alloc], memref_type)
         rewriter.replace_matched_op(

--- a/tests/filecheck/dialects/snax/snax_invalid.mlir
+++ b/tests/filecheck/dialects/snax/snax_invalid.mlir
@@ -2,7 +2,7 @@
 
 "builtin.module"() ({
   %0 = arith.constant 45 : i32
-  %1 = "snax.alloc"(%0) <{"memory_space" = 1 : i32}> : (i32) -> !llvm.struct<(i32)>
+  %1 = "snax.alloc"(%0) <{"memory_space" = 1 : i32, "alignment" = 64 : i32}> : (i32) -> !llvm.struct<(i32)>
 }) : () -> ()
 
 // CHECK: Operation does not verify: Invalid Memref Descriptor: Expected first element to be LLVMPointerType
@@ -11,7 +11,7 @@
 
 "builtin.module"() ({
   %0 = arith.constant 45 : i32
-  %1 = "snax.alloc"(%0) <{"memory_space" = 2 : i32}> : (i32) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+  %1 = "snax.alloc"(%0) <{"memory_space" = 2 : i32, "alignment" = 64 : i32}> : (i32) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 }) : () -> ()
 
 // CHECK: Operation does not verify: Invalid Memref Descriptor: Expected third element to be IntegerType
@@ -20,7 +20,7 @@
 
 "builtin.module"() ({
   %0 = arith.constant 45 : i32
-  %1 = "snax.alloc"(%0) <{"memory_space" = 2 : i32}> : (i32) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<1 x i32>, !llvm.array<2 x i32>)>
+  %1 = "snax.alloc"(%0) <{"memory_space" = 2 : i32, "alignment" = 64 : i32}> : (i32) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<1 x i32>, !llvm.array<2 x i32>)>
 }) : () -> ()
 
 // CHECK: Operation does not verify: Invalid Memref Descriptor: Expected shape and strides to have the same dimension

--- a/tests/filecheck/dialects/snax/snax_ops.mlir
+++ b/tests/filecheck/dialects/snax/snax_ops.mlir
@@ -5,7 +5,7 @@
   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, 1 : i32>
   %1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, 1 : i32>) -> memref<8x8xi32, strided<[1, 16]>, 1 : i32>
   %2 = arith.constant 45 : i32
-  %3 = "snax.alloc"(%2) <{"memory_space" = 0 : i32}> : (i32) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+  %3 = "snax.alloc"(%2) <{"memory_space" = 0 : i32, "alignment" = 64 : i32}> : (i32) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 }) : () -> ()
 
 
@@ -13,5 +13,5 @@
 // CHECK-NEXT:   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, 1 : i32>
 // CHECK-NEXT:   %1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, 1 : i32>) -> memref<8x8xi32, strided<[1, 16]>, 1 : i32>
 // CHECK-NEXT:   %2 = "arith.constant"() <{"value" = 45 : i32}> : () -> i32
-// CHECK-NEXT:   %3 = "snax.alloc"(%2) <{"memory_space" = 0 : i32}> : (i32) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %3 = "snax.alloc"(%2) <{"memory_space" = 0 : i32, "alignment" = 64 : i32}> : (i32) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/transforms/memref_to_snax.mlir
+++ b/tests/filecheck/transforms/memref_to_snax.mlir
@@ -1,19 +1,19 @@
 // RUN: ./compiler/snax-opt --split-input-file %s -p memref-to-snax --print-op-generic | filecheck %s
 
 "builtin.module"() ({
-  %0 = "memref.alloc"() <{"alignment" = 64 : i32, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<16x16xi32>
+  %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<16x16xi32>
 }) : () -> ()
 
 // expect nothing to change because no memory space is specified
 // CHECK: "builtin.module"() ({
-// CHECK-NEXT:   %0 = "memref.alloc"() <{"alignment" = 64 : i32, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<16x16xi32>
+// CHECK-NEXT:   %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<16x16xi32>
 // CHECK-NEXT: }) : () -> ()
 
 
 // -----
 
 "builtin.module"() ({
-  %0 = "memref.alloc"() <{"alignment" = 64 : i32, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<16x16xi32, 1: i32>
+  %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<16x16xi32, 1: i32>
 }) : () -> ()
 
 // CHECK: "builtin.module"() ({
@@ -22,7 +22,7 @@
 // CHECK-NEXT:   %2 = "arith.constant"() <{"value" = 4 : index}> : () -> index
 // CHECK-NEXT:   %3 = "arith.muli"(%0, %2) : (index, index) -> index
 // CHECK-NEXT:   %4 = "arith.muli"(%1, %3) : (index, index) -> index
-// CHECK-NEXT:   %5 = "snax.alloc"(%4) <{"memory_space" = 1 : i32, "alignment" = 64 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %5 = "snax.alloc"(%4) <{"memory_space" = 1 : i32, "alignment" = 64 : i64}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT:   %6 = "builtin.unrealized_conversion_cast"(%5) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<16x16xi32, 1 : i32>
 // CHECK-NEXT: }) : () -> ()
 
@@ -30,7 +30,7 @@
 
 "builtin.module"() ({
   %0 = "test.op"() : () -> (index)
-  %1 = "memref.alloc"(%0) <{"alignment" = 64 : i32, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?x16xi32, 1: i32>
+  %1 = "memref.alloc"(%0) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?x16xi32, 1: i32>
 }) : () -> ()
 
 // CHECK: "builtin.module"() ({
@@ -39,7 +39,7 @@
 // CHECK-NEXT:   %2 = "arith.constant"() <{"value" = 4 : index}> : () -> index
 // CHECK-NEXT:   %3 = "arith.muli"(%0, %2) : (index, index) -> index
 // CHECK-NEXT:   %4 = "arith.muli"(%1, %3) : (index, index) -> index
-// CHECK-NEXT:   %5 = "snax.alloc"(%4) <{"memory_space" = 1 : i32, "alignment" = 64 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %5 = "snax.alloc"(%4) <{"memory_space" = 1 : i32, "alignment" = 64 : i64}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT:   %6 = "builtin.unrealized_conversion_cast"(%5) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<?x16xi32, 1 : i32>
 // CHECK-NEXT: }) : () -> ()
 
@@ -47,7 +47,7 @@
 // -----
 
 "builtin.module"() ({
-  %0 = "memref.alloc"() <{"alignment" = 64 : i32, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 1 : i32>
+  %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 1 : i32>
 }) : () -> ()
 
 // CHECK: "builtin.module"() ({
@@ -73,7 +73,7 @@
 // CHECK-NEXT:   %19 = "arith.muli"(%5, %7) : (index, index) -> index
 // CHECK-NEXT:   %20 = "arith.addi"(%18, %19) : (index, index) -> index
 // CHECK-NEXT:   %21 = "arith.muli"(%11, %20) : (index, index) -> index
-// CHECK-NEXT:   %22 = "snax.alloc"(%21) <{"memory_space" = 1 : i32, "alignment" = 64 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %22 = "snax.alloc"(%21) <{"memory_space" = 1 : i32, "alignment" = 64 : i64}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT:   %23 = "builtin.unrealized_conversion_cast"(%22) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 1 : i32>
 // CHECK-NEXT: }) : () -> ()
 
@@ -81,7 +81,7 @@
 
 "builtin.module"() ({
   %0 = "test.op"() : () -> (index)
-  %1 = "memref.alloc"(%0) <{"alignment" = 64 : i32, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (?, 32)>, 1 : i32>
+  %1 = "memref.alloc"(%0) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (?, 32)>, 1 : i32>
 }) : () -> ()
 
 // CHECK: "builtin.module"() ({
@@ -108,6 +108,6 @@
 // CHECK-NEXT:   %20 = "arith.muli"(%6, %8) : (index, index) -> index
 // CHECK-NEXT:   %21 = "arith.addi"(%19, %20) : (index, index) -> index
 // CHECK-NEXT:   %22 = "arith.muli"(%12, %21) : (index, index) -> index
-// CHECK-NEXT:   %23 = "snax.alloc"(%22) <{"memory_space" = 1 : i32, "alignment" = 64 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %23 = "snax.alloc"(%22) <{"memory_space" = 1 : i32, "alignment" = 64 : i64}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT:   %24 = "builtin.unrealized_conversion_cast"(%23) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (?, 32)>, 1 : i32>
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/transforms/memref_to_snax.mlir
+++ b/tests/filecheck/transforms/memref_to_snax.mlir
@@ -1,19 +1,19 @@
 // RUN: ./compiler/snax-opt --split-input-file %s -p memref-to-snax --print-op-generic | filecheck %s
 
 "builtin.module"() ({
-  %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<16x16xi32>
+  %0 = "memref.alloc"() <{"alignment" = 64 : i32, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<16x16xi32>
 }) : () -> ()
 
 // expect nothing to change because no memory space is specified
 // CHECK: "builtin.module"() ({
-// CHECK-NEXT:   %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<16x16xi32>
+// CHECK-NEXT:   %0 = "memref.alloc"() <{"alignment" = 64 : i32, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<16x16xi32>
 // CHECK-NEXT: }) : () -> ()
 
 
 // -----
 
 "builtin.module"() ({
-  %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<16x16xi32, 1: i32>
+  %0 = "memref.alloc"() <{"alignment" = 64 : i32, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<16x16xi32, 1: i32>
 }) : () -> ()
 
 // CHECK: "builtin.module"() ({
@@ -22,7 +22,7 @@
 // CHECK-NEXT:   %2 = "arith.constant"() <{"value" = 4 : index}> : () -> index
 // CHECK-NEXT:   %3 = "arith.muli"(%0, %2) : (index, index) -> index
 // CHECK-NEXT:   %4 = "arith.muli"(%1, %3) : (index, index) -> index
-// CHECK-NEXT:   %5 = "snax.alloc"(%4) <{"memory_space" = 1 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %5 = "snax.alloc"(%4) <{"memory_space" = 1 : i32, "alignment" = 64 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT:   %6 = "builtin.unrealized_conversion_cast"(%5) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<16x16xi32, 1 : i32>
 // CHECK-NEXT: }) : () -> ()
 
@@ -30,7 +30,7 @@
 
 "builtin.module"() ({
   %0 = "test.op"() : () -> (index)
-  %1 = "memref.alloc"(%0) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?x16xi32, 1: i32>
+  %1 = "memref.alloc"(%0) <{"alignment" = 64 : i32, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?x16xi32, 1: i32>
 }) : () -> ()
 
 // CHECK: "builtin.module"() ({
@@ -39,7 +39,7 @@
 // CHECK-NEXT:   %2 = "arith.constant"() <{"value" = 4 : index}> : () -> index
 // CHECK-NEXT:   %3 = "arith.muli"(%0, %2) : (index, index) -> index
 // CHECK-NEXT:   %4 = "arith.muli"(%1, %3) : (index, index) -> index
-// CHECK-NEXT:   %5 = "snax.alloc"(%4) <{"memory_space" = 1 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %5 = "snax.alloc"(%4) <{"memory_space" = 1 : i32, "alignment" = 64 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT:   %6 = "builtin.unrealized_conversion_cast"(%5) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<?x16xi32, 1 : i32>
 // CHECK-NEXT: }) : () -> ()
 
@@ -47,7 +47,7 @@
 // -----
 
 "builtin.module"() ({
-  %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 1 : i32>
+  %0 = "memref.alloc"() <{"alignment" = 64 : i32, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 1 : i32>
 }) : () -> ()
 
 // CHECK: "builtin.module"() ({
@@ -73,7 +73,7 @@
 // CHECK-NEXT:   %19 = "arith.muli"(%5, %7) : (index, index) -> index
 // CHECK-NEXT:   %20 = "arith.addi"(%18, %19) : (index, index) -> index
 // CHECK-NEXT:   %21 = "arith.muli"(%11, %20) : (index, index) -> index
-// CHECK-NEXT:   %22 = "snax.alloc"(%21) <{"memory_space" = 1 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %22 = "snax.alloc"(%21) <{"memory_space" = 1 : i32, "alignment" = 64 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT:   %23 = "builtin.unrealized_conversion_cast"(%22) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 1 : i32>
 // CHECK-NEXT: }) : () -> ()
 
@@ -81,7 +81,7 @@
 
 "builtin.module"() ({
   %0 = "test.op"() : () -> (index)
-  %1 = "memref.alloc"(%0) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (?, 32)>, 1 : i32>
+  %1 = "memref.alloc"(%0) <{"alignment" = 64 : i32, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (?, 32)>, 1 : i32>
 }) : () -> ()
 
 // CHECK: "builtin.module"() ({
@@ -108,6 +108,6 @@
 // CHECK-NEXT:   %20 = "arith.muli"(%6, %8) : (index, index) -> index
 // CHECK-NEXT:   %21 = "arith.addi"(%19, %20) : (index, index) -> index
 // CHECK-NEXT:   %22 = "arith.muli"(%12, %21) : (index, index) -> index
-// CHECK-NEXT:   %23 = "snax.alloc"(%22) <{"memory_space" = 1 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %23 = "snax.alloc"(%22) <{"memory_space" = 1 : i32, "alignment" = 64 : i32}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT:   %24 = "builtin.unrealized_conversion_cast"(%23) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (?, 32)>, 1 : i32>
 // CHECK-NEXT: }) : () -> ()


### PR DESCRIPTION
This PR adds an alignment property to the `snax.alloc` op
This is important to us if we want to align a memref with a specific memory bank