### PR TITLE
add shape operands to snax alloc op

### DIFF
--- a/compiler/dialects/snax.py
+++ b/compiler/dialects/snax.py
@@ -17,10 +17,12 @@ from xdsl.irdl import (
     IRDLOperation,
     Operand,
     OpResult,
+    VarOperand,
     irdl_op_definition,
     operand_def,
     opt_prop_def,
     result_def,
+    var_operand_def,
 )
 from xdsl.utils.exceptions import VerifyException
 
@@ -96,6 +98,7 @@ class Alloc(IRDLOperation):
     name = "snax.alloc"
 
     size: Operand = operand_def(IntegerType | IndexType)
+    shapes: VarOperand = var_operand_def(IntegerType | IndexType)
     result: OpResult = result_def(LLVMStructType)
     memory_space: Attribute | None = opt_prop_def(Attribute)
     alignment: AnyIntegerAttr | None = opt_prop_def(AnyIntegerAttr)
@@ -104,6 +107,7 @@ class Alloc(IRDLOperation):
         self,
         rank: int,
         size: SSAValue | Operation,
+        shapes: list[SSAValue | Operation],
         memory_space: Attribute = NoneAttr(),
         alignment: AnyIntegerAttr = None,
         integer_type: IntegerType = i32,
@@ -115,7 +119,7 @@ class Alloc(IRDLOperation):
             alignment = IntegerAttr(1, IntegerType(64))
 
         super().__init__(
-            operands=[size],
+            operands=[size, shapes],
             result_types=[descriptor.descriptor],
             properties={"memory_space": memory_space, "alignment": alignment},
         )

--- a/compiler/transforms/memref_to_snax.py
+++ b/compiler/transforms/memref_to_snax.py
@@ -61,6 +61,8 @@ class AllocOpRewrite(RewritePattern):
                 ops_to_add.append(shape_op)
                 shape_ops.append(shape_op)
 
+        shape_ops_arg = [x for x in shape_ops]
+
         if isinstance(layout, NoneAttr):
             # get size based on shape
             shape = memref_type.shape
