### PR TITLE
Improve acc dialect optimizations

### DIFF
--- a/compiler/dialects/acc.py
+++ b/compiler/dialects/acc.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 from xdsl.dialects.builtin import ArrayAttr, StringAttr
 from xdsl.ir import (

--- a/compiler/dialects/acc.py
+++ b/compiler/dialects/acc.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 
 from xdsl.dialects.builtin import ArrayAttr, StringAttr
 from xdsl.ir import (

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -7,7 +7,7 @@ from xdsl.xdsl_opt_main import xDSLOptMain
 from compiler.dialects.acc import ACC
 from compiler.dialects.snax import Snax
 from compiler.dialects.tsl import TSL
-from compiler.transforms.acc_cse import AccCse
+from compiler.transforms.acc_cse import AccDeduplicate
 from compiler.transforms.clear_memory_space import ClearMemorySpace
 from compiler.transforms.convert_linalg_to_acc import ConvertLinalgToAccPass
 from compiler.transforms.dispatch_kernels import DispatchKernels
@@ -55,7 +55,7 @@ class SNAXOptMain(xDSLOptMain):
             RealizeMemrefCastsPass.name, lambda: RealizeMemrefCastsPass
         )
         super().register_pass(MemrefToSNAX.name, lambda: MemrefToSNAX)
-        super().register_pass(AccCse.name, lambda: AccCse)
+        super().register_pass(AccDeduplicate.name, lambda: AccDeduplicate)
         super().register_pass(
             ConvertLinalgToAccPass.name, lambda: ConvertLinalgToAccPass
         )

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -7,7 +7,7 @@ from xdsl.xdsl_opt_main import xDSLOptMain
 from compiler.dialects.acc import ACC
 from compiler.dialects.snax import Snax
 from compiler.dialects.tsl import TSL
-from compiler.transforms.acc_cse import AccDeduplicate
+from compiler.transforms.acc_dedup import AccDeduplicate
 from compiler.transforms.clear_memory_space import ClearMemorySpace
 from compiler.transforms.convert_linalg_to_acc import ConvertLinalgToAccPass
 from compiler.transforms.dispatch_kernels import DispatchKernels

--- a/compiler/transforms/acc_cse.py
+++ b/compiler/transforms/acc_cse.py
@@ -1,12 +1,8 @@
 from xdsl.dialects import builtin
 from xdsl.ir import MLContext, SSAValue
 from xdsl.passes import ModulePass
-from xdsl.pattern_rewriter import (
-    PatternRewriter,
-    PatternRewriteWalker,
-    RewritePattern,
-    op_type_rewrite_pattern,
-)
+from xdsl.pattern_rewriter import (PatternRewriter, PatternRewriteWalker,
+                                   RewritePattern, op_type_rewrite_pattern)
 
 from compiler.dialects import acc
 from compiler.inference.trace_acc_state import infer_state_of

--- a/compiler/transforms/acc_cse.py
+++ b/compiler/transforms/acc_cse.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from xdsl.dialects import builtin, scf
 from xdsl.ir import MLContext, OpResult, SSAValue
 from xdsl.passes import ModulePass

--- a/compiler/transforms/acc_cse.py
+++ b/compiler/transforms/acc_cse.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from xdsl.dialects import builtin, scf
 from xdsl.ir import MLContext, OpResult, SSAValue
 from xdsl.passes import ModulePass
@@ -123,12 +124,10 @@ class HoistSetupCallsIntoConditionals(RewritePattern):
         rewriter.erase_matched_op()
 
 
-class AccCse(ModulePass):
+class AccDeduplicate(ModulePass):
     """
-    Common subexpression elimination for the `acc` (accelerator) dialect.
-
-    This pass rewrites acc dialect operations to find and simplify redundant
-    setup calls.
+    Reduce the number of parameters in setup calls by inferring previously
+    set up values and carefully moving setup calls around.
     """
 
     name = "acc-dedup"

--- a/compiler/transforms/acc_cse.py
+++ b/compiler/transforms/acc_cse.py
@@ -1,7 +1,8 @@
-from xdsl.dialects import builtin
-from xdsl.ir import MLContext, SSAValue
+from xdsl.dialects import builtin, scf
+from xdsl.ir import MLContext, OpResult, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
     PatternRewriter,
     PatternRewriteWalker,
     RewritePattern,
@@ -53,6 +54,75 @@ class SimplifyRedundantSetupCalls(RewritePattern):
         )
 
 
