### PR TITLE
Lower linalg to acc2 dialect

### DIFF
--- a/compiler/dialects/acc.py
+++ b/compiler/dialects/acc.py
@@ -1,14 +1,29 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 from xdsl.dialects.builtin import ArrayAttr, StringAttr
-from xdsl.ir import (Attribute, Dialect, Operation, ParametrizedAttribute,
-                     SSAValue, TypeAttribute)
-from xdsl.irdl import (AttrSizedOperandSegments, IRDLOperation, ParameterDef,
-                       VerifyException, irdl_attr_definition,
-                       irdl_op_definition, operand_def, opt_operand_def,
-                       prop_def, result_def, var_operand_def)
+from xdsl.ir import (
+    Attribute,
+    Dialect,
+    Operation,
+    ParametrizedAttribute,
+    SSAValue,
+    TypeAttribute,
+)
+from xdsl.irdl import (
+    AttrSizedOperandSegments,
+    IRDLOperation,
+    ParameterDef,
+    VerifyException,
+    irdl_attr_definition,
+    irdl_op_definition,
+    operand_def,
+    opt_operand_def,
+    prop_def,
+    result_def,
+    var_operand_def,
+)
 
 
 @irdl_attr_definition
@@ -133,8 +148,8 @@ class SetupOp(IRDLOperation):
 
     def __init__(
         self,
-        vals: Sequence[SSAValue | Operation],
-        param_names: Sequence[str] | Sequence[StringAttr],
+        vals: Iterable[SSAValue | Operation],
+        param_names: Iterable[str] | Iterable[StringAttr],
         accelerator: str | StringAttr,
         in_state: SSAValue | Operation | None = None,
     ):

--- a/compiler/inference/trace_acc_state.py
+++ b/compiler/inference/trace_acc_state.py
@@ -1,0 +1,69 @@
+"""
+This inference helpers are used to figure out which values are
+present at which points in the IR.
+
+Example inference results:
+
+```
+acc.setup(A = %1, B = %2)  // previous state = {}
+// ...
+acc.setup(A = %3, C = %1)  // previous state = {A = %1, B = %2}
+```
+
+These inference passes walk the IR backwards.
+"""
+
+from xdsl.dialects import scf
+from xdsl.ir import Block, SSAValue
+
+from compiler.dialects import acc
+
+State = dict[str, SSAValue]
+
+
+def infer_state_of(state_var: SSAValue) -> State:
+    """
+    Entrance function of the inference pass.
+
+    This walks up the def-use chain to compute all values
+    that are guaranteed to be set in this state.
+    """
+    owner = state_var.owner
+    match owner:
+        case acc.SetupOp(in_state=None) as setup_op:
+            return {name: val for name, val in setup_op.iter_params()}
+        case acc.SetupOp(in_state=st) as setup_op if st is not None:
+            in_state = infer_state_of(st)
+            in_state.update(dict(setup_op.iter_params()))
+            return in_state
+        case scf.If() as if_op:
+            return state_union(*infer_states_for_if(if_op, state_var))
+        case Block():
+            # TODO: maybe implement something here?
+            return {}
+        case _:
+            raise ValueError(f"Cannot infer state for op {owner.name}")
+
+
+def infer_states_for_if(op: scf.If, state: SSAValue) -> tuple[State, State]:
+    """
+    Walk both sides of the if/else block and return the computed
+    states for the given state SSA value (`state`)
+    """
+    assert state in op.results, "Expected state to be one of the scf.if results!"
+    idx = op.results.index(state)
+
+    states = []
+    for region in op.regions:
+        # we know the last op must be the yield
+        yield_op = region.block.last_op
+        assert isinstance(yield_op, scf.Yield)
+        # we know the yield op has the same number of operands as the
+        # scf.if has results, so [idx] must be defined
+        states.append(infer_state_of(yield_op.operands[idx]))
+    assert len(states) == 2
+    return tuple(states)
+
+
+def state_union(a: State, b: State) -> State:
+    return {k: a[k] for k in a if a[k] == b[k]}

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -8,6 +8,7 @@ from compiler.dialects.acc import ACC
 from compiler.dialects.snax import Snax
 from compiler.dialects.tsl import TSL
 from compiler.transforms.acc_cse import AccCse
+from compiler.transforms.convert_linalg_to_acc import ConvertLinalgToAccPass
 from compiler.transforms.clear_memory_space import ClearMemorySpace
 from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
@@ -55,6 +56,7 @@ class SNAXOptMain(xDSLOptMain):
         )
         super().register_pass(MemrefToSNAX.name, lambda: MemrefToSNAX)
         super().register_pass(AccCse.name, lambda: AccCse)
+        super().register_pass(ConvertLinalgToAccPass.name, lambda: ConvertLinalgToAccPass)
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -8,8 +8,8 @@ from compiler.dialects.acc import ACC
 from compiler.dialects.snax import Snax
 from compiler.dialects.tsl import TSL
 from compiler.transforms.acc_cse import AccCse
