### PR TITLE
dialects: (acc) Add acc dialect and acc-cse pass to simplify setups

### DIFF
--- a/compiler/dialects/acc.py
+++ b/compiler/dialects/acc.py
@@ -22,7 +22,6 @@ from xdsl.irdl import (
     result_def,
     var_operand_def,
 )
-from xdsl.utils.hints import isa
 
 
 @irdl_attr_definition
@@ -84,6 +83,7 @@ class SetupOp(IRDLOperation):
     If acc.setup is called without any parameters, the resulting state is the
     "empty" state, that represents a state without known values.
     """
+
     name = "acc.setup"
 
     values = var_operand_def(Attribute)  # TODO: make more precise?

--- a/compiler/dialects/acc.py
+++ b/compiler/dialects/acc.py
@@ -1,0 +1,163 @@
+from collections.abc import Iterable, Sequence
+
+from xdsl.dialects.builtin import ArrayAttr, StringAttr
+from xdsl.ir import (
+    Attribute,
+    Dialect,
+    Operation,
+    ParametrizedAttribute,
+    SSAValue,
+    TypeAttribute,
+)
+from xdsl.irdl import (
+    AttrSizedOperandSegments,
+    IRDLOperation,
+    ParameterDef,
+    VerifyException,
+    irdl_attr_definition,
+    irdl_op_definition,
+    operand_def,
+    opt_operand_def,
+    prop_def,
+    result_def,
+    var_operand_def,
+)
+
+
+@irdl_attr_definition
+class TokenType(ParametrizedAttribute, TypeAttribute):
+    """
+    Async token type for launched accelerator requests.
+    """
+
+    name = "acc.token"
+
+
+@irdl_attr_definition
+class StateType(ParametrizedAttribute, TypeAttribute):
+    """
+    Used to trace an accelerators CSR state through def-use chain
+    """
+
+    name = "acc.state"
+
+    accelerator: ParameterDef[StringAttr]
+
+
+@irdl_op_definition
+class LaunchOp(IRDLOperation):
+    """
+    Launch an accelerator. This acts as a barrier for CSR values,
+    meaning CSRs can be safely modified after a launch op without
+    interfering with the Accelerator.
+    """
+
+    name = "acc.launch"
+
+    accelerator = prop_def(StringAttr)
+
+    token = result_def()
+
+    def verify_(self) -> None:
+        # that the token is used
+        if len(self.token.uses) != 1 or not isinstance(
+            next(iter(self.token.uses)).operation, AwaitOp
+        ):
+            raise VerifyException("Launch token must be used by exactly one await op")
+        # TODO: allow use in control flow
+
+
+@irdl_op_definition
+class AwaitOp(IRDLOperation):
+    name = "acc.await"
+
+    token = operand_def(TokenType)
+
+
+@irdl_op_definition
+class SetupOp(IRDLOperation):
+    name = "acc.setup"
+
+    values = var_operand_def(Attribute)  # TODO: make more precise?
+    """
+    The actual values used to set up the CSRs
+    """
+
+    in_state = opt_operand_def(StateType)
+    """
+    The state produced by a previous acc.setup
+    """
+
+    out_state = result_def(StateType)
+    """
+    The CSR state after the setup op modified it.
+    """
+
+    param_names = prop_def(ArrayAttr[StringAttr])
+    """
+    Maps the SSA values in `values` to accelerator parameter names
+    """
+
+    accelerator = prop_def(StringAttr)
+    """
+    Name of the accelerator this setup is for
+    """
+
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
+    def __init__(
+        self,
+        vals: Sequence[SSAValue],
+        param_names: Sequence[str],
+        accelerator: str | StringAttr,
+        in_state: SSAValue | Operation | None = None,
+    ):
+        if not isinstance(accelerator, StringAttr):
+            accelerator = StringAttr(accelerator)
+
+        super().__init__(
+            operands=[vals, in_state],
+            properties={
+                "param_names": ArrayAttr([StringAttr(x) for x in param_names]),
+                "accelerator": accelerator,
+            },
+            result_types=[StateType((accelerator,))],
+        )
+
+    def iter_params(self) -> Iterable[tuple[str, SSAValue]]:
+        return zip((p.data for p in self.param_names), self.values)
+
+    def verify_(self) -> None:
+        # that accelerator on input matches output
+        if self.in_state is not None:
+            if self.in_state.type != self.out_state.type:
+                raise VerifyException("Input and output state accelerators must match")
+        if self.accelerator != self.out_state.type.accelerator:
+            raise VerifyException(
+                "Output state accelerator and accelerator the "
+                "operations property must match"
+            )
+
+        # that len(values) == len(param_names)
+        if len(self.values) != len(self.param_names):
+            raise ValueError(
+                "Must have received same number of values as parameter names"
+            )
+
+        # that a state is not used twice
+        if len(self.out_state.uses) > 1:
+            raise VerifyException("States must be used at most once")
+
+
+ACC = Dialect(
+    "acc",
+    [
+        SetupOp,
+        LaunchOp,
+        AwaitOp,
+    ],
+    [
+        StateType,
+        TokenType,
+    ],
+)

--- a/compiler/dialects/acc.py
+++ b/compiler/dialects/acc.py
@@ -64,7 +64,9 @@ class LaunchOp(IRDLOperation):
         # that the state and my accelerator match
         assert isinstance(self.state.type, StateType)
         if self.state.type.accelerator != self.accelerator:
-            raise VerifyException("The state's accelerator does not match the launch accelerator!")
+            raise VerifyException(
+                "The state's accelerator does not match the launch accelerator!"
+            )
 
         # that the token is used
         if len(self.token.uses) != 1 or not isinstance(
@@ -79,6 +81,7 @@ class AwaitOp(IRDLOperation):
     """
     Blocks until the launched operation finishes.
     """
+
     name = "acc.await"
 
     token = operand_def(TokenType)

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -4,8 +4,10 @@ from collections.abc import Sequence
 from xdsl.ir import MLContext
 from xdsl.xdsl_opt_main import xDSLOptMain
 
+from compiler.dialects.acc import ACC
 from compiler.dialects.snax import Snax
 from compiler.dialects.tsl import TSL
+from compiler.transforms.acc_cse import AccCse
 from compiler.transforms.clear_memory_space import ClearMemorySpace
 from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
@@ -38,6 +40,7 @@ class SNAXOptMain(xDSLOptMain):
         ## Add custom dialects & passes
         self.ctx.load_dialect(Snax)
         self.ctx.load_dialect(TSL)
+        self.ctx.load_dialect(ACC)
         super().register_pass(DispatchKernels.name, lambda: DispatchKernels)
         super().register_pass(LinalgToLibraryCall.name, lambda: LinalgToLibraryCall)
         super().register_pass(SetMemorySpace.name, lambda: SetMemorySpace)
@@ -51,6 +54,7 @@ class SNAXOptMain(xDSLOptMain):
             RealizeMemrefCastsPass.name, lambda: RealizeMemrefCastsPass
         )
         super().register_pass(MemrefToSNAX.name, lambda: MemrefToSNAX)
+        super().register_pass(AccCse.name, lambda: AccCse)
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/transforms/acc_cse.py
+++ b/compiler/transforms/acc_cse.py
@@ -46,6 +46,15 @@ class SimplifyRedundantSetupCalls(RewritePattern):
 
         # Step 3: If no new params remain, elide the whole op
         if not new_params:
+            # This only happens when:
+            #  1) The operation has no input state, and
+            #  2) The operation has no parameters it sets
+            if op.in_state is None:
+                # in this case, we can't elide the operation if it's output state is used
+                # otherwise we would break stuff. So we just assume that a setup without
+                # parameters returns an "empty" state that assumes nothing.
+                return
+
             op.out_state.replace_by(op.in_state)
             rewriter.erase_matched_op()
             return

--- a/compiler/transforms/acc_cse.py
+++ b/compiler/transforms/acc_cse.py
@@ -44,7 +44,7 @@ class YeetSetupStuff(RewritePattern):
             (name, val) for name, val in op.iter_params() if prev_state.get(name) != val
         ]
 
-        # Step 3: If no new params remain, yeet the whole op
+        # Step 3: If no parameters change, the whole op can be erased
         if not new_params:
             op.out_state.replace_by(op.in_state)
             rewriter.erase_matched_op()

--- a/compiler/transforms/acc_cse.py
+++ b/compiler/transforms/acc_cse.py
@@ -47,10 +47,6 @@ class YeetSetupStuff(RewritePattern):
         # Step 3: If no new params remain, yeet the whole op
         if not new_params:
             op.out_state.replace_by(op.in_state)
-            print("about to erase")
-            print(prev_state)
-            print(op)
-            print(new_params)
             rewriter.erase_matched_op()
             return
 

--- a/compiler/transforms/acc_cse.py
+++ b/compiler/transforms/acc_cse.py
@@ -25,7 +25,7 @@ def get_state_before(op: acc.SetupOp) -> dict[str, SSAValue]:
         if not isinstance(parent, acc.SetupOp):
             raise RuntimeError("We can't handle this yet")
 
-        for name, val in op.iter_params():
+        for name, val in parent.iter_params():
             if name not in state:
                 state[name] = val
 
@@ -47,10 +47,14 @@ class YeetSetupStuff(RewritePattern):
         # Step 3: If no new params remain, yeet the whole op
         if not new_params:
             op.out_state.replace_by(op.in_state)
+            print("about to erase")
+            print(prev_state)
+            print(op)
+            print(new_params)
             rewriter.erase_matched_op()
             return
 
-        # Step 4: If no parameters change, we are a no-op
+        # Step 4: If all parameters change, we are a no-op
         if len(new_params) == len(op.param_names):
             return
 

--- a/compiler/transforms/acc_cse.py
+++ b/compiler/transforms/acc_cse.py
@@ -50,9 +50,9 @@ class SimplifyRedundantSetupCalls(RewritePattern):
             #  1) The operation has no input state, and
             #  2) The operation has no parameters it sets
             if op.in_state is None:
-                # in this case, we can't elide the operation if it's output state is used
-                # otherwise we would break stuff. So we just assume that a setup without
-                # parameters returns an "empty" state that assumes nothing.
+                # in this case, we can't elide the operation if it's output state is
+                # used otherwise we would break stuff. So we just assume that a setup
+                # without parameters returns an "empty" state that assumes nothing.
                 return
 
             op.out_state.replace_by(op.in_state)

--- a/compiler/transforms/acc_cse.py
+++ b/compiler/transforms/acc_cse.py
@@ -1,0 +1,78 @@
+from xdsl.dialects import builtin
+from xdsl.ir import MLContext, SSAValue
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+from compiler.dialects import acc
+
+
+def get_state_before(op: acc.SetupOp) -> dict[str, SSAValue]:
+    """
+    Walk the def-use chain up and return a dictionary representing which
+    parameter is currently set to which value before `op` is encountered.
+    """
+    state: dict[str, SSAValue] = {}
+
+    while op.in_state is not None:
+        parent = op.in_state.owner
+
+        # TODO: handle more stuff here later
+        if not isinstance(parent, acc.SetupOp):
+            raise RuntimeError("We can't handle this yet")
+
+        for name, val in op.iter_params():
+            if name not in state:
+                state[name] = val
+
+        op = parent
+    return state
+
+
+class YeetSetupStuff(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: acc.SetupOp, rewriter: PatternRewriter, /):
+        # Step 1: Figure out previous state
+        prev_state = get_state_before(op)
+
+        # Step 2: Yeet out redundant stuff
+        new_params: list[tuple[str, SSAValue]] = [
+            (name, val) for name, val in op.iter_params() if prev_state.get(name) != val
+        ]
+
+        # Step 3: If no new params remain, yeet the whole op
+        if not new_params:
+            op.out_state.replace_by(op.in_state)
+            rewriter.erase_matched_op()
+            return
+
+        # Step 4: If no parameters change, we are a no-op
+        if len(new_params) == len(op.param_names):
+            return
+
+        # Step 5: Replace matched op with reduced version
+        rewriter.replace_matched_op(
+            acc.SetupOp(
+                [val for _, val in new_params],
+                [param for param, _ in new_params],
+                op.accelerator,
+                op.in_state,
+            )
+        )
+
+
+class AccCse(ModulePass):
+    """
+    Common subexpression elimination for the `acc` (accelerator) dialect.
+
+    This pass analyzes the accelerator
+    """
+
+    name = "acc-cse"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(YeetSetupStuff()).rewrite_module(op)

--- a/compiler/transforms/acc_cse.py
+++ b/compiler/transforms/acc_cse.py
@@ -50,7 +50,7 @@ class YeetSetupStuff(RewritePattern):
             rewriter.erase_matched_op()
             return
 
-        # Step 4: If all parameters change, we are a no-op
+        # Step 4: If all parameters change, do nothing
         if len(new_params) == len(op.param_names):
             return
 

--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -1,0 +1,20 @@
+from xdsl.dialects import builtin, test
+from xdsl.dialects.builtin import StringAttr
+
+from compiler.dialects import acc
+
+
+def test_acc_setup():
+    one, two = test.TestOp(result_types=[builtin.i32, builtin.i32]).results
+
+    setup1 = acc.SetupOp([one, two], ["A", "B"], "acc1")
+    setup1.verify()
+
+    assert setup1.accelerator == StringAttr("acc1")
+
+    setup2 = acc.SetupOp(setup1.values, ["A", "B"], setup1.accelerator, setup1)
+    setup2.verify()
+
+    assert setup2.accelerator == setup1.accelerator
+    assert isinstance(setup2.out_state.type, acc.StateType)
+    assert setup2.out_state.type.accelerator == setup1.accelerator

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -9,7 +9,7 @@ func.func @test() {
         operandSegmentSizes = array<i32: 2, 0>
     }> : (i32, i32) -> !acc.state<"acc1">
 
-    %token = "acc.launch"() <{accelerator = "acc1"}>: () -> !acc.token
+    %token = "acc.launch"(%state) <{accelerator = "acc1"}>: (!acc.state<"acc1">) -> !acc.token
 
     %state2 = "acc.setup"(%one, %two, %state) <{
         param_names = ["A", "B"],
@@ -27,7 +27,7 @@ func.func @test() {
 // CHECK-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:     %state = "acc.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc.state<"acc1">
-// CHECK-NEXT:     %token = "acc.launch"() <{"accelerator" = "acc1"}> : () -> !acc.token
+// CHECK-NEXT:     %token = "acc.launch"(%state) <{"accelerator" = "acc1"}> : (!acc.state<"acc1">) -> !acc.token
 // CHECK-NEXT:     %state2 = "acc.setup"(%one, %two, %state) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 1>}> : (i32, i32, !acc.state<"acc1">) -> !acc.state<"acc1">
 // CHECK-NEXT:     "acc.await"(%token) : (!acc.token) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -11,14 +11,11 @@ func.func @test() {
 
     %token = "acc.launch"() <{accelerator = "acc1"}>: () -> !acc.token
 
-    %state2 = "acc.setup"(%one, %one, %state) <{
+    %state2 = "acc.setup"(%one, %two, %state) <{
         param_names = ["A", "B"],
         accelerator = "acc1",
         operandSegmentSizes = array<i32: 2, 1>
     }> : (i32, i32, !acc.state<"acc1">) -> !acc.state<"acc1">
-
-
-    "acc.setup"(..., %state2)
 
     "acc.await"(%token) : (!acc.token) -> ()
 

--- a/tests/filecheck/transforms/acc-cse.mlir
+++ b/tests/filecheck/transforms/acc-cse.mlir
@@ -1,4 +1,4 @@
-// RUN: snax-opt -p acc-cse
+// RUN: ./compiler/snax-opt %s -p acc-cse
 
 func.func @test() {
     %one, %two = "test.op"() : () -> (i32, i32)
@@ -30,14 +30,14 @@ func.func @test() {
     func.return
 }
 
-// CHECK-NEXT: "builtin.module"() ({
-// CHECK-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
+// CHECK-NEXT: builtin.module {
+// CHECK-NEXT:   func.func @test() {
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:     %state = "acc.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc.state<"acc1">
 // CHECK-NEXT:     %token = "acc.launch"() <{"accelerator" = "acc1"}> : () -> !acc.token
 // CHECK-NEXT:     %state2 = "acc.setup"(%one, %state) <{"param_names" = ["B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 1, 1>}> : (i32, !acc.state<"acc1">) -> !acc.state<"acc1">
 // CHECK-NEXT:     "acc.await"(%token) : (!acc.token) -> ()
 // CHECK-NEXT:     "test.op"(%state2) : (!acc.state<"acc1">) -> ()
-// CHECK-NEXT:     "func.return"() : () -> ()
-// CHECK-NEXT:   }) : () -> ()
-// CHECK-NEXT: }) : () -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/tests/filecheck/transforms/acc-cse.mlir
+++ b/tests/filecheck/transforms/acc-cse.mlir
@@ -1,0 +1,23 @@
+// RUN: snax-opt -p acc-cse
+
+func.func @test() {
+    %one, %two = "test.op"() : () -> (i32, i32)
+
+    %state = "acc.setup"(%one, %two) <{
+        param_names = ["A", "B"],
+        accelerator = "acc1",
+        operandSegmentSizes = array<i32: 2, 0>
+    }> : (i32, i32) -> !acc.state<"acc1">
+
+    %token = "acc.launch"() <{accelerator = "acc1"}>: () -> !acc.token
+
+    %state2 = "acc.setup"(%one, %two, %state) <{
+        param_names = ["A", "B"],
+        accelerator = "acc1",
+        operandSegmentSizes = array<i32: 2, 1>
+    }> : (i32, i32, !acc.state<"acc1">) -> !acc.state<"acc1">
+
+    "acc.await"(%token) : (!acc.token) -> ()
+
+    func.return
+}

--- a/tests/filecheck/transforms/acc-cse.mlir
+++ b/tests/filecheck/transforms/acc-cse.mlir
@@ -1,4 +1,4 @@
-// RUN: ./compiler/snax-opt %s -p acc-cse
+// RUN: ./compiler/snax-opt %s -p acc-cse | filecheck %s
 
 func.func @test() {
     %one, %two = "test.op"() : () -> (i32, i32)
@@ -9,7 +9,7 @@ func.func @test() {
         operandSegmentSizes = array<i32: 2, 0>
     }> : (i32, i32) -> !acc.state<"acc1">
 
-    %token = "acc.launch"() <{accelerator = "acc1"}>: () -> !acc.token
+    %token = "acc.launch"(%state) <{accelerator = "acc1"}> : (!acc.state<"acc1">) -> !acc.token
 
     %state2 = "acc.setup"(%one, %one, %state) <{
         param_names = ["A", "B"],
@@ -34,7 +34,7 @@ func.func @test() {
 // CHECK-NEXT:   func.func @test() {
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:     %state = "acc.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc.state<"acc1">
-// CHECK-NEXT:     %token = "acc.launch"() <{"accelerator" = "acc1"}> : () -> !acc.token
+// CHECK-NEXT:     %token = "acc.launch"(%state) <{"accelerator" = "acc1"}> : (!acc.state<"acc1">) -> !acc.token
 // CHECK-NEXT:     %state2 = "acc.setup"(%one, %state) <{"param_names" = ["B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 1, 1>}> : (i32, !acc.state<"acc1">) -> !acc.state<"acc1">
 // CHECK-NEXT:     "acc.await"(%token) : (!acc.token) -> ()
 // CHECK-NEXT:     "test.op"(%state2) : (!acc.state<"acc1">) -> ()

--- a/tests/filecheck/transforms/acc-cse.mlir
+++ b/tests/filecheck/transforms/acc-cse.mlir
@@ -30,13 +30,14 @@ func.func @test() {
     func.return
 }
 
-// CHECK-NEXT: builtin.module {
-// CHECK-NEXT:   func.func @test() {
+// CHECK-NEXT: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:     %state = "acc.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc.state<"acc1">
 // CHECK-NEXT:     %token = "acc.launch"() <{"accelerator" = "acc1"}> : () -> !acc.token
+// CHECK-NEXT:     %state2 = "acc.setup"(%one, %state) <{"param_names" = ["B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 1, 1>}> : (i32, !acc.state<"acc1">) -> !acc.state<"acc1">
 // CHECK-NEXT:     "acc.await"(%token) : (!acc.token) -> ()
-// CHECK-NEXT:     "test.op"(%state) : (!acc.state<"acc1">) -> ()
-// CHECK-NEXT:     func.return
-// CHECK-NEXT:   }
-// CHECK-NEXT: }
+// CHECK-NEXT:     "test.op"(%state2) : (!acc.state<"acc1">) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/transforms/acc-cse.mlir
+++ b/tests/filecheck/transforms/acc-cse.mlir
@@ -11,7 +11,13 @@ func.func @test() {
 
     %token = "acc.launch"() <{accelerator = "acc1"}>: () -> !acc.token
 
-    %state2 = "acc.setup"(%one, %two, %state) <{
+    %state2 = "acc.setup"(%one, %one, %state) <{
+        param_names = ["A", "B"],
+        accelerator = "acc1",
+        operandSegmentSizes = array<i32: 2, 1>
+    }> : (i32, i32, !acc.state<"acc1">) -> !acc.state<"acc1">
+
+    %state3 = "acc.setup"(%one, %one, %state2) <{
         param_names = ["A", "B"],
         accelerator = "acc1",
         operandSegmentSizes = array<i32: 2, 1>
@@ -19,5 +25,18 @@ func.func @test() {
 
     "acc.await"(%token) : (!acc.token) -> ()
 
+    "test.op"(%state3) : (!acc.state<"acc1">) -> ()
+
     func.return
 }
+
+// CHECK-NEXT: builtin.module {
+// CHECK-NEXT:   func.func @test() {
+// CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
+// CHECK-NEXT:     %state = "acc.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc.state<"acc1">
+// CHECK-NEXT:     %token = "acc.launch"() <{"accelerator" = "acc1"}> : () -> !acc.token
+// CHECK-NEXT:     "acc.await"(%token) : (!acc.token) -> ()
+// CHECK-NEXT:     "test.op"(%state) : (!acc.state<"acc1">) -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }


### PR DESCRIPTION
`acc` dialect: (snax) accelerator setup and dispatch code, used to represent setup, launching and waiting for accelerator calls.

`acc-cse` pass: elide redundant setup operations from IR.