+class HoistSetupCallsIntoConditionals(RewritePattern):
+    """
+    Hoists setup calls into scf.if blocks.
+
+    This will never result in additional setup calls and only
+    reduced the number of fields that are set up.
+    (proof left as an exercise to the reader)
+
+    Things we need to worry about:
+
+    - not inserting a setup op before the originally produced state
+      is launched.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: acc.SetupOp, rewriter: PatternRewriter, /):
+        # do not apply if our in_state is not an scf.if
+        if op.in_state is None or not isinstance(op.in_state.owner, scf.If):
+            return
+        # grab some helper vars
+        old_in_state = op.in_state
+        assert isinstance(old_in_state, OpResult)
+
+        # Step 1: Check that it's legal to move:
+        uses = tuple(
+            use for use in op.in_state.uses if isinstance(use.operation, acc.LaunchOp)
+        )
+        # if we have some launch ops, we need to investigate further:
+        if len(uses) > 0:
+            # if there is a launch outside the scf.if
+            launch_op = uses[0].operation
+            # check that it is in the same block (if not bail out)
+            # TODO: better check this case?
+            if launch_op.parent_block() is not op.parent_block():
+                return
+            # if we share a block, figure out index and compare:
+            block = launch_op.parent_block()
+            assert block is not None
+            # launch op index < our index => we have a launch between us and the if
+            # that means we can't hoist.
+            if block.get_operation_index(launch_op) < block.get_operation_index(op):
+                return
+
+        # Step 2: Clone the op into the end of both branches
+        for region in op.in_state.owner.regions:
+            # grab the yield op:
+            yield_op = region.block.last_op
+            assert isinstance(yield_op, scf.Yield)
+            new_in_state = yield_op.operands[old_in_state.index]
+
+            # insert a copy of the setup op but replace the
+            # original in_state with the yielded state of the region
+            rewriter.insert_op_before(
+                new_setup := op.clone(value_mapper={op.in_state: new_in_state}),
+                yield_op,
+            )
+            # replace the yield op with a new yield op that yields the
+            # newly produced state
+            rewriter.replace_op(
+                yield_op,
+                yield_op.clone(value_mapper={new_in_state: new_setup.out_state}),
+            )
+
+        # erase the op, replacing all uses of its out state by
+        # its in_state.
+        op.out_state.replace_by(op.in_state)
+        rewriter.erase_matched_op()
+
+
 class AccCse(ModulePass):
     """
     Common subexpression elimination for the `acc` (accelerator) dialect.