@@ -116,6 +118,7 @@ class AllocOpRewrite(RewritePattern):
         snax_alloc = snax.Alloc(
             memref_type.get_num_dims(),
             total_size_op,
+            shape_ops_arg,
             memory_space,
             alloc_op.alignment,
             element_type,

--- a/tests/dialects/test_snax.py
+++ b/tests/dialects/test_snax.py
@@ -68,8 +68,9 @@ def test_memref_memory_space_cast():
 
 def test_snax_alloc():
     size = TestSSAValue(i32)
+    shape = [TestSSAValue(i32), TestSSAValue(i32)]
     dim = 2
-    alloc_a = Alloc(dim, size, memory_space=builtin.IntegerAttr(1, i32))
+    alloc_a = Alloc(dim, size, shape, memory_space=builtin.IntegerAttr(1, i32))
 
     assert alloc_a.size is size
     assert alloc_a.memory_space.value.data == 1

--- a/tests/filecheck/dialects/snax/snax_ops.mlir
+++ b/tests/filecheck/dialects/snax/snax_ops.mlir
@@ -4,14 +4,14 @@
 "builtin.module"() ({
   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, 1 : i32>
   %1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, 1 : i32>) -> memref<8x8xi32, strided<[1, 16]>, 1 : i32>
-  %2 = arith.constant 45 : i32
-  %3 = "snax.alloc"(%2) <{"memory_space" = 0 : i32, "alignment" = 64 : i32}> : (i32) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+  %2 = "test.op"() : () -> index
+  %3 = "snax.alloc"(%2, %2, %2) <{"memory_space" = 0 : i32, "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 }) : () -> ()
 
 
-// CHECK: "builtin.module"() ({
+// CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, 1 : i32>
 // CHECK-NEXT:   %1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, 1 : i32>) -> memref<8x8xi32, strided<[1, 16]>, 1 : i32>
-// CHECK-NEXT:   %2 = "arith.constant"() <{"value" = 45 : i32}> : () -> i32
-// CHECK-NEXT:   %3 = "snax.alloc"(%2) <{"memory_space" = 0 : i32, "alignment" = 64 : i32}> : (i32) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %2 = "test.op"() : () -> index
+// CHECK-NEXT:   %3 = "snax.alloc"(%2, %2, %2) <{"memory_space" = 0 : i32, "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/transforms/memref_to_snax.mlir
+++ b/tests/filecheck/transforms/memref_to_snax.mlir
@@ -22,7 +22,7 @@
 // CHECK-NEXT:   %2 = "arith.constant"() <{"value" = 4 : index}> : () -> index
 // CHECK-NEXT:   %3 = "arith.muli"(%0, %2) : (index, index) -> index
 // CHECK-NEXT:   %4 = "arith.muli"(%1, %3) : (index, index) -> index
-// CHECK-NEXT:   %5 = "snax.alloc"(%4) <{"memory_space" = 1 : i32, "alignment" = 64 : i64}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %5 = "snax.alloc"(%4, %0, %1) <{"memory_space" = 1 : i32, "alignment" = 64 : i64}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT:   %6 = "builtin.unrealized_conversion_cast"(%5) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<16x16xi32, 1 : i32>
 // CHECK-NEXT: }) : () -> ()
 
@@ -39,7 +39,7 @@
 // CHECK-NEXT:   %2 = "arith.constant"() <{"value" = 4 : index}> : () -> index
 // CHECK-NEXT:   %3 = "arith.muli"(%0, %2) : (index, index) -> index
 // CHECK-NEXT:   %4 = "arith.muli"(%1, %3) : (index, index) -> index
-// CHECK-NEXT:   %5 = "snax.alloc"(%4) <{"memory_space" = 1 : i32, "alignment" = 64 : i64}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %5 = "snax.alloc"(%4, %0, %1) <{"memory_space" = 1 : i32, "alignment" = 64 : i64}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT:   %6 = "builtin.unrealized_conversion_cast"(%5) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<?x16xi32, 1 : i32>
 // CHECK-NEXT: }) : () -> ()
 
@@ -73,7 +73,7 @@
 // CHECK-NEXT:   %19 = "arith.muli"(%5, %7) : (index, index) -> index
 // CHECK-NEXT:   %20 = "arith.addi"(%18, %19) : (index, index) -> index
 // CHECK-NEXT:   %21 = "arith.muli"(%11, %20) : (index, index) -> index
-// CHECK-NEXT:   %22 = "snax.alloc"(%21) <{"memory_space" = 1 : i32, "alignment" = 64 : i64}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %22 = "snax.alloc"(%21, %0, %1) <{"memory_space" = 1 : i32, "alignment" = 64 : i64}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT:   %23 = "builtin.unrealized_conversion_cast"(%22) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, 1 : i32>
 // CHECK-NEXT: }) : () -> ()
 
@@ -108,6 +108,6 @@
 // CHECK-NEXT:   %20 = "arith.muli"(%6, %8) : (index, index) -> index
 // CHECK-NEXT:   %21 = "arith.addi"(%19, %20) : (index, index) -> index
 // CHECK-NEXT:   %22 = "arith.muli"(%12, %21) : (index, index) -> index
-// CHECK-NEXT:   %23 = "snax.alloc"(%22) <{"memory_space" = 1 : i32, "alignment" = 64 : i64}> : (index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %23 = "snax.alloc"(%22, %1, %0) <{"memory_space" = 1 : i32, "alignment" = 64 : i64}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT:   %24 = "builtin.unrealized_conversion_cast"(%23) : (!llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>) -> memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (?, 32)>, 1 : i32>
 // CHECK-NEXT: }) : () -> ()


### PR DESCRIPTION
For futher lowering the `snax.alloc` operation, we need the shape information to populate the llvm memref descriptor. The shape operands are already inserted in the ir, this PR just includes them as actual operands of the `snax.alloc` op.