### PR TITLE
limit lowering to snax.alloc to memory space L1

### DIFF
--- a/compiler/transforms/memref_to_snax.py
+++ b/compiler/transforms/memref_to_snax.py
@@ -17,8 +17,8 @@ from compiler.dialects.tsl import TiledStridedLayoutAttr
 class AllocOpRewrite(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, alloc_op: memref.Alloc, rewriter: PatternRewriter):
-        """Swap memref.alloc op with snax.alloc, for now, we suppport
-        NoneType layouts and TSL Layouts"""
+        """Swap memref.alloc op with snax.alloc, for now, we support
+        NoneType layouts and TSL Layouts, and a memory space of 1 (=L1)"""
 
         # get the memref type
         memref_type: memref.MemRefType = alloc_op.memref.type
@@ -32,8 +32,8 @@ class AllocOpRewrite(RewritePattern):
         # get the memory space
         memory_space = memref_type.memory_space
 
-        # if the memory space is not defined, conversion to snax is not possible
-        if isinstance(memory_space, NoneAttr):
+        # if the memory space is not 1, conversion to snax is not possible
+        if isinstance(memory_space, NoneAttr) or memory_space.value.data != 1:
             return
 
         # get the layout


### PR DESCRIPTION
To fix the errors in mlperf tiny benchmarks from #90 