-from compiler.transforms.convert_linalg_to_acc import ConvertLinalgToAccPass
 from compiler.transforms.clear_memory_space import ClearMemorySpace
+from compiler.transforms.convert_linalg_to_acc import ConvertLinalgToAccPass
 from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
 from compiler.transforms.insert_sync_barrier import InsertSyncBarrier
@@ -56,7 +56,9 @@ class SNAXOptMain(xDSLOptMain):
         )
         super().register_pass(MemrefToSNAX.name, lambda: MemrefToSNAX)
         super().register_pass(AccCse.name, lambda: AccCse)
-        super().register_pass(ConvertLinalgToAccPass.name, lambda: ConvertLinalgToAccPass)
+        super().register_pass(
+            ConvertLinalgToAccPass.name, lambda: ConvertLinalgToAccPass
+        )
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/transforms/acc_cse.py
+++ b/compiler/transforms/acc_cse.py
@@ -1,8 +1,12 @@
 from xdsl.dialects import builtin
 from xdsl.ir import MLContext, SSAValue
 from xdsl.passes import ModulePass
-from xdsl.pattern_rewriter import (PatternRewriter, PatternRewriteWalker,
-                                   RewritePattern, op_type_rewrite_pattern)
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
 
 from compiler.dialects import acc
 from compiler.inference.trace_acc_state import infer_state_of

--- a/compiler/transforms/acc_cse.py
+++ b/compiler/transforms/acc_cse.py
@@ -1,4 +1,4 @@
-from xdsl.dialects import builtin
+from xdsl.dialects import builtin, scf
 from xdsl.ir import MLContext, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -20,6 +20,10 @@ def get_state_before(op: acc.SetupOp) -> dict[str, SSAValue]:
 
     while op.in_state is not None:
         parent = op.in_state.owner
+
+        if isinstance(parent, scf.If):
+            # TODO: implement
+            return {}
 
         # TODO: handle more stuff here later
         if not isinstance(parent, acc.SetupOp):