@@ -61,7 +131,15 @@ class AccCse(ModulePass):
     setup calls.
     """
 
-    name = "acc-cse"
+    name = "acc-dedup"
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
-        PatternRewriteWalker(SimplifyRedundantSetupCalls()).rewrite_module(op)
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    HoistSetupCallsIntoConditionals(),
+                    SimplifyRedundantSetupCalls(),
+                ]
+            ),
+            walk_reverse=True,
+        ).rewrite_module(op)

--- a/compiler/transforms/acc_cse.py
+++ b/compiler/transforms/acc_cse.py
@@ -1,8 +1,12 @@
 from xdsl.dialects import builtin
 from xdsl.ir import MLContext, SSAValue
 from xdsl.passes import ModulePass
-from xdsl.pattern_rewriter import (PatternRewriter, PatternRewriteWalker,
-                                   RewritePattern, op_type_rewrite_pattern)
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
 
 from compiler.dialects import acc
 from compiler.inference.trace_acc_state import infer_state_of

--- a/compiler/transforms/acc_dedup.py
+++ b/compiler/transforms/acc_dedup.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+
 from xdsl.dialects import builtin, scf
 from xdsl.ir import MLContext, OpResult, SSAValue
 from xdsl.passes import ModulePass

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1,5 +1,7 @@
 // RUN: XDSL_ROUNDTRIP
 
+acc.accelerator @acc1 {"A" = 42 : i32, "B" = 69 : i32, "C" = 420 : i32}
+
 func.func @test() {
     %one, %two = "test.op"() : () -> (i32, i32)
 
@@ -24,6 +26,7 @@ func.func @test() {
 
 
 // CHECK-NEXT: "builtin.module"() ({
+// CHECK-NEXT:   "acc.accelerator"() <{"name" = @acc1, "fields" = {"A" = 42 : i32, "B" = 69 : i32, "C" = 420 : i32}}>
 // CHECK-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:     %state = "acc2.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc2.state<"acc1">

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1,7 +1,5 @@
 // RUN: XDSL_ROUNDTRIP
 
-acc.accelerator @acc1 {"A" = 42 : i32, "B" = 69 : i32, "C" = 420 : i32}
-
 func.func @test() {
     %one, %two = "test.op"() : () -> (i32, i32)
 
@@ -26,7 +24,6 @@ func.func @test() {
 
 
 // CHECK-NEXT: "builtin.module"() ({
-// CHECK-NEXT:   "acc.accelerator"() <{"name" = @acc1, "fields" = {"A" = 42 : i32, "B" = 69 : i32, "C" = 420 : i32}}>
 // CHECK-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:     %state = "acc2.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc2.state<"acc1">

--- a/tests/filecheck/transforms/acc-cse.mlir
+++ b/tests/filecheck/transforms/acc-cse.mlir
@@ -1,4 +1,4 @@
-// RUN: ./compiler/snax-opt %s -p acc-cse | filecheck %s
+// RUN: ./compiler/snax-opt %s -p acc-dedup | filecheck %s
 
 func.func @test() {
     %one, %two = "test.op"() : () -> (i32, i32)

--- a/tests/filecheck/transforms/acc-cse.mlir
+++ b/tests/filecheck/transforms/acc-cse.mlir
@@ -1,43 +1,91 @@
 // RUN: ./compiler/snax-opt %s -p acc-dedup | filecheck %s
 
-func.func @test() {
-    %one, %two = "test.op"() : () -> (i32, i32)
+func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
+  %0 = arith.constant 0 : index
+  %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
+  %2 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
+  %3 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
+  %4 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
 
-    %state = "acc2.setup"(%one, %two) <{
-        param_names = ["A", "B"],
-        accelerator = "acc1",
-        operandSegmentSizes = array<i32: 2, 0>
-    }> : (i32, i32) -> !acc2.state<"acc1">
+  %5 = "acc2.setup"(%1, %2, %3, %4) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index) -> !acc2.state<"snax_hwpe_mult">
+  %6 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+  "acc2.await"(%6) : (!acc2.token) -> ()
 
-    %token = "acc2.launch"(%state) <{accelerator = "acc1"}> : (!acc2.state<"acc1">) -> !acc2.token
+  %7 = "test.op"() : () -> i1
 
-    %state2 = "acc2.setup"(%one, %one, %state) <{
-        param_names = ["A", "B"],
-        accelerator = "acc1",
-        operandSegmentSizes = array<i32: 2, 1>
-    }> : (i32, i32, !acc2.state<"acc1">) -> !acc2.state<"acc1">
+  %8, %9 = "scf.if"(%7) ({
+    %10 = "acc2.setup"(%1, %3, %3, %4, %5) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+    %11 = "acc2.launch"(%10) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+    "acc2.await"(%11) : (!acc2.token) -> ()
 
-    %state3 = "acc2.setup"(%one, %one, %state2) <{
-        param_names = ["A", "B"],
-        accelerator = "acc1",
-        operandSegmentSizes = array<i32: 2, 1>
-    }> : (i32, i32, !acc2.state<"acc1">) -> !acc2.state<"acc1">
+    %12 = "test.op"() : () -> i32
+    scf.yield %12, %10 : i32, !acc2.state<"snax_hwpe_mult">
+  }, {
+    %13 = "test.op"() : () -> i32
 
-    "acc2.await"(%token) : (!acc2.token) -> ()
+    %14 = "acc2.setup"(%1, %2, %3, %4, %5) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+    %15 = "acc2.launch"(%14) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+    "acc2.await"(%15) : (!acc2.token) -> ()
 
-    "test.op"(%state3) : (!acc2.state<"acc1">) -> ()
+    scf.yield %13, %14 : i32, !acc2.state<"snax_hwpe_mult">
+  }) : (i1) -> (i32, !acc2.state<"snax_hwpe_mult">)
 
-    func.return
+  "test.op"(%8) : (i32) -> ()
+
+  %16 = "acc2.setup"(%1, %3, %2, %4, %9) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+  %17 = "acc2.launch"(%16) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+  "acc2.await"(%17) : (!acc2.token) -> ()
+
+  func.return
 }
 
+
 // CHECK-NEXT: builtin.module {
-// CHECK-NEXT:   func.func @test() {
-// CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
-// CHECK-NEXT:     %state = "acc2.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc2.state<"acc1">
-// CHECK-NEXT:     %token = "acc2.launch"(%state) <{"accelerator" = "acc1"}> : (!acc2.state<"acc1">) -> !acc2.token
-// CHECK-NEXT:     %state2 = "acc2.setup"(%one, %state) <{"param_names" = ["B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 1, 1>}> : (i32, !acc2.state<"acc1">) -> !acc2.state<"acc1">
-// CHECK-NEXT:     "acc2.await"(%token) : (!acc2.token) -> ()
-// CHECK-NEXT:     "test.op"(%state2) : (!acc2.state<"acc1">) -> ()
+// CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
+// CHECK-NEXT:     %0 = arith.constant 0 : index
+// CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %2 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %3 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %4 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
+
+                   // Full setup:
+
+// CHECK-NEXT:     %5 = "acc2.setup"(%1, %2, %3, %4) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     %6 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+// CHECK-NEXT:     "acc2.await"(%6) : (!acc2.token) -> ()
+// CHECK-NEXT:     %7 = "test.op"() : () -> i1
+// CHECK-NEXT:     %8, %9 = "scf.if"(%7) ({
+
+                     // Elide A and O setups:
+
+// CHECK-NEXT:       %10 = "acc2.setup"(%3, %5) <{"param_names" = ["B"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       %11 = "acc2.launch"(%10) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+// CHECK-NEXT:       "acc2.await"(%11) : (!acc2.token) -> ()
+// CHECK-NEXT:       %12 = "test.op"() : () -> i32
+
+                     // Hoisted into if, elided A, B
+
+// CHECK-NEXT:       %13 = "acc2.setup"(%2, %10) <{"param_names" = ["O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       scf.yield %12, %13 : i32, !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     }, {
+// CHECK-NEXT:       %14 = "test.op"() : () -> i32
+
+                     // Elide full setup op
+
+// CHECK-NEXT:       %15 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+// CHECK-NEXT:       "acc2.await"(%15) : (!acc2.token) -> ()
+
+                     // Hoisted into if, elided A
+
+// CHECK-NEXT:       %16 = "acc2.setup"(%3, %2, %5) <{"param_names" = ["B", "O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 2, 1>}> : (index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       scf.yield %14, %16 : i32, !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     }) : (i1) -> (i32, !acc2.state<"snax_hwpe_mult">)
+// CHECK-NEXT:     "test.op"(%8) : (i32) -> ()
+
+                   // fully elided setup op
+
+// CHECK-NEXT:     %17 = "acc2.launch"(%9) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+// CHECK-NEXT:     "acc2.await"(%17) : (!acc2.token) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/convert-linalg-to-acc.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-acc.mlir
@@ -1,5 +1,5 @@
 // XFAIL: *
-// RUN: ./compiler/snax-opt -p convert-linalg-to-acc,mlir-opt[cse,canonicalize],acc-cse %s | filecheck %s
+// RUN: ./compiler/snax-opt -p convert-linalg-to-acc,mlir-opt[cse,canonicalize] %s | filecheck %s
 
 "builtin.module"() ({
   func.func public @simple_mult(
@@ -67,21 +67,21 @@
 // CHECK-NEXT:     "acc2.await"(%6) : (!acc2.token) -> ()
 // CHECK-NEXT:     %7 = "test.op"() : () -> i1
 // CHECK-NEXT:     %8, %9 = "scf.if"(%7) ({
-// CHECK-NEXT:       %10 = "acc2.setup"(%3, %5) <{"param_names" = ["B"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       %10 = "acc2.setup"(%1, %3, %3, %4, %5) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:       %11 = "acc2.launch"(%10) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
 // CHECK-NEXT:       "acc2.await"(%11) : (!acc2.token) -> ()
 // CHECK-NEXT:       %12 = "test.op"() : () -> i32
-// CHECK-NEXT:       %13 = "acc2.setup"(%2, %10) <{"param_names" = ["O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:       scf.yield %12, %13 : i32, !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       scf.yield %12, %10 : i32, !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     }, {
-// CHECK-NEXT:       %14 = "test.op"() : () -> i32
-// CHECK-NEXT:       %15 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+// CHECK-NEXT:       %13 = "test.op"() : () -> i32
+// CHECK-NEXT:       %14 = "acc2.setup"(%1, %2, %3, %4, %5) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       %15 = "acc2.launch"(%14) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
 // CHECK-NEXT:       "acc2.await"(%15) : (!acc2.token) -> ()
-// CHECK-NEXT:       %16 = "acc2.setup"(%3, %2, %5) <{"param_names" = ["B", "O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 2, 1>}> : (index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:       scf.yield %14, %16 : i32, !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       scf.yield %13, %14 : i32, !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     }) : (i1) -> (i32, !acc2.state<"snax_hwpe_mult">)
 // CHECK-NEXT:     "test.op"(%8) : (i32) -> ()
-// CHECK-NEXT:     %17 = "acc2.launch"(%9) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+// CHECK-NEXT:     %16 = "acc2.setup"(%1, %3, %2, %4, %9) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     %17 = "acc2.launch"(%16) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
 // CHECK-NEXT:     "acc2.await"(%17) : (!acc2.token) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }

--- a/tests/filecheck/transforms/convert-linalg-to-acc.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-acc.mlir
@@ -81,6 +81,3 @@
 // CHECK-NEXT:     %14 = "acc2.setup"(%3, %2, %9) <{"param_names" = ["B", "O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 2, 1>}> : (index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     %15 = "acc2.launch"(%14) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
 // CHECK-NEXT:     "acc2.await"(%15) : (!acc2.token) -> ()
-// CHECK-NEXT:     func.return
-// CHECK-NEXT:   }
-// CHECK-NEXT: }

--- a/tests/filecheck/transforms/convert-linalg-to-acc.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-acc.mlir
@@ -20,7 +20,7 @@
     %v_final = "scf.if"(%i1) ({
 
       linalg.generic { indexing_maps = [], iterator_types = ["parallel"], library_call = "snax_hwpe_mult" }
-      ins(%A, %B: memref<?xi32>, memref<?xi32>) outs(%D: memref<?xi32>) {
+      ins(%A, %D: memref<?xi32>, memref<?xi32>) outs(%D: memref<?xi32>) {
       ^bb0(%a: i32, %b: i32, %d: i32):
           %r0 = arith.muli %a, %b : i32
           linalg.yield %r0 : i32
@@ -67,17 +67,22 @@
 // CHECK-NEXT:     "acc2.await"(%6) : (!acc2.token) -> ()
 // CHECK-NEXT:     %7 = "test.op"() : () -> i1
 // CHECK-NEXT:     %8, %9 = "scf.if"(%7) ({
-// CHECK-NEXT:       %10 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
-// CHECK-NEXT:       "acc2.await"(%10) : (!acc2.token) -> ()
-// CHECK-NEXT:       %11 = "test.op"() : () -> i32
-// CHECK-NEXT:       scf.yield %11, %5 : i32, !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:     }, {
+// CHECK-NEXT:       %10 = "acc2.setup"(%3, %5) <{"param_names" = ["B"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       %11 = "acc2.launch"(%10) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+// CHECK-NEXT:       "acc2.await"(%11) : (!acc2.token) -> ()
 // CHECK-NEXT:       %12 = "test.op"() : () -> i32
-// CHECK-NEXT:       %13 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
-// CHECK-NEXT:       "acc2.await"(%13) : (!acc2.token) -> ()
-// CHECK-NEXT:       scf.yield %12, %5 : i32, !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       %13 = "acc2.setup"(%2, %10) <{"param_names" = ["O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       scf.yield %12, %13 : i32, !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     }, {
+// CHECK-NEXT:       %14 = "test.op"() : () -> i32
+// CHECK-NEXT:       %15 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+// CHECK-NEXT:       "acc2.await"(%15) : (!acc2.token) -> ()
+// CHECK-NEXT:       %16 = "acc2.setup"(%3, %2, %5) <{"param_names" = ["B", "O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 2, 1>}> : (index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       scf.yield %14, %16 : i32, !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     }) : (i1) -> (i32, !acc2.state<"snax_hwpe_mult">)
 // CHECK-NEXT:     "test.op"(%8) : (i32) -> ()
-// CHECK-NEXT:     %14 = "acc2.setup"(%3, %2, %9) <{"param_names" = ["B", "O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 2, 1>}> : (index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:     %15 = "acc2.launch"(%14) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
-// CHECK-NEXT:     "acc2.await"(%15) : (!acc2.token) -> ()
+// CHECK-NEXT:     %17 = "acc2.launch"(%9) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
+// CHECK-NEXT:     "acc2.await"(%17) : (!acc2.token) -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }


### PR DESCRIPTION
Stacked on top of #103 

This PR:

- Renames `acc-cse` to `acc-dedup` to better reflect what it's doing
- Adds a rewrite to hoist setup calls into `scf.if` operations