### PR TITLE
compiler: snax.alloc to func lowering

### DIFF
--- a/compiler/transforms/memref_to_snax.py
+++ b/compiler/transforms/memref_to_snax.py
@@ -69,8 +69,12 @@ class AllocOpRewrite(RewritePattern):
 
             # multiply all the dimensions with the element width
             # to get the size we need to allocate
-            assert element_type.width.data % 8 == 0
-            element_size = element_type.width.data // 8
+            if isinstance(element_type, builtin.AnyFloat):
+                element_width = element_type.get_bitwidth()
+            else:
+                element_width = element_type.width
+            assert element_width.data % 8 == 0
+            element_size = element_width.data // 8
             element_size_op = Constant.from_int_and_width(element_size, IndexType())
             total_size_op = element_size_op
             ops_to_add.append(element_size_op)

--- a/compiler/transforms/memref_to_snax.py
+++ b/compiler/transforms/memref_to_snax.py
@@ -121,7 +121,6 @@ class AllocOpRewrite(RewritePattern):
             shape_ops_arg,
             memory_space,
             alloc_op.alignment,
-            element_type,
         )
         conversion_cast_op = UnrealizedConversionCastOp.get([snax_alloc], memref_type)
         rewriter.replace_matched_op(

--- a/compiler/transforms/memref_to_snax.py
+++ b/compiler/transforms/memref_to_snax.py
@@ -70,11 +70,11 @@ class AllocOpRewrite(RewritePattern):
             # multiply all the dimensions with the element width
             # to get the size we need to allocate
             if isinstance(element_type, builtin.AnyFloat):
-                element_width = element_type.get_bitwidth()
+                element_width = element_type.get_bitwidth
             else:
-                element_width = element_type.width
-            assert element_width.data % 8 == 0
-            element_size = element_width.data // 8
+                element_width = element_type.width.data
+            assert element_width % 8 == 0
+            element_size = element_width // 8
             element_size_op = Constant.from_int_and_width(element_size, IndexType())
             total_size_op = element_size_op
             ops_to_add.append(element_size_op)

--- a/compiler/transforms/snax_to_func.py
+++ b/compiler/transforms/snax_to_func.py
@@ -117,3 +117,5 @@ class SNAXToFunc(ModulePass):
         if contains_sync:
             PatternRewriteWalker(InsertFunctionCall()).rewrite_module(module)
             PatternRewriteWalker(InsertFunctionDeclaration()).rewrite_module(module)
+
+        PatternRewriteWalker(AllocToFunc()).rewrite_module(module)

--- a/compiler/transforms/snax_to_func.py
+++ b/compiler/transforms/snax_to_func.py
@@ -1,4 +1,4 @@
-from xdsl.dialects import builtin, func
+from xdsl.dialects import arith, builtin, func, llvm
 from xdsl.ir import MLContext
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -26,6 +26,82 @@ class InsertFunctionDeclaration(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, module_op: builtin.ModuleOp, rewriter: PatternRewriter):
         func_op = func.FuncOp.external("snax_cluster_hw_barrier", [], [])
+        SymbolTable.insert_or_update(module_op, func_op)
+
+
+class AllocToFunc(RewritePattern):
+    """Swap snax.alloc with function call
+
+    Awaiting an llvm.inline_asm snitch runtime, implement the snax.allocs
+    through C interfacing with function calls. The function call returns a
+    pointer to the allocated memory. Aligned allocation is not supported yet,
+    and the argument will be ignored. The pass is only implemented for L1 (TCDM)
+    memory space allocations.
+
+    In this pass we must also initialize the llvm struct with the correct contents
+    for now we only populate pointer, aligned_pointer, offset and shapes.
+    The strides are not pupulated because they are not used, and often not available.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, alloc_op: snax.Alloc, rewriter: PatternRewriter):
+        ## only supoorting L1 allocation for now
+        if not (
+            isinstance(alloc_op.memory_space, builtin.IntegerAttr)
+            and alloc_op.memory_space.value.data == 1
+        ):
+            return
+
+        def dense_array(pos):
+            return builtin.DenseArrayBase.create_dense_int_or_index(builtin.i64, pos)
+
+        ops_to_insert = []
+
+        func_call = func.Call(
+            "snax_alloc_l1", [alloc_op.size], [llvm.LLVMPointerType.opaque()]
+        )
+        ops_to_insert.append(func_call)
+
+        llvm_struct = llvm.UndefOp(alloc_op.result.type)
+        ops_to_insert.append(llvm_struct)
+
+        llvm_struct = llvm.InsertValueOp(
+            dense_array([0]), llvm_struct.res, func_call.res[0]
+        )
+        ops_to_insert.append(llvm_struct)
+
+        llvm_struct = llvm.InsertValueOp(
+            dense_array([1]), llvm_struct.res, func_call.res[0]
+        )
+        ops_to_insert.append(llvm_struct)
+
+        cst_zero = arith.Constant.from_int_and_width(0, builtin.i32)
+        llvm_struct = llvm.InsertValueOp(dense_array([2]), llvm_struct.res, cst_zero)
+        ops_to_insert.extend([cst_zero, llvm_struct])
+
+        # use shape operands to populate shape of memref descriptor
+        for i, shape_op in enumerate(alloc_op.shapes):
+            if isinstance(shape_op.type, builtin.IndexType):
+                # we must cast to integer for valid llvm op
+                shape_op = builtin.UnrealizedConversionCastOp.get(
+                    [shape_op], [builtin.i32]
+                )
+                ops_to_insert.append(shape_op)
+            llvm_struct = llvm.InsertValueOp(
+                dense_array([3, i]), llvm_struct.res, shape_op.results[0]
+            )
+            ops_to_insert.append(llvm_struct)
+
+        module_op = alloc_op.get_toplevel_object()
+
+        rewriter.replace_matched_op(ops_to_insert)
+
+        func_op = func.FuncOp.external(
+            "snax_alloc_l1",
+            [builtin.IndexType()],
+            [llvm.LLVMPointerType.opaque()],
+        )
+
         SymbolTable.insert_or_update(module_op, func_op)
 
 

--- a/kernels/simple_mult/main.c
+++ b/kernels/simple_mult/main.c
@@ -47,6 +47,8 @@ int main() {
   _mlir_ciface_simple_mult(&memrefA, &memrefB, &memrefD);
   (void)snrt_mcycle();
 
+  snrt_cluster_hw_barrier();
+
   // Correctness check -
   // from this point on only core 0 is required to be alive.
   int thiscore = snrt_cluster_core_idx();

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -107,7 +107,7 @@ MLIRPREPROC3FLAGS += --mlir-print-local-scope
 
 # SNAX opt
 
-SNAXOPTFLAGS = -p set-memory-space,realize-memref-casts,insert-sync-barrier,dispatch-regions,dispatch-kernels,linalg-to-library-call,snax-copy-to-dma,snax-to-func,clear-memory-space
+SNAXOPTFLAGS = -p set-memory-space,realize-memref-casts,insert-sync-barrier,dispatch-regions,dispatch-kernels,linalg-to-library-call,snax-copy-to-dma,memref-to-snax,snax-to-func,clear-memory-space
 
 %.snax-opt.mlir: %.preprocfinal.mlir
 	$(SNAXOPT) $(SNAXOPTFLAGS) -o $@ $<

--- a/runtime/include/snax_rt.h
+++ b/runtime/include/snax_rt.h
@@ -18,6 +18,15 @@ int8_t *_mlir_memref_to_llvm_alloc(uint32_t size) {
   return allocated_pointer;
 };
 
+int8_t *_mlir_ciface_snax_alloc_l1(uint32_t size) {
+  if (snrt_is_dm_core()) {
+    // printf("Allocating %d bytes\n", size);
+    allocated_pointer = (int8_t *)snrt_l1alloc(size);
+  }
+  snrt_cluster_hw_barrier();
+  return allocated_pointer;
+}
+
 void _mlir_ciface_snax_cluster_hw_barrier() {
   snrt_cluster_hw_barrier();
   return;
@@ -25,6 +34,8 @@ void _mlir_ciface_snax_cluster_hw_barrier() {
 
 void _mlir_ciface_snax_dma_1d_transfer(size_t *source, size_t *destination,
                                        size_t size) {
+  // printf("Copying %d bytes from %p to %p\n", size, (void *)source,
+  //        (void *)destination);
   snrt_dma_start_1d((void *)destination, (void *)source, size);
   snrt_dma_wait_all();
   return;
@@ -34,7 +45,7 @@ void _mlir_ciface_snax_dma_2d_transfer(size_t *source, size_t *destination,
                                        size_t size, size_t src_stride,
                                        size_t dst_stride, size_t repeat) {
   // printf("Copying %d bytes from %p to %p, stridsrc %x stridedst %x rpt %d\n",
-  // size, source, destination, src_stride, dst_stride, repeat);
+  //        size, source, destination, src_stride, dst_stride, repeat);
   snrt_dma_start_2d((void *)destination, (void *)source, size, dst_stride,
                     src_stride, repeat);
 }

--- a/tests/filecheck/transforms/snax_to_func.mlir
+++ b/tests/filecheck/transforms/snax_to_func.mlir
@@ -9,3 +9,26 @@
 //CHECK-NEXT:   "func.func"() <{"sym_name" = "snax_cluster_hw_barrier", "function_type" = () -> (), "sym_visibility" = "private"}> ({
 //CHECK-NEXT:   }) : () -> ()
 //CHECK-NEXT: }) : () -> ()
+
+// -----
+
+"builtin.module"() ({
+  %0 = "test.op"() : () -> (index)
+  %1 = "snax.alloc"(%0, %0, %0) <{"memory_space" = 1 : i32, "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+}) : () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   %0 = "test.op"() : () -> index
+// CHECK-NEXT:   %1 = "func.call"(%0) <{"callee" = @snax_alloc_l1}> : (index) -> !llvm.ptr
+// CHECK-NEXT:   %2 = "llvm.mlir.undef"() : () -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %3 = "llvm.insertvalue"(%2, %1) <{"position" = array<i64: 0>}> : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>, !llvm.ptr) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %4 = "llvm.insertvalue"(%3, %1) <{"position" = array<i64: 1>}> : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>, !llvm.ptr) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %5 = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
+// CHECK-NEXT:   %6 = "llvm.insertvalue"(%4, %5) <{"position" = array<i64: 2>}> : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>, i32) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %7 = "builtin.unrealized_conversion_cast"(%0) : (index) -> i32
+// CHECK-NEXT:   %8 = "llvm.insertvalue"(%6, %7) <{"position" = array<i64: 3, 0>}> : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>, i32) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %9 = "builtin.unrealized_conversion_cast"(%0) : (index) -> i32
+// CHECK-NEXT:   %10 = "llvm.insertvalue"(%8, %9) <{"position" = array<i64: 3, 1>}> : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>, i32) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "snax_alloc_l1", "function_type" = (index) -> !llvm.ptr, "sym_visibility" = "private"}> ({
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()


### PR DESCRIPTION
The PR implements a lowering which replaces `snax.alloc` calls with the relevant function call and populates the llvm memref descriptor accordingly.

Note: although there are no changes to the `alloc` kernel (and other kernels using a `memref.alloc`), this kernel now uses this updated flow, and keeps operating correctly!