--- a/compiler/transforms/convert_linalg_to_acc.py
+++ b/compiler/transforms/convert_linalg_to_acc.py
@@ -1,0 +1,220 @@
+import itertools
+
+from dataclasses import dataclass, field
+from typing import Sequence
+from xdsl.ir import Operation, MLContext, SSAValue, Region, Block
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import PatternRewriter, RewritePattern, op_type_rewrite_pattern, PatternRewriteWalker
+from compiler.dialects import acc
+from xdsl.dialects import linalg, builtin, arith, memref, func, scf
+
+
+class AcceleratorConfig:
+    name = "snax_hwpe_mult"
+
+    fields = (
+        'A', 'B', 'O', 'size'
+    )
+
+    def generate_vals(self, op: linalg.Generic) -> Sequence[tuple[Sequence[Operation], SSAValue]]:
+        """
+        Produce a `Sequence[Operation], SSAValue` tuple for each field that contains:
+
+        - a list of operations that calculate the field value
+        - a reference to the SSAValue containing the calculated field value
+        """
+        a, b, c = op.operands
+
+        zero = arith.Constant.from_int_and_width(0, builtin.IndexType())
+        dim = memref.Dim.from_source_and_index(a, zero)
+        size = [zero, dim], dim.result
+
+        ptrs = [
+            (
+                [ptr := memref.ExtractAlignedPointerAsIndexOp.get(ref)],
+                ptr.aligned_pointer
+            ) for ref in (a, b, c)
+        ]
+
+        return ptrs + [size]
+
+
+@dataclass
+class ConvertLinalgToAcceleratorPattern(RewritePattern):
+    module: builtin.ModuleOp
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: linalg.Generic, rewriter: PatternRewriter, /):
+        if op.library_call is None:
+            return
+
+        if op.library_call.data != 'snax_hwpe_mult':
+            return
+
+        # grab accelerator
+        accelerator = AcceleratorConfig()
+
+        # grab arguments
+        args = accelerator.generate_vals(op)
+
+        # insert ops to calculate arguments
+        for new_ops, _ in args:
+            rewriter.insert_op_before_matched_op(new_ops)
+
+        # instantiate setup call
+        rewriter.insert_op_before_matched_op(
+            setup := acc.SetupOp([val for _, val in args], accelerator.fields, accelerator.name)
+        )
+
+        # launch
+        rewriter.insert_op_before_matched_op(
+            token := acc.LaunchOp(setup)
+        )
+
+        # await
+        rewriter.replace_matched_op(
+            acc.AwaitOp(token)
+        )
+
+@dataclass
+class ConnectStatesThroughControlFlowPattern(RewritePattern):
+    walked_funcs: set[str] = field(default_factory=set)
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, func_op: func.FuncOp, rewriter: PatternRewriter, /):
+        if func_op.sym_name.data in self.walked_funcs:
+            return
+        self.walked_funcs.add(func_op.sym_name.data)
+        _walk(func_op, {}, rewriter)
+
+
+def _walk(container: Region | Operation, state: dict[str, SSAValue], rewriter: PatternRewriter) -> dict[str, SSAValue]:
+    if isinstance(container, Operation):
+        regions = container.regions
+    else:
+        regions = [container]
+
+    for region in regions:
+        for block in region.blocks:
+            for op in block.ops:
+                # arith, memref, linalg and test ops are not relevant to accelerator setup
+                if op.name.split('.')[0] in ('arith', 'memref', 'linalg', 'test'):
+                    continue
+                # handle acc2 dialect ops:
+                elif op.name.startswith('acc2.'):
+                    # the setup op is the only relevant one for now:
+                    if isinstance(op, acc.SetupOp):
+                        accel = op.accelerator.data
+                        if accel in state and op.in_state != state[accel]:
+                            new_op = acc.SetupOp(
+                                op.values,
+                                op.param_names,
+                                op.accelerator,
+                                state[accel],
+                            )
+                            rewriter.replace_op(op, new_op)
+                            op = new_op
+                        state[accel] = op.out_state
+                    else:
+                        pass
+                elif isinstance(op, scf.If):
+                    if_state = _walk(op.true_region, state.copy(), rewriter)
+                    else_state = _walk(op.false_region, state.copy(), rewriter)
+
+                    delta = calc_if_state_delta(state, if_state, else_state)
+                    if not delta:
+                        continue
+                    # grab a list of added return vals for both if branch and else branch
+                    new_vals: tuple[tuple[SSAValue, ...], ...] = (
+                        tuple(if_val   for if_val, _   in delta.values()),
+                        tuple(else_val for _, else_val in delta.values()),
+                    )
+                    # somehow rewrite this fucker
+                    for branch, added_vals in zip(op.regions, new_vals):
+                        assert isinstance(branch, Region)
+                        if not branch.blocks:
+                            branch.add_block(Block([scf.Yield(*added_vals)]))
+                        else:
+                            rewriter.replace_op(
+                                branch.block.last_op,
+                                scf.Yield(*branch.block.last_op.operands, *added_vals)
+                            )
+
+                    num_scf_results = len(op.results)
+                    rewriter.replace_op(
+                        op, new_if := scf.If(
+                            op.cond,
+                            [val.type for val in (*op.results, *new_vals[0])],
+                            op.detach_region(op.regions[0]),
+                            # trust me, this is correct. The previous line removes
+                            # the block from the list
+                            op.detach_region(op.regions[0])
+                        ),
+                        [new_if.results[i] for i in range(num_scf_results)]
+                    )
+                    # update state:
+                    for res in new_if.results[num_scf_results:]:
+                        state[res.type.accelerator.data] = res
+
+                # calling another function invalidates all states
+                elif isinstance(op, func.Call):
+                    state.clear()
+                elif isinstance(op, (func.Return, scf.Yield)):
+                    continue
+                else:
+                    raise RuntimeError(f"What is a {op}?")
+    return state
+
+
+def calc_if_state_delta(old_state: dict[str, SSAValue], if_state: dict[str, SSAValue], else_state: dict[str, SSAValue]) -> dict[str, tuple[SSAValue, SSAValue]]:
+    """
+    Given three state dictionaries (mapping accelerator names
+    to SSA vals containing their state, return a new dict that:
+
+    - Contains tuples (if_branch_val, else_branch_val)
+    - For all accelerators whose state val changed in *at least
+      one* of the branches
+    - And for all accelerator states that got introduced in *both*
+      branches
+
+    """
+    new_state: dict[str, tuple[SSAValue, SSAValue]] = {}
+
+    # for every key in the old state, find out if it changed
+    for k in old_state:
+        # get new vals (or None if dropped)
+        new_vals = (
+            if_state.pop(k, None),
+            else_state.pop(k, None),
+        )
+        # drop val if it is invalidated on one side
+        if any(v is None for v in new_vals):
+            continue
+        # if no val changed
+        if all(v == old_state[k] for v in new_vals):
+            continue
+        new_state[k] = new_vals
+
+    # check for states that are present in both branches
+    for k in if_state:
+        if k not in else_state:
+            continue
+        # add them to the new dict
+        new_state[k] = (if_state[k], else_state[k])
+
+    return new_state
+
+
+
+
+class ConvertLinalgToAccPass(ModulePass):
+    name = "convert-linalg-to-acc"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(ConvertLinalgToAcceleratorPattern(op)).rewrite_module(op)
+        # run these strictly sequentially, otherwise stuff breaks
+        PatternRewriteWalker(ConnectStatesThroughControlFlowPattern()).rewrite_module(op)
+
+
+
+
+

--- a/compiler/transforms/convert_linalg_to_acc.py
+++ b/compiler/transforms/convert_linalg_to_acc.py
@@ -192,7 +192,7 @@ def _walk(
                     state.clear()
                 # arith, memref, linalg and test ops are not relevant to
                 # accelerator setup, so we can skip them
-                elif op.dialect_name() in ("arith", "memref", "linalg", "test"):
+                elif op.dialect_name() in ("arith", "memref", "linalg", "test", "acc2"):
                     continue
                 # these ops are specifically whitelisted:
                 elif isinstance(op, func.Return | scf.Yield):

--- a/compiler/transforms/convert_linalg_to_acc.py
+++ b/compiler/transforms/convert_linalg_to_acc.py
@@ -175,7 +175,7 @@ def _walk(
                 # calling another function invalidates all states
                 elif isinstance(op, func.Call):
                     state.clear()
-                elif isinstance(op, (func.Return, scf.Yield)):
+                elif isinstance(op, func.Return | scf.Yield):
                     continue
                 else:
                     raise RuntimeError(f"What is a {op}?")

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -14,7 +14,7 @@ GENTRACE      = /opt/snitch_cluster/util/trace/gen_trace.py
 MLIROPT       = mlir-opt-17
 MLIRTRANSLATE = mlir-translate-17
 SNAXOPT       = $(MAKEFILE_RULES_DIRNAME)/../compiler/snax-opt
-PYTHON        = /opt/python3.11/bin/python3
+PYTHON        = python3
 TFLITE_TO_TOSA = $(MAKEFILE_RULES_DIRNAME)/tflite_to_tosa.py
 
 # Mixing .c and .ll files makes some flags, useful for the former,

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1,38 +1,35 @@
 // RUN: XDSL_ROUNDTRIP
 
-acc.accelerator @acc1 {"A" = 42 : i32, "B" = 69 : i32, "C" = 420 : i32}
-
 func.func @test() {
     %one, %two = "test.op"() : () -> (i32, i32)
 
-    %state = "acc.setup"(%one, %two) <{
+    %state = "acc2.setup"(%one, %two) <{
         param_names = ["A", "B"],
         accelerator = "acc1",
         operandSegmentSizes = array<i32: 2, 0>
-    }> : (i32, i32) -> !acc.state<"acc1">
+    }> : (i32, i32) -> !acc2.state<"acc1">
 
-    %token = "acc.launch"(%state) <{accelerator = "acc1"}>: (!acc.state<"acc1">) -> !acc.token
+    %token = "acc2.launch"(%state) <{accelerator = "acc1"}>: (!acc2.state<"acc1">) -> !acc2.token
 
-    %state2 = "acc.setup"(%one, %two, %state) <{
+    %state2 = "acc2.setup"(%one, %two, %state) <{
         param_names = ["A", "B"],
         accelerator = "acc1",
         operandSegmentSizes = array<i32: 2, 1>
-    }> : (i32, i32, !acc.state<"acc1">) -> !acc.state<"acc1">
+    }> : (i32, i32, !acc2.state<"acc1">) -> !acc2.state<"acc1">
 
-    "acc.await"(%token) : (!acc.token) -> ()
+    "acc2.await"(%token) : (!acc2.token) -> ()
 
     func.return
 }
 
 
 // CHECK-NEXT: "builtin.module"() ({
-// CHECK-NEXT:   "acc.accelerator"() <{"name" = @acc1, "fields" = {"A" = 42 : i32, "B" = 69 : i32, "C" = 420 : i32}}>
 // CHECK-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
-// CHECK-NEXT:     %state = "acc.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc.state<"acc1">
-// CHECK-NEXT:     %token = "acc.launch"(%state) <{"accelerator" = "acc1"}> : (!acc.state<"acc1">) -> !acc.token
-// CHECK-NEXT:     %state2 = "acc.setup"(%one, %two, %state) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 1>}> : (i32, i32, !acc.state<"acc1">) -> !acc.state<"acc1">
-// CHECK-NEXT:     "acc.await"(%token) : (!acc.token) -> ()
+// CHECK-NEXT:     %state = "acc2.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc2.state<"acc1">
+// CHECK-NEXT:     %token = "acc2.launch"(%state) <{"accelerator" = "acc1"}> : (!acc2.state<"acc1">) -> !acc2.token
+// CHECK-NEXT:     %state2 = "acc2.setup"(%one, %two, %state) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 1>}> : (i32, i32, !acc2.state<"acc1">) -> !acc2.state<"acc1">
+// CHECK-NEXT:     "acc2.await"(%token) : (!acc2.token) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1,5 +1,7 @@
 // RUN: XDSL_ROUNDTRIP
 
+acc.accelerator @acc1 {"A" = 42 : i32, "B" = 69 : i32, "C" = 420 : i32}
+
 func.func @test() {
     %one, %two = "test.op"() : () -> (i32, i32)
 
@@ -24,6 +26,7 @@ func.func @test() {
 
 
 // CHECK-NEXT: "builtin.module"() ({
+// CHECK-NEXT:   "acc.accelerator"() <{"name" = @acc1, "fields" = {"A" = 42 : i32, "B" = 69 : i32, "C" = 420 : i32}}>
 // CHECK-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:     %state = "acc.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc.state<"acc1">

--- a/tests/filecheck/transforms/acc-cse.mlir
+++ b/tests/filecheck/transforms/acc-cse.mlir
@@ -3,29 +3,29 @@
 func.func @test() {
     %one, %two = "test.op"() : () -> (i32, i32)
 
-    %state = "acc.setup"(%one, %two) <{
+    %state = "acc2.setup"(%one, %two) <{
         param_names = ["A", "B"],
         accelerator = "acc1",
         operandSegmentSizes = array<i32: 2, 0>
-    }> : (i32, i32) -> !acc.state<"acc1">
+    }> : (i32, i32) -> !acc2.state<"acc1">
 
-    %token = "acc.launch"(%state) <{accelerator = "acc1"}> : (!acc.state<"acc1">) -> !acc.token
+    %token = "acc2.launch"(%state) <{accelerator = "acc1"}> : (!acc2.state<"acc1">) -> !acc2.token
 
-    %state2 = "acc.setup"(%one, %one, %state) <{
+    %state2 = "acc2.setup"(%one, %one, %state) <{
         param_names = ["A", "B"],
         accelerator = "acc1",
         operandSegmentSizes = array<i32: 2, 1>
-    }> : (i32, i32, !acc.state<"acc1">) -> !acc.state<"acc1">
+    }> : (i32, i32, !acc2.state<"acc1">) -> !acc2.state<"acc1">
 
-    %state3 = "acc.setup"(%one, %one, %state2) <{
+    %state3 = "acc2.setup"(%one, %one, %state2) <{
         param_names = ["A", "B"],
         accelerator = "acc1",
         operandSegmentSizes = array<i32: 2, 1>
-    }> : (i32, i32, !acc.state<"acc1">) -> !acc.state<"acc1">
+    }> : (i32, i32, !acc2.state<"acc1">) -> !acc2.state<"acc1">
 
-    "acc.await"(%token) : (!acc.token) -> ()
+    "acc2.await"(%token) : (!acc2.token) -> ()
 
-    "test.op"(%state3) : (!acc.state<"acc1">) -> ()
+    "test.op"(%state3) : (!acc2.state<"acc1">) -> ()
 
     func.return
 }
@@ -33,11 +33,11 @@ func.func @test() {
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   func.func @test() {
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
-// CHECK-NEXT:     %state = "acc.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc.state<"acc1">
-// CHECK-NEXT:     %token = "acc.launch"(%state) <{"accelerator" = "acc1"}> : (!acc.state<"acc1">) -> !acc.token
-// CHECK-NEXT:     %state2 = "acc.setup"(%one, %state) <{"param_names" = ["B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 1, 1>}> : (i32, !acc.state<"acc1">) -> !acc.state<"acc1">
-// CHECK-NEXT:     "acc.await"(%token) : (!acc.token) -> ()
-// CHECK-NEXT:     "test.op"(%state2) : (!acc.state<"acc1">) -> ()
+// CHECK-NEXT:     %state = "acc2.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc2.state<"acc1">
+// CHECK-NEXT:     %token = "acc2.launch"(%state) <{"accelerator" = "acc1"}> : (!acc2.state<"acc1">) -> !acc2.token
+// CHECK-NEXT:     %state2 = "acc2.setup"(%one, %state) <{"param_names" = ["B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 1, 1>}> : (i32, !acc2.state<"acc1">) -> !acc2.state<"acc1">
+// CHECK-NEXT:     "acc2.await"(%token) : (!acc2.token) -> ()
+// CHECK-NEXT:     "test.op"(%state2) : (!acc2.state<"acc1">) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/convert-linalg-to-acc.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-acc.mlir
@@ -2,84 +2,56 @@
 // RUN: ./compiler/snax-opt -p convert-linalg-to-acc,mlir-opt[cse,canonicalize],acc-cse %s | filecheck %s
 
 "builtin.module"() ({
-    func.func public @simple_mult(%A: memref<?xi32>,
-                                 %B: memref<?xi32>,
-                                 %D: memref<?xi32>) -> () {
-      linalg.generic {
-          indexing_maps = [
-            affine_map<(n) -> (n)>,
-            affine_map<(n) -> (n)>,
-            affine_map<(n) -> (n)>
-          ],
-          iterator_types = ["parallel"],
-          library_call = "snax_hwpe_mult"
-      } ins(%A, %B: memref<?xi32>, memref<?xi32>)
-        outs(%D: memref<?xi32>) {
-      ^bb0(%a: i32, %b: i32, %d: i32):
-        %r0 = arith.muli %a, %b : i32
-        linalg.yield %r0 : i32
-      }
-
-      %i1 = "test.op"() : () -> i1
-
-      %v_final = "scf.if"(%i1) ({
-        linalg.generic {
-          indexing_maps = [
-            affine_map<(n) -> (n)>,
-            affine_map<(n) -> (n)>,
-            affine_map<(n) -> (n)>
-          ],
-          iterator_types = ["parallel"],
-          library_call = "snax_hwpe_mult"
-        } ins(%A, %B: memref<?xi32>, memref<?xi32>)
-          outs(%D: memref<?xi32>) {
-        ^bb0(%a: i32, %b: i32, %d: i32):
-            %r0 = arith.muli %a, %b : i32
-            linalg.yield %r0 : i32
-        }
-        %v1 = "test.op"() : () -> i32
-
-        scf.yield %v1 : i32
-      }, {
-        %v2 = "test.op"() : () -> i32
-
-        linalg.generic {
-          indexing_maps = [
-            affine_map<(n) -> (n)>,
-            affine_map<(n) -> (n)>,
-            affine_map<(n) -> (n)>
-          ],
-          iterator_types = ["parallel"],
-          library_call = "snax_hwpe_mult"
-        } ins(%A, %B: memref<?xi32>, memref<?xi32>)
-          outs(%D: memref<?xi32>) {
-        ^bb0(%a: i32, %b: i32, %d: i32):
-            %r0 = arith.muli %a, %b : i32
-            linalg.yield %r0 : i32
-        }
-
-        scf.yield %v2 : i32
-      }) : (i1) -> i32
-
-      "test.op"(%v_final) : (i32) -> ()
-
-      linalg.generic {
-          indexing_maps = [
-            affine_map<(n) -> (n)>,
-            affine_map<(n) -> (n)>,
-            affine_map<(n) -> (n)>
-          ],
-          iterator_types = ["parallel"],
-          library_call = "snax_hwpe_mult"
-      } ins(%A, %D: memref<?xi32>, memref<?xi32>)
-        outs(%B: memref<?xi32>) {
-      ^bb0(%a: i32, %b: i32, %d: i32):
-        %r0 = arith.muli %a, %b : i32
-        linalg.yield %r0 : i32
-      }
-
-      return
+  func.func public @simple_mult(
+    %A: memref<?xi32>,
+    %B: memref<?xi32>,
+    %D: memref<?xi32>
+  ) -> () {
+    linalg.generic { indexing_maps = [], iterator_types = ["parallel"], library_call = "snax_hwpe_mult" }
+    ins(%A, %B: memref<?xi32>, memref<?xi32>)
+      outs(%D: memref<?xi32>) {
+    ^bb0(%a: i32, %b: i32, %d: i32):
+      %r0 = arith.muli %a, %b : i32
+      linalg.yield %r0 : i32
     }
+
+    %i1 = "test.op"() : () -> i1
+
+    %v_final = "scf.if"(%i1) ({
+
+      linalg.generic { indexing_maps = [], iterator_types = ["parallel"], library_call = "snax_hwpe_mult" }
+      ins(%A, %B: memref<?xi32>, memref<?xi32>) outs(%D: memref<?xi32>) {
+      ^bb0(%a: i32, %b: i32, %d: i32):
+          %r0 = arith.muli %a, %b : i32
+          linalg.yield %r0 : i32
+      }
+      %v1 = "test.op"() : () -> i32
+
+      scf.yield %v1 : i32
+    }, {
+      %v2 = "test.op"() : () -> i32
+
+      linalg.generic { indexing_maps = [], iterator_types = ["parallel"], library_call = "snax_hwpe_mult" }
+      ins(%A, %B: memref<?xi32>, memref<?xi32>) outs(%D: memref<?xi32>) {
+      ^bb0(%a: i32, %b: i32, %d: i32):
+          %r0 = arith.muli %a, %b : i32
+          linalg.yield %r0 : i32
+      }
+
+      scf.yield %v2 : i32
+    }) : (i1) -> i32
+
+    "test.op"(%v_final) : (i32) -> ()
+
+    linalg.generic { indexing_maps = [], iterator_types = ["parallel"], library_call = "snax_hwpe_mult" }
+    ins(%A, %D: memref<?xi32>, memref<?xi32>) outs(%B: memref<?xi32>) {
+    ^bb0(%a: i32, %b: i32, %d: i32):
+      %r0 = arith.muli %a, %b : i32
+      linalg.yield %r0 : i32
+    }
+
+    func.return
+  }
 }): () -> ()
 
 

--- a/tests/filecheck/transforms/convert-linalg-to-acc.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-acc.mlir
@@ -1,0 +1,73 @@
+// RUN: ./compiler/snax-opt -p convert-linalg-to-acc,mlir-opt[cse],acc-cse %s | filecheck %s
+
+"builtin.module"() ({
+    func.func public @simple_mult(%A: memref<?xi32>,
+                                 %B: memref<?xi32>,
+                                 %D: memref<?xi32>) -> () {
+      linalg.generic {
+          indexing_maps = [
+            affine_map<(n) -> (n)>,
+            affine_map<(n) -> (n)>,
+            affine_map<(n) -> (n)>
+          ],
+          iterator_types = ["parallel"],
+          library_call = "snax_hwpe_mult"
+      } ins(%A, %B: memref<?xi32>, memref<?xi32>)
+        outs(%D: memref<?xi32>) {
+      ^bb0(%a: i32, %b: i32, %d: i32):
+        %r0 = arith.muli %a, %b : i32
+        linalg.yield %r0 : i32
+      }
+
+      %i1 = "test.op"() : () -> i1
+
+      %v_final = "scf.if"(%i1) ({
+            %s = "acc2.setup"() <{accelerator = "snax_hwpe_mult", param_names = [], operandSegmentSizes = array<i32: 0, 0>}> : () -> !acc2.state<"snax_hwpe_mult">
+            %v1 = "test.op"() : () -> i32
+
+            scf.yield %v1 : i32
+      }, {
+            %v2 = "test.op"() : () -> i32
+            %s2 = "acc2.setup"() <{accelerator = "snax_hwpe_mult", param_names = [], operandSegmentSizes = array<i32: 0, 0>}> : () -> !acc2.state<"snax_hwpe_mult">
+
+            scf.yield %v2 : i32
+      }) : (i1) -> i32
+
+      "test.op"(%v_final) : (i32) -> ()
+
+      linalg.generic {
+          indexing_maps = [
+            affine_map<(n) -> (n)>,
+            affine_map<(n) -> (n)>,
+            affine_map<(n) -> (n)>
+          ],
+          iterator_types = ["parallel"],
+          library_call = "snax_hwpe_mult"
+      } ins(%A, %D: memref<?xi32>, memref<?xi32>)
+        outs(%B: memref<?xi32>) {
+      ^bb0(%a: i32, %b: i32, %d: i32):
+        %r0 = arith.muli %a, %b : i32
+        linalg.yield %r0 : i32
+      }
+
+      return
+    }
+}): () -> ()
+
+// CHECK-NEXT: builtin.module {
+// CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
+// CHECK-NEXT:     %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %2 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %3 = arith.constant 0 : index
+// CHECK-NEXT:     %4 = "memref.dim"(%arg0, %3) : (memref<?xi32>, index) -> index
+// CHECK-NEXT:     %5 = "acc2.setup"(%0, %1, %2, %4) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     %6 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+// CHECK-NEXT:     "acc2.await"(%6) : (!acc2.token) -> ()
+// CHECK-NEXT:     "test.op"() : () -> ()
+// CHECK-NEXT:     %7 = "acc2.setup"(%2, %1, %5) <{"param_names" = ["B", "O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 2, 1>}> : (index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     %8 = "acc2.launch"(%7) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+// CHECK-NEXT:     "acc2.await"(%8) : (!acc2.token) -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/tests/filecheck/transforms/convert-linalg-to-acc.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-acc.mlir
@@ -1,4 +1,5 @@
-// RUN: ./compiler/snax-opt -p convert-linalg-to-acc,mlir-opt[cse],acc-cse %s | filecheck %s
+// XFAIL: *
+// RUN: ./compiler/snax-opt -p convert-linalg-to-acc,mlir-opt[cse,canonicalize],acc-cse %s | filecheck %s
 
 "builtin.module"() ({
     func.func public @simple_mult(%A: memref<?xi32>,
@@ -22,15 +23,42 @@
       %i1 = "test.op"() : () -> i1
 
       %v_final = "scf.if"(%i1) ({
-            %s = "acc2.setup"() <{accelerator = "snax_hwpe_mult", param_names = [], operandSegmentSizes = array<i32: 0, 0>}> : () -> !acc2.state<"snax_hwpe_mult">
-            %v1 = "test.op"() : () -> i32
+        linalg.generic {
+          indexing_maps = [
+            affine_map<(n) -> (n)>,
+            affine_map<(n) -> (n)>,
+            affine_map<(n) -> (n)>
+          ],
+          iterator_types = ["parallel"],
+          library_call = "snax_hwpe_mult"
+        } ins(%A, %B: memref<?xi32>, memref<?xi32>)
+          outs(%D: memref<?xi32>) {
+        ^bb0(%a: i32, %b: i32, %d: i32):
+            %r0 = arith.muli %a, %b : i32
+            linalg.yield %r0 : i32
+        }
+        %v1 = "test.op"() : () -> i32
 
-            scf.yield %v1 : i32
+        scf.yield %v1 : i32
       }, {
-            %v2 = "test.op"() : () -> i32
-            %s2 = "acc2.setup"() <{accelerator = "snax_hwpe_mult", param_names = [], operandSegmentSizes = array<i32: 0, 0>}> : () -> !acc2.state<"snax_hwpe_mult">
+        %v2 = "test.op"() : () -> i32
 
-            scf.yield %v2 : i32
+        linalg.generic {
+          indexing_maps = [
+            affine_map<(n) -> (n)>,
+            affine_map<(n) -> (n)>,
+            affine_map<(n) -> (n)>
+          ],
+          iterator_types = ["parallel"],
+          library_call = "snax_hwpe_mult"
+        } ins(%A, %B: memref<?xi32>, memref<?xi32>)
+          outs(%D: memref<?xi32>) {
+        ^bb0(%a: i32, %b: i32, %d: i32):
+            %r0 = arith.muli %a, %b : i32
+            linalg.yield %r0 : i32
+        }
+
+        scf.yield %v2 : i32
       }) : (i1) -> i32
 
       "test.op"(%v_final) : (i32) -> ()
@@ -54,20 +82,33 @@
     }
 }): () -> ()
 
+
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
-// CHECK-NEXT:     %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
-// CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
-// CHECK-NEXT:     %2 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
-// CHECK-NEXT:     %3 = arith.constant 0 : index
-// CHECK-NEXT:     %4 = "memref.dim"(%arg0, %3) : (memref<?xi32>, index) -> index
-// CHECK-NEXT:     %5 = "acc2.setup"(%0, %1, %2, %4) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     %0 = arith.constant 0 : index
+// CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %2 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %3 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %4 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
+// CHECK-NEXT:     %5 = "acc2.setup"(%1, %2, %3, %4) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index) -> !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     %6 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
 // CHECK-NEXT:     "acc2.await"(%6) : (!acc2.token) -> ()
-// CHECK-NEXT:     "test.op"() : () -> ()
-// CHECK-NEXT:     %7 = "acc2.setup"(%2, %1, %5) <{"param_names" = ["B", "O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 2, 1>}> : (index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:     %8 = "acc2.launch"(%7) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
-// CHECK-NEXT:     "acc2.await"(%8) : (!acc2.token) -> ()
+// CHECK-NEXT:     %7 = "test.op"() : () -> i1
+// CHECK-NEXT:     %8, %9 = "scf.if"(%7) ({
+// CHECK-NEXT:       %10 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+// CHECK-NEXT:       "acc2.await"(%10) : (!acc2.token) -> ()
+// CHECK-NEXT:       %11 = "test.op"() : () -> i32
+// CHECK-NEXT:       scf.yield %11, %5 : i32, !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     }, {
+// CHECK-NEXT:       %12 = "test.op"() : () -> i32
+// CHECK-NEXT:       %13 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+// CHECK-NEXT:       "acc2.await"(%13) : (!acc2.token) -> ()
+// CHECK-NEXT:       scf.yield %12, %5 : i32, !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     }) : (i1) -> (i32, !acc2.state<"snax_hwpe_mult">)
+// CHECK-NEXT:     "test.op"(%8) : (i32) -> ()
+// CHECK-NEXT:     %14 = "acc2.setup"(%3, %2, %9) <{"param_names" = ["B", "O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 2, 1>}> : (index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     %15 = "acc2.launch"(%14) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+// CHECK-NEXT:     "acc2.await"(%15) : (!acc2.token) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/inference/test_acc_state_tracing.py
+++ b/tests/inference/test_acc_state_tracing.py
@@ -2,8 +2,7 @@ from xdsl.dialects import builtin, scf
 from xdsl.ir import BlockArgument
 
 from compiler.dialects import acc
-from compiler.inference.trace_acc_state import (infer_state_of,
-                                                infer_states_for_if)
+from compiler.inference.trace_acc_state import infer_state_of, infer_states_for_if
 
 ACC = "acc1"
 

--- a/tests/inference/test_acc_state_tracing.py
+++ b/tests/inference/test_acc_state_tracing.py
@@ -1,0 +1,41 @@
+from xdsl.dialects import builtin, scf
+from xdsl.ir import BlockArgument
+
+from compiler.dialects import acc
+from compiler.inference.trace_acc_state import (infer_state_of,
+                                                infer_states_for_if)
+
+ACC = "acc1"
+
+
+def test_simple_setup_tracing():
+    a, b, c = tuple(BlockArgument(builtin.i32, None, i) for i in range(3))
+
+    empty_setup = acc.SetupOp([], [], ACC)
+
+    full_setup = acc.SetupOp([a, b, c], ["A", "B", "C"], ACC, empty_setup)
+
+    assert infer_state_of(empty_setup.out_state) == {}
+
+    assert infer_state_of(full_setup.out_state) == {"A": a, "B": b, "C": c}
+
+    # construct if block that sets state
+    if_block = scf.If(
+        a,
+        [acc.StateType("acc1")],
+        [
+            s1 := acc.SetupOp([b], ["A"], ACC, full_setup),
+            scf.Yield(s1),
+        ],
+        [
+            s2 := acc.SetupOp([c], ["B"], ACC, full_setup),
+            scf.Yield(s2),
+        ],
+    )
+
+    assert infer_states_for_if(if_block, if_block.results[0]) == (
+        {"A": b, "B": b, "C": c},  # if block
+        {"A": a, "B": c, "C": c},  # else block
+    )
+
+    assert infer_state_of(if_block.results[0]) == {"C": c}


### PR DESCRIPTION
This PR contains:

 - Rename `acc` to `acc2`, as `acc` is already used for the openACC dialect in MLIR
 - A new `convert-linalg-to-acc` pass:
    - That converts linalg annotated with `library_call = "snax_hwpe_mult"` to acc2 dialect ops
    - That then connects the `!acc2.state` ssa values through the IR such that they conform to the control flow (currently handles `scf.if` but not `scf.for`)
 - Improvements to the `acc-cse` pass that is now able to infer states through `scf.if` ops. 
 - A test that depends on `mlir-opt` passes, we marked it `XFAIL` for now until we can update to a commit of xDSL that contains xdslproject/xdsl#2293