### PR TITLE
Add backend for acc2 dialect

### DIFF
--- a/compiler/dialects/acc.py
+++ b/compiler/dialects/acc.py
@@ -236,23 +236,16 @@ class AcceleratorOp(IRDLOperation):
 
     launch_addr = prop_def(IntegerAttr)
 
-    barrier_enable = prop_def(
+    barrier_sw_barrier = prop_def(
         IntegerAttr
     )  # TODO: this will be reworked in a later version
-
-    barrier_trigger = prop_def(
-        IntegerAttr
-    )  # TODO: this will be reworked in a later version
-
-    # TODO: handle the await/poll stuff
 
     def __init__(
         self,
         name: str | StringAttr | SymbolRefAttr,
         fields: dict[str, int] | DictionaryAttr,
         launch: int | IntegerAttr,
-        barrier_enable: int | IntegerAttr,
-        barrier_trigger: int | IntegerAttr,
+        barrier_sw_barrier: int | IntegerAttr,
     ):
         if not isinstance(fields, DictionaryAttr):
             fields = DictionaryAttr(
@@ -270,15 +263,10 @@ class AcceleratorOp(IRDLOperation):
                     if not isinstance(launch, IntegerAttr)
                     else launch
                 ),
-                "barrier_enable": (
-                    IntegerAttr(barrier_enable, i32)
-                    if not isinstance(barrier_enable, IntegerAttr)
-                    else barrier_enable
-                ),
-                "barrier_trigger": (
-                    IntegerAttr(barrier_trigger, i32)
-                    if not isinstance(barrier_trigger, IntegerAttr)
-                    else barrier_trigger
+                "barrier_sw_barrier": (
+                    IntegerAttr(barrier_sw_barrier, i32)
+                    if not isinstance(barrier_sw_barrier, IntegerAttr)
+                    else barrier_sw_barrier
                 ),
             }
         )

--- a/compiler/dialects/acc.py
+++ b/compiler/dialects/acc.py
@@ -236,16 +236,14 @@ class AcceleratorOp(IRDLOperation):
 
     launch_addr = prop_def(IntegerAttr)
 
-    barrier_sw_barrier = prop_def(
-        IntegerAttr
-    )  # TODO: this will be reworked in a later version
+    barrier = prop_def(IntegerAttr)  # TODO: this will be reworked in a later version
 
     def __init__(
         self,
         name: str | StringAttr | SymbolRefAttr,
         fields: dict[str, int] | DictionaryAttr,
         launch: int | IntegerAttr,
-        barrier_sw_barrier: int | IntegerAttr,
+        barrier: int | IntegerAttr,
     ):
         if not isinstance(fields, DictionaryAttr):
             fields = DictionaryAttr(
@@ -263,10 +261,10 @@ class AcceleratorOp(IRDLOperation):
                     if not isinstance(launch, IntegerAttr)
                     else launch
                 ),
-                "barrier_sw_barrier": (
-                    IntegerAttr(barrier_sw_barrier, i32)
-                    if not isinstance(barrier_sw_barrier, IntegerAttr)
-                    else barrier_sw_barrier
+                "barrier": (
+                    IntegerAttr(barrier, i32)
+                    if not isinstance(barrier, IntegerAttr)
+                    else barrier
                 ),
             }
         )

--- a/compiler/dialects/acc.py
+++ b/compiler/dialects/acc.py
@@ -169,7 +169,7 @@ class SetupOp(IRDLOperation):
 
     def __init__(
         self,
-        vals: Iterable[SSAValue | Operation],
+        vals: list[SSAValue | Operation],
         param_names: Iterable[str] | Iterable[StringAttr],
         accelerator: str | StringAttr,
         in_state: SSAValue | Operation | None = None,

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -9,6 +9,7 @@ from compiler.dialects.snax import Snax
 from compiler.dialects.tsl import TSL
 from compiler.transforms.acc_dedup import AccDeduplicate
 from compiler.transforms.clear_memory_space import ClearMemorySpace
+from compiler.transforms.convert_acc_to_csr import ConvertAccToCsrPass
 from compiler.transforms.convert_linalg_to_acc import ConvertLinalgToAccPass
 from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
@@ -59,6 +60,7 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(
             ConvertLinalgToAccPass.name, lambda: ConvertLinalgToAccPass
         )
+        super().register_pass(ConvertAccToCsrPass.name, lambda: ConvertAccToCsrPass)
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/transforms/convert_acc_to_csr.py
+++ b/compiler/transforms/convert_acc_to_csr.py
@@ -128,7 +128,7 @@ class LowerAccAwaitToCsr(LowerAccBasePattern):
                     [],
                     [],
                     [
-                        barrier_sw_barrier := arith.Constant(acc_op.barrier_sw_barrier),
+                        barrier := arith.Constant(acc_op.barrier),
                         zero := arith.Constant(
                             builtin.IntegerAttr.from_int_and_width(0, 32)
                         ),
@@ -138,7 +138,7 @@ class LowerAccAwaitToCsr(LowerAccBasePattern):
                             # =r = store result in A 32- or 64-bit
                             # general-purpose register (depending on the platform XLEN)
                             "=r, I",
-                            [barrier_sw_barrier],
+                            [barrier],
                             [i32],
                             has_side_effects=True,
                         ),

--- a/compiler/transforms/convert_acc_to_csr.py
+++ b/compiler/transforms/convert_acc_to_csr.py
@@ -1,0 +1,223 @@
+from abc import ABC
+from dataclasses import dataclass
+from functools import cache
+
+from xdsl.dialects import arith, builtin, llvm
+from xdsl.dialects.builtin import StringAttr
+from xdsl.ir import MLContext, Operation
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.traits import SymbolTable
+
+from compiler.dialects import acc
+
+
+@dataclass
+class LowerAccPattern(RewritePattern, ABC):
+    """
+    Wraps some common logic to get handles to accelerator ops inside the module.
+    """
+
+    module: builtin.ModuleOp
+
+    @cache
+    def get_acc(self, accelerator: StringAttr) -> acc.AcceleratorOp:
+        """
+        Get a reference to the accelerator
+        """
+        trait = self.module.get_trait(SymbolTable)
+        assert trait is not None
+        acc_op = trait.lookup_symbol(self.module, accelerator)
+        if not isinstance(acc_op, acc.AcceleratorOp):
+            raise RuntimeError(
+                f"Invalid IR: no accelerator op for @{accelerator.data} found in module"
+            )
+        return acc_op
+
+    def __hash__(self):
+        return id(self)
+
+
+class LowerAccSetupToCsr(LowerAccPattern):
+    """
+    Convert setup ops to a series of CSR sets:
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: acc.SetupOp, rewriter: PatternRewriter, /):
+        # grab a dict that translates field names to CSR addresses:
+        field_to_csr = dict(self.get_acc(op.accelerator).field_items())
+
+        # emit the llvm assembly code to set csr values:
+        for field, val in op.iter_params():
+            addr = field_to_csr[field]
+            rewriter.insert_op_before_matched_op(
+                [
+                    addr_val := arith.Constant(addr),
+                    llvm.InlineAsmOp(
+                        [[addr_val, val]],
+                        [[]],
+                        "csrw $0, $1",
+                        "I, r",
+                        has_side_effects=True,
+                    ),
+                ]
+            )
+        # delete the old setup op
+        rewriter.erase_matched_op(safe_erase=False)
+
+
+class LowerAccLaunchToCsr(LowerAccPattern):
+    """
+    Convert launch ops to a single csr set (1)
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: acc.LaunchOp, rewriter: PatternRewriter, /):
+        assert isinstance(op.state.type, acc.StateType)
+        acc_op = self.get_acc(op.state.type.accelerator)
+
+        # insert an op that sets the launch CSR to 1
+        rewriter.replace_matched_op(
+            [
+                addr_val := arith.Constant(acc_op.launch_addr),
+                val := arith.Constant(builtin.IntegerAttr.from_int_and_width(1, 5)),
+                llvm.InlineAsmOp(
+                    [[addr_val, val]],
+                    [[]],
+                    "csrw $0, $1",
+                    # I = any 12 bit immediate, K = any 5 bit immediate
+                    # The K allows LLVM to emit an `csrrwi` instruction,
+                    # which has room for one 5 bit immediate only.
+                    "I, K",
+                    has_side_effects=True,
+                ),
+            ],
+            [op.state],
+            safe_erase=False,
+        )
+
+
+class LowerAccAwaitToCsr(LowerAccPattern):
+    """
+    Lower await ops to a series of CSR sets:
+
+    1: enable barriers
+    2: trigger barrier
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: acc.AwaitOp, rewriter: PatternRewriter, /):
+        assert isinstance(op.token.type, acc.StateType | acc.TokenType)
+        acc_op = self.get_acc(op.token.type.accelerator)
+
+        # TODO: this is a temporary solution that will be reworked eventually
+
+        # emit a barrier_enable, and then a barrier_trigger:
+        rewriter.replace_matched_op(
+            [
+                barrier_enable := arith.Constant(acc_op.barrier_enable),
+                barrier_trigger := arith.Constant(acc_op.barrier_trigger),
+                one := arith.Constant(builtin.IntegerAttr.from_int_and_width(1, 5)),
+                zero := arith.Constant(builtin.IntegerAttr.from_int_and_width(0, 5)),
+                llvm.InlineAsmOp(
+                    [[barrier_enable, one]],
+                    [[]],
+                    "csrw $0, $1",
+                    # I = any 12 bit immediate, K = any 5 bit immediate
+                    # The K allows LLVM to emit an `csrrwi` instruction,
+                    # which has room for one 5 bit immediate only.
+                    "I, K",
+                    has_side_effects=True,
+                ),
+                llvm.InlineAsmOp(
+                    [[barrier_trigger, zero]],
+                    [[]],
+                    "csrw $0, $1",
+                    # I = any 12 bit immediate, K = any 5 bit immediate
+                    # The K allows LLVM to emit an `csrrwi` instruction,
+                    # which has room for one 5 bit immediate only.
+                    "I, K",
+                    has_side_effects=True,
+                ),
+            ],
+            safe_erase=False,
+        )
+
+
+class DeleteAllStates(RewritePattern):
+    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter, /):
+        if any(isinstance(operand.type, acc.StateType) for operand in op.operands):
+            new_op = op.__class__.create(
+                operands=[
+                    operand
+                    for operand in op.operands
+                    if not isinstance(operand.type, acc.StateType)
+                ],
+                result_types=[res.type for res in op.results],
+                properties=op.properties,
+                attributes=op.attributes,
+                successors=op.successors,
+                regions=[reg.clone() for reg in op.regions],
+            )
+            rewriter.replace_op(op, new_op)
+            op = new_op
+
+        if any(isinstance(result.type, acc.StateType) for result in op.results):
+            new_op = op.__class__.create(
+                operands=op.operands,
+                result_types=[
+                    res.type
+                    for res in op.results
+                    if not isinstance(res.type, acc.StateType)
+                ],
+                properties=op.properties,
+                attributes=op.attributes,
+                successors=op.successors,
+                regions=[op.detach_region(reg) for reg in tuple(op.regions)],
+            )
+            new_ops_results = list(new_op.results)[::-1]
+            replace_results_by = [
+                None if isinstance(res.type, acc.StateType) else new_ops_results.pop()
+                for res in op.results
+            ]
+            rewriter.replace_op(op, new_op, new_results=replace_results_by)
+
+
+class RemoveAcceleratorOps(RewritePattern):
+    """
+    Delete all accelerator ops after we lowered the setup ops
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: acc.AcceleratorOp, rewriter: PatternRewriter, /):
+        rewriter.erase_matched_op()
+
+
+class ConvertAccToCsrPass(ModulePass):
+    """
+    Converts acc2 dialect ops to series of SNAX-like csr sets.
+    """
+
+    name = "convert-acc-to-csr"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    LowerAccSetupToCsr(op),
+                    LowerAccLaunchToCsr(op),
+                    LowerAccAwaitToCsr(op),
+                    DeleteAllStates(),
+                ]
+            ),
+            walk_reverse=True,
+        ).rewrite_module(op)
+
+        PatternRewriteWalker(RemoveAcceleratorOps()).rewrite_module(op)

--- a/compiler/transforms/convert_acc_to_csr.py
+++ b/compiler/transforms/convert_acc_to_csr.py
@@ -68,7 +68,7 @@ class LowerAccSetupToCsr(LowerAccBasePattern):
                     addr_val := arith.Constant(addr),
                     llvm.InlineAsmOp(
                         "csrw $0, $1",
-                        "I, r",
+                        "I, rK",
                         [addr_val, val],
                         has_side_effects=True,
                     ),
@@ -154,7 +154,7 @@ class LowerAccAwaitToCsr(LowerAccBasePattern):
                 zero := arith.Constant(builtin.IntegerAttr.from_int_and_width(0, 5)),
                 llvm.InlineAsmOp(
                     "csrw $0, $1",
-                    "I, r",
+                    "I, K",
                     [addr_val, zero],
                     has_side_effects=True,
                 ),

--- a/compiler/transforms/convert_linalg_to_acc.py
+++ b/compiler/transforms/convert_linalg_to_acc.py
@@ -221,7 +221,14 @@ def _walk(
                     state.clear()
                 # arith, memref, linalg and test ops are not relevant to
                 # accelerator setup, so we can skip them
-                elif op.dialect_name() in ("arith", "memref", "linalg", "test", "acc2"):
+                elif op.dialect_name() in (
+                    "arith",
+                    "memref",
+                    "linalg",
+                    "test",
+                    "acc2",
+                    "snax",
+                ):
                     continue
                 # these ops are specifically whitelisted:
                 elif isinstance(op, func.Return | scf.Yield):

--- a/compiler/transforms/convert_linalg_to_acc.py
+++ b/compiler/transforms/convert_linalg_to_acc.py
@@ -63,7 +63,7 @@ class HWPEAcceleratorInfo:
             fields          = {A=0x3d0, B=0x3d1, O=0x3d3, n_iters=0x3d4,
                                vector_length=0x3d5, mode=0x3d6},
             launch_addr     = 0x3c0,
-            barrier_sw_barrier = 0x3c3,
+            barrier = 0x3c3,
         }> : () -> ()
         """
         return acc.AcceleratorOp(

--- a/compiler/transforms/convert_linalg_to_acc.py
+++ b/compiler/transforms/convert_linalg_to_acc.py
@@ -33,13 +33,14 @@ class HWPEAcceleratorInfo:
         a, b, c = op.operands
 
         zero = arith.Constant.from_int_and_width(0, builtin.IndexType())
-        one = arith.Constant.from_int_and_width(1, builtin.IndexType())
+        iters_one = arith.Constant.from_int_and_width(1, 32)
+        mode_one = arith.Constant.from_int_and_width(1, 32)
         dim = memref.Dim.from_source_and_index(a, zero)
         dim_i32 = arith.IndexCastOp(dim, builtin.i32)
         vector_length = [zero, dim, dim_i32], dim_i32.result
 
-        nr_iters = [one], one.result
-        mode = [one], one.result
+        nr_iters = [iters_one], iters_one.result
+        mode = [mode_one], mode_one.result
 
         ptrs = [
             (

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -4,7 +4,7 @@
     name               = @acc1,
     fields             = {A=0x3c0, B=0x3c1},
     launch_addr        = 0x3cf,
-    barrier_sw_barrier = 0x7c3
+    barrier            = 0x7c3
 }> : () -> ()
 
 func.func @test() {
@@ -31,7 +31,7 @@ func.func @test() {
 
 
 // CHECK-NEXT: "builtin.module"() ({
-// CHECK-NEXT:   "acc2.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_addr" = 975 : i64, "barrier_sw_barrier" = 1987 : i64}> : () -> ()
+// CHECK-NEXT:   "acc2.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_addr" = 975 : i64, "barrier" = 1987 : i64}> : () -> ()
 // CHECK-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:     %state = "acc2.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc2.state<"acc1">

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1,5 +1,7 @@
 // RUN: XDSL_ROUNDTRIP
 
+acc2.accelerator @acc1 {A=0x3c0, B=0x3c1}
+
 func.func @test() {
     %one, %two = "test.op"() : () -> (i32, i32)
 
@@ -24,6 +26,7 @@ func.func @test() {
 
 
 // CHECK-NEXT: "builtin.module"() ({
+// CHECK-NEXT:   "acc2.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}}> : () -> ()
 // CHECK-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:     %state = "acc2.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc2.state<"acc1">

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -19,8 +19,6 @@ func.func @test() {
 
     %token = "acc2.launch"(%state) <{accelerator = "acc1"}>: (!acc2.state<"acc1">) -> !acc2.token<"acc1">
 
-    "acc2.await"(%token) : (!acc2.token<"acc1">) -> ()
-
     %state2 = "acc2.setup"(%one, %two, %state) <{
         param_names = ["A", "B"],
         accelerator = "acc1",

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -17,7 +17,9 @@ func.func @test() {
         operandSegmentSizes = array<i32: 2, 0>
     }> : (i32, i32) -> !acc2.state<"acc1">
 
-    %token = "acc2.launch"(%state) <{accelerator = "acc1"}>: (!acc2.state<"acc1">) -> !acc2.token
+    %token = "acc2.launch"(%state) <{accelerator = "acc1"}>: (!acc2.state<"acc1">) -> !acc2.token<"acc1">
+
+    "acc2.await"(%token) : (!acc2.token<"acc1">) -> ()
 
     %state2 = "acc2.setup"(%one, %two, %state) <{
         param_names = ["A", "B"],
@@ -25,7 +27,7 @@ func.func @test() {
         operandSegmentSizes = array<i32: 2, 1>
     }> : (i32, i32, !acc2.state<"acc1">) -> !acc2.state<"acc1">
 
-    "acc2.await"(%token) : (!acc2.token) -> ()
+    "acc2.await"(%token) : (!acc2.token<"acc1">) -> ()
 
     func.return
 }
@@ -36,9 +38,9 @@ func.func @test() {
 // CHECK-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:     %state = "acc2.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc2.state<"acc1">
-// CHECK-NEXT:     %token = "acc2.launch"(%state) <{"accelerator" = "acc1"}> : (!acc2.state<"acc1">) -> !acc2.token
+// CHECK-NEXT:     %token = "acc2.launch"(%state) <{"accelerator" = "acc1"}> : (!acc2.state<"acc1">) -> !acc2.token<"acc1">
 // CHECK-NEXT:     %state2 = "acc2.setup"(%one, %two, %state) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 1>}> : (i32, i32, !acc2.state<"acc1">) -> !acc2.state<"acc1">
-// CHECK-NEXT:     "acc2.await"(%token) : (!acc2.token) -> ()
+// CHECK-NEXT:     "acc2.await"(%token) : (!acc2.token<"acc1">) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1,6 +1,12 @@
 // RUN: XDSL_ROUNDTRIP
 
-acc2.accelerator @acc1 {A=0x3c0, B=0x3c1}
+"acc2.accelerator"() <{
+    name            = @acc1,
+    fields          = {A=0x3c0, B=0x3c1},
+    launch_addr     = 0x3cf,
+    barrier_enable  = 0x7c3,
+    barrier_trigger = 0x7c4
+}> : () -> ()
 
 func.func @test() {
     %one, %two = "test.op"() : () -> (i32, i32)
@@ -26,7 +32,7 @@ func.func @test() {
 
 
 // CHECK-NEXT: "builtin.module"() ({
-// CHECK-NEXT:   "acc2.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}}> : () -> ()
+// CHECK-NEXT:   "acc2.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_addr" = 975 : i64, "barrier_enable" = 1987 : i64, "barrier_trigger" = 1988 : i64}> : () -> ()
 // CHECK-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:     %state = "acc2.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc2.state<"acc1">

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1,11 +1,10 @@
 // RUN: XDSL_ROUNDTRIP
 
 "acc2.accelerator"() <{
-    name            = @acc1,
-    fields          = {A=0x3c0, B=0x3c1},
-    launch_addr     = 0x3cf,
-    barrier_enable  = 0x7c3,
-    barrier_trigger = 0x7c4
+    name               = @acc1,
+    fields             = {A=0x3c0, B=0x3c1},
+    launch_addr        = 0x3cf,
+    barrier_sw_barrier = 0x7c3
 }> : () -> ()
 
 func.func @test() {
@@ -32,7 +31,7 @@ func.func @test() {
 
 
 // CHECK-NEXT: "builtin.module"() ({
-// CHECK-NEXT:   "acc2.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_addr" = 975 : i64, "barrier_enable" = 1987 : i64, "barrier_trigger" = 1988 : i64}> : () -> ()
+// CHECK-NEXT:   "acc2.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_addr" = 975 : i64, "barrier_sw_barrier" = 1987 : i64}> : () -> ()
 // CHECK-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:     %state = "acc2.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc2.state<"acc1">

--- a/tests/filecheck/transforms/acc-cse.mlir
+++ b/tests/filecheck/transforms/acc-cse.mlir
@@ -8,15 +8,15 @@ func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg
   %4 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
 
   %5 = "acc2.setup"(%1, %2, %3, %4) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index) -> !acc2.state<"snax_hwpe_mult">
-  %6 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
-  "acc2.await"(%6) : (!acc2.token) -> ()
+  %6 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+  "acc2.await"(%6) : (!acc2.token<"snax_hwpe_mult">) -> ()
 
   %7 = "test.op"() : () -> i1
 
   %8, %9 = "scf.if"(%7) ({
     %10 = "acc2.setup"(%1, %3, %3, %4, %5) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-    %11 = "acc2.launch"(%10) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
-    "acc2.await"(%11) : (!acc2.token) -> ()
+    %11 = "acc2.launch"(%10) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+    "acc2.await"(%11) : (!acc2.token<"snax_hwpe_mult">) -> ()
 
     %12 = "test.op"() : () -> i32
     scf.yield %12, %10 : i32, !acc2.state<"snax_hwpe_mult">
@@ -24,8 +24,8 @@ func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg
     %13 = "test.op"() : () -> i32
 
     %14 = "acc2.setup"(%1, %2, %3, %4, %5) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-    %15 = "acc2.launch"(%14) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
-    "acc2.await"(%15) : (!acc2.token) -> ()
+    %15 = "acc2.launch"(%14) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+    "acc2.await"(%15) : (!acc2.token<"snax_hwpe_mult">) -> ()
 
     scf.yield %13, %14 : i32, !acc2.state<"snax_hwpe_mult">
   }) : (i1) -> (i32, !acc2.state<"snax_hwpe_mult">)
@@ -33,8 +33,8 @@ func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg
   "test.op"(%8) : (i32) -> ()
 
   %16 = "acc2.setup"(%1, %3, %2, %4, %9) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-  %17 = "acc2.launch"(%16) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
-  "acc2.await"(%17) : (!acc2.token) -> ()
+  %17 = "acc2.launch"(%16) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+  "acc2.await"(%17) : (!acc2.token<"snax_hwpe_mult">) -> ()
 
   func.return
 }
@@ -51,16 +51,16 @@ func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg
                    // Full setup:
 
 // CHECK-NEXT:     %5 = "acc2.setup"(%1, %2, %3, %4) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:     %6 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
-// CHECK-NEXT:     "acc2.await"(%6) : (!acc2.token) -> ()
+// CHECK-NEXT:     %6 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:     "acc2.await"(%6) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:     %7 = "test.op"() : () -> i1
 // CHECK-NEXT:     %8, %9 = "scf.if"(%7) ({
 
                      // Elide A and O setups:
 
 // CHECK-NEXT:       %10 = "acc2.setup"(%3, %5) <{"param_names" = ["B"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:       %11 = "acc2.launch"(%10) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
-// CHECK-NEXT:       "acc2.await"(%11) : (!acc2.token) -> ()
+// CHECK-NEXT:       %11 = "acc2.launch"(%10) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:       "acc2.await"(%11) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:       %12 = "test.op"() : () -> i32
 
                      // Hoisted into if, elided A, B
@@ -72,8 +72,8 @@ func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg
 
                      // Elide full setup op
 
-// CHECK-NEXT:       %15 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
-// CHECK-NEXT:       "acc2.await"(%15) : (!acc2.token) -> ()
+// CHECK-NEXT:       %15 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:       "acc2.await"(%15) : (!acc2.token<"snax_hwpe_mult">) -> ()
 
                      // Hoisted into if, elided A
 
@@ -84,8 +84,8 @@ func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg
 
                    // fully elided setup op
 
-// CHECK-NEXT:     %17 = "acc2.launch"(%9) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token
-// CHECK-NEXT:     "acc2.await"(%17) : (!acc2.token) -> ()
+// CHECK-NEXT:     %17 = "acc2.launch"(%9) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:     "acc2.await"(%17) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/convert-acc-to-csr.mlir
+++ b/tests/filecheck/transforms/convert-acc-to-csr.mlir
@@ -63,40 +63,88 @@ builtin.module {
 // CHECK-NEXT:     %13 = arith.constant 960 : i64
 // CHECK-NEXT:     %14 = arith.constant 1 : i5
 // CHECK-NEXT:     "llvm.inline_asm"(%13, %14) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:     %15 = arith.constant 963 : i64
-// CHECK-NEXT:     %16 = arith.constant 0 : i5
-// CHECK-NEXT:     "llvm.inline_asm"(%15, %16) <{"asm_string" = "\n  csrr a0, $0\n1:\n  bnez a0, 1b\n  csrwi 0x3c5, $1\n  nop\n  nop\n  nop\n", "constraints" = "I,K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:     scf.while () : () -> () {
+// CHECK-NEXT:       %15 = arith.constant 963 : i64
+// CHECK-NEXT:       %16 = arith.constant 0 : i32
+// CHECK-NEXT:       %17 = "llvm.inline_asm"(%15) <{"asm_string" = "csrr $0, $1", "constraints" = "=r, I", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64) -> i32
+// CHECK-NEXT:       %18 = arith.cmpi ne, %17, %16 : i32
+// CHECK-NEXT:       scf.condition(%18)
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       scf.yield
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %19 = arith.constant 965 : i12
+// CHECK-NEXT:     %20 = arith.constant 0 : i5
+// CHECK-NEXT:     "llvm.inline_asm"(%19, %20) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i12, i5) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
+// CHECK-NEXT:     "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
+// CHECK-NEXT:     "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
 // CHECK-NEXT:     "scf.if"(%i1) ({
-// CHECK-NEXT:       %17 = arith.constant 977 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%17, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
-// CHECK-NEXT:       %18 = arith.constant 960 : i64
-// CHECK-NEXT:       %19 = arith.constant 1 : i5
-// CHECK-NEXT:       "llvm.inline_asm"(%18, %19) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:       %20 = arith.constant 963 : i64
-// CHECK-NEXT:       %21 = arith.constant 0 : i5
-// CHECK-NEXT:       "llvm.inline_asm"(%20, %21) <{"asm_string" = "\n  csrr a0, $0\n1:\n  bnez a0, 1b\n  csrwi 0x3c5, $1\n  nop\n  nop\n  nop\n", "constraints" = "I,K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:       %22 = arith.constant 979 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%22, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:       %21 = arith.constant 977 : i64
+// CHECK-NEXT:       "llvm.inline_asm"(%21, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:       %22 = arith.constant 960 : i64
+// CHECK-NEXT:       %23 = arith.constant 1 : i5
+// CHECK-NEXT:       "llvm.inline_asm"(%22, %23) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:       scf.while () : () -> () {
+// CHECK-NEXT:         %24 = arith.constant 963 : i64
+// CHECK-NEXT:         %25 = arith.constant 0 : i32
+// CHECK-NEXT:         %26 = "llvm.inline_asm"(%24) <{"asm_string" = "csrr $0, $1", "constraints" = "=r, I", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64) -> i32
+// CHECK-NEXT:         %27 = arith.cmpi ne, %26, %25 : i32
+// CHECK-NEXT:         scf.condition(%27)
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         scf.yield
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %28 = arith.constant 965 : i12
+// CHECK-NEXT:       %29 = arith.constant 0 : i5
+// CHECK-NEXT:       "llvm.inline_asm"(%28, %29) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i12, i5) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
+// CHECK-NEXT:       "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
+// CHECK-NEXT:       "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
+// CHECK-NEXT:       %30 = arith.constant 979 : i64
+// CHECK-NEXT:       "llvm.inline_asm"(%30, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }, {
-// CHECK-NEXT:       %23 = arith.constant 960 : i64
-// CHECK-NEXT:       %24 = arith.constant 1 : i5
-// CHECK-NEXT:       "llvm.inline_asm"(%23, %24) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:       %25 = arith.constant 963 : i64
-// CHECK-NEXT:       %26 = arith.constant 0 : i5
-// CHECK-NEXT:       "llvm.inline_asm"(%25, %26) <{"asm_string" = "\n  csrr a0, $0\n1:\n  bnez a0, 1b\n  csrwi 0x3c5, $1\n  nop\n  nop\n  nop\n", "constraints" = "I,K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:       %27 = arith.constant 977 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%27, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
-// CHECK-NEXT:       %28 = arith.constant 979 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%28, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:       %31 = arith.constant 960 : i64
+// CHECK-NEXT:       %32 = arith.constant 1 : i5
+// CHECK-NEXT:       "llvm.inline_asm"(%31, %32) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:       scf.while () : () -> () {
+// CHECK-NEXT:         %33 = arith.constant 963 : i64
+// CHECK-NEXT:         %34 = arith.constant 0 : i32
+// CHECK-NEXT:         %35 = "llvm.inline_asm"(%33) <{"asm_string" = "csrr $0, $1", "constraints" = "=r, I", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64) -> i32
+// CHECK-NEXT:         %36 = arith.cmpi ne, %35, %34 : i32
+// CHECK-NEXT:         scf.condition(%36)
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         scf.yield
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %37 = arith.constant 965 : i12
+// CHECK-NEXT:       %38 = arith.constant 0 : i5
+// CHECK-NEXT:       "llvm.inline_asm"(%37, %38) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i12, i5) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
+// CHECK-NEXT:       "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
+// CHECK-NEXT:       "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
+// CHECK-NEXT:       %39 = arith.constant 977 : i64
+// CHECK-NEXT:       "llvm.inline_asm"(%39, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:       %40 = arith.constant 979 : i64
+// CHECK-NEXT:       "llvm.inline_asm"(%40, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }) : (i1) -> ()
-// CHECK-NEXT:     %29 = arith.constant 960 : i64
-// CHECK-NEXT:     %30 = arith.constant 1 : i5
-// CHECK-NEXT:     "llvm.inline_asm"(%29, %30) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:     %31 = arith.constant 963 : i64
-// CHECK-NEXT:     %32 = arith.constant 0 : i5
-// CHECK-NEXT:     "llvm.inline_asm"(%31, %32) <{"asm_string" = "\n  csrr a0, $0\n1:\n  bnez a0, 1b\n  csrwi 0x3c5, $1\n  nop\n  nop\n  nop\n", "constraints" = "I,K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:     %41 = arith.constant 960 : i64
+// CHECK-NEXT:     %42 = arith.constant 1 : i5
+// CHECK-NEXT:     "llvm.inline_asm"(%41, %42) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:     scf.while () : () -> () {
+// CHECK-NEXT:       %43 = arith.constant 963 : i64
+// CHECK-NEXT:       %44 = arith.constant 0 : i32
+// CHECK-NEXT:       %45 = "llvm.inline_asm"(%43) <{"asm_string" = "csrr $0, $1", "constraints" = "=r, I", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64) -> i32
+// CHECK-NEXT:       %46 = arith.cmpi ne, %45, %44 : i32
+// CHECK-NEXT:       scf.condition(%46)
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       scf.yield
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %47 = arith.constant 965 : i12
+// CHECK-NEXT:     %48 = arith.constant 0 : i5
+// CHECK-NEXT:     "llvm.inline_asm"(%47, %48) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i12, i5) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
+// CHECK-NEXT:     "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
+// CHECK-NEXT:     "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/convert-acc-to-csr.mlir
+++ b/tests/filecheck/transforms/convert-acc-to-csr.mlir
@@ -1,0 +1,114 @@
+// RUN: compiler/snax-opt %s -p convert-acc-to-csr | filecheck %s
+
+builtin.module {
+
+  "acc2.accelerator"() <{
+      name            = @snax_hwpe_mult,
+      fields          = {A=0x3c0, B=0x3c1, O=0x3c2, size=0x3c3},
+      launch_addr     = 0x3cf,
+      barrier_enable  = 0x7c3,
+      barrier_trigger = 0x7c4
+  }> : () -> ()
+
+  func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>, %i1 : i1) {
+    %0 = arith.constant 0 : index
+    %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
+    %2 = "arith.index_cast"(%1) : (index) -> i32
+    %3 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
+    %4 = "arith.index_cast"(%3) : (index) -> i32
+    %5 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
+    %6 = "arith.index_cast"(%5) : (index) -> i32
+    %7 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
+    %8 = "arith.index_cast"(%7) : (index) -> i32
+    %9 = "acc2.setup"(%2, %4, %6, %8) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
+    %10 = "acc2.launch"(%9) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+    "acc2.await"(%10) : (!acc2.token<"snax_hwpe_mult">) -> ()
+    %13 = "scf.if"(%i1) ({
+      %14 = "acc2.setup"(%6, %9) <{"param_names" = ["B"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+      %15 = "acc2.launch"(%14) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+      "acc2.await"(%15) : (!acc2.token<"snax_hwpe_mult">) -> ()
+      %17 = "acc2.setup"(%4, %14) <{"param_names" = ["O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+      scf.yield %17 : !acc2.state<"snax_hwpe_mult">
+    }, {
+      %19 = "acc2.launch"(%9) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+      "acc2.await"(%19) : (!acc2.token<"snax_hwpe_mult">) -> ()
+      %20 = "acc2.setup"(%6, %4, %9) <{"param_names" = ["B", "O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 2, 1>}> : (i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+      scf.yield %20 : !acc2.state<"snax_hwpe_mult">
+    }) : (i1) -> (!acc2.state<"snax_hwpe_mult">)
+    %21 = "acc2.launch"(%13) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+    "acc2.await"(%21) : (!acc2.token<"snax_hwpe_mult">) -> ()
+    func.return
+  }
+}
+
+// CHECK-NEXT: builtin.module {
+// CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>, %i1 : i1) {
+// CHECK-NEXT:     %0 = arith.constant 0 : index
+// CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %2 = "arith.index_cast"(%1) : (index) -> i32
+// CHECK-NEXT:     %3 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %4 = "arith.index_cast"(%3) : (index) -> i32
+// CHECK-NEXT:     %5 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %6 = "arith.index_cast"(%5) : (index) -> i32
+// CHECK-NEXT:     %7 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
+// CHECK-NEXT:     %8 = "arith.index_cast"(%7) : (index) -> i32
+// CHECK-NEXT:     %9 = arith.constant 960 : i64
+// CHECK-NEXT:     "llvm.inline_asm"(%9, %2) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:     %10 = arith.constant 961 : i64
+// CHECK-NEXT:     "llvm.inline_asm"(%10, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:     %11 = arith.constant 962 : i64
+// CHECK-NEXT:     "llvm.inline_asm"(%11, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:     %12 = arith.constant 963 : i64
+// CHECK-NEXT:     "llvm.inline_asm"(%12, %8) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:     %13 = arith.constant 975 : i64
+// CHECK-NEXT:     %14 = arith.constant 1 : i5
+// CHECK-NEXT:     "llvm.inline_asm"(%13, %14) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:     %15 = arith.constant 1987 : i64
+// CHECK-NEXT:     %16 = arith.constant 1988 : i64
+// CHECK-NEXT:     %17 = arith.constant 1 : i5
+// CHECK-NEXT:     %18 = arith.constant 0 : i5
+// CHECK-NEXT:     "llvm.inline_asm"(%15, %17) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%16, %18) <{"asm_string" = "csrw $2, $3", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:     "scf.if"(%i1) ({
+// CHECK-NEXT:       %19 = arith.constant 961 : i64
+// CHECK-NEXT:       "llvm.inline_asm"(%19, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:       %20 = arith.constant 975 : i64
+// CHECK-NEXT:       %21 = arith.constant 1 : i5
+// CHECK-NEXT:       "llvm.inline_asm"(%20, %21) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:       %22 = arith.constant 1987 : i64
+// CHECK-NEXT:       %23 = arith.constant 1988 : i64
+// CHECK-NEXT:       %24 = arith.constant 1 : i5
+// CHECK-NEXT:       %25 = arith.constant 0 : i5
+// CHECK-NEXT:       "llvm.inline_asm"(%22, %24) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%23, %25) <{"asm_string" = "csrw $2, $3", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:       %26 = arith.constant 962 : i64
+// CHECK-NEXT:       "llvm.inline_asm"(%26, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:       scf.yield
+// CHECK-NEXT:     }, {
+// CHECK-NEXT:       %27 = arith.constant 975 : i64
+// CHECK-NEXT:       %28 = arith.constant 1 : i5
+// CHECK-NEXT:       "llvm.inline_asm"(%27, %28) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:       %29 = arith.constant 1987 : i64
+// CHECK-NEXT:       %30 = arith.constant 1988 : i64
+// CHECK-NEXT:       %31 = arith.constant 1 : i5
+// CHECK-NEXT:       %32 = arith.constant 0 : i5
+// CHECK-NEXT:       "llvm.inline_asm"(%29, %31) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%30, %32) <{"asm_string" = "csrw $2, $3", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:       %33 = arith.constant 961 : i64
+// CHECK-NEXT:       "llvm.inline_asm"(%33, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:       %34 = arith.constant 962 : i64
+// CHECK-NEXT:       "llvm.inline_asm"(%34, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:       scf.yield
+// CHECK-NEXT:     }) : (i1) -> ()
+// CHECK-NEXT:     %35 = arith.constant 975 : i64
+// CHECK-NEXT:     %36 = arith.constant 1 : i5
+// CHECK-NEXT:     "llvm.inline_asm"(%35, %36) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:     %37 = arith.constant 1987 : i64
+// CHECK-NEXT:     %38 = arith.constant 1988 : i64
+// CHECK-NEXT:     %39 = arith.constant 1 : i5
+// CHECK-NEXT:     %40 = arith.constant 0 : i5
+// CHECK-NEXT:     "llvm.inline_asm"(%37, %39) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%38, %40) <{"asm_string" = "csrw $2, $3", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/tests/filecheck/transforms/convert-acc-to-csr.mlir
+++ b/tests/filecheck/transforms/convert-acc-to-csr.mlir
@@ -1,4 +1,4 @@
-// RUN: compiler/snax-opt %s -p convert-acc-to-csr | filecheck %s
+// RUN: ./compiler/snax-opt %s -p convert-acc-to-csr | filecheck %s
 
 builtin.module {
 
@@ -68,7 +68,7 @@ builtin.module {
 // CHECK-NEXT:     %17 = arith.constant 1 : i5
 // CHECK-NEXT:     %18 = arith.constant 0 : i5
 // CHECK-NEXT:     "llvm.inline_asm"(%15, %17) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
-// CHECK-NEXT:     "llvm.inline_asm"(%16, %18) <{"asm_string" = "csrw $2, $3", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%16, %18) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
 // CHECK-NEXT:     "scf.if"(%i1) ({
 // CHECK-NEXT:       %19 = arith.constant 961 : i64
 // CHECK-NEXT:       "llvm.inline_asm"(%19, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
@@ -80,7 +80,7 @@ builtin.module {
 // CHECK-NEXT:       %24 = arith.constant 1 : i5
 // CHECK-NEXT:       %25 = arith.constant 0 : i5
 // CHECK-NEXT:       "llvm.inline_asm"(%22, %24) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
-// CHECK-NEXT:       "llvm.inline_asm"(%23, %25) <{"asm_string" = "csrw $2, $3", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%23, %25) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
 // CHECK-NEXT:       %26 = arith.constant 962 : i64
 // CHECK-NEXT:       "llvm.inline_asm"(%26, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
 // CHECK-NEXT:       scf.yield
@@ -93,7 +93,7 @@ builtin.module {
 // CHECK-NEXT:       %31 = arith.constant 1 : i5
 // CHECK-NEXT:       %32 = arith.constant 0 : i5
 // CHECK-NEXT:       "llvm.inline_asm"(%29, %31) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
-// CHECK-NEXT:       "llvm.inline_asm"(%30, %32) <{"asm_string" = "csrw $2, $3", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%30, %32) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
 // CHECK-NEXT:       %33 = arith.constant 961 : i64
 // CHECK-NEXT:       "llvm.inline_asm"(%33, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
 // CHECK-NEXT:       %34 = arith.constant 962 : i64
@@ -108,7 +108,7 @@ builtin.module {
 // CHECK-NEXT:     %39 = arith.constant 1 : i5
 // CHECK-NEXT:     %40 = arith.constant 0 : i5
 // CHECK-NEXT:     "llvm.inline_asm"(%37, %39) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
-// CHECK-NEXT:     "llvm.inline_asm"(%38, %40) <{"asm_string" = "csrw $2, $3", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%38, %40) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/convert-acc-to-csr.mlir
+++ b/tests/filecheck/transforms/convert-acc-to-csr.mlir
@@ -6,7 +6,7 @@ builtin.module {
       name            = @snax_hwpe_mult,
       fields          = {A=0x3d0, B=0x3d1, O=0x3d3, nr_iters=0x3d4, vector_length=0x3d5, mode=0x3d6},
       launch_addr     = 0x3c0,
-      barrier_sw_barrier  = 0x3c3
+      barrier         = 0x3c3
   }> : () -> ()
 
   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>, %i1 : i1) {

--- a/tests/filecheck/transforms/convert-acc-to-csr.mlir
+++ b/tests/filecheck/transforms/convert-acc-to-csr.mlir
@@ -53,62 +53,62 @@ builtin.module {
 // CHECK-NEXT:     %7 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
 // CHECK-NEXT:     %8 = "arith.index_cast"(%7) : (index) -> i32
 // CHECK-NEXT:     %9 = arith.constant 960 : i64
-// CHECK-NEXT:     "llvm.inline_asm"(%9, %2) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%9, %2) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:     %10 = arith.constant 961 : i64
-// CHECK-NEXT:     "llvm.inline_asm"(%10, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%10, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:     %11 = arith.constant 962 : i64
-// CHECK-NEXT:     "llvm.inline_asm"(%11, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%11, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:     %12 = arith.constant 963 : i64
-// CHECK-NEXT:     "llvm.inline_asm"(%12, %8) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%12, %8) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:     %13 = arith.constant 975 : i64
 // CHECK-NEXT:     %14 = arith.constant 1 : i5
-// CHECK-NEXT:     "llvm.inline_asm"(%13, %14) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%13, %14) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
 // CHECK-NEXT:     %15 = arith.constant 1987 : i64
 // CHECK-NEXT:     %16 = arith.constant 1988 : i64
 // CHECK-NEXT:     %17 = arith.constant 1 : i5
 // CHECK-NEXT:     %18 = arith.constant 0 : i5
-// CHECK-NEXT:     "llvm.inline_asm"(%15, %17) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
-// CHECK-NEXT:     "llvm.inline_asm"(%16, %18) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%15, %17) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%16, %18) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
 // CHECK-NEXT:     "scf.if"(%i1) ({
 // CHECK-NEXT:       %19 = arith.constant 961 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%19, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%19, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:       %20 = arith.constant 975 : i64
 // CHECK-NEXT:       %21 = arith.constant 1 : i5
-// CHECK-NEXT:       "llvm.inline_asm"(%20, %21) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%20, %21) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
 // CHECK-NEXT:       %22 = arith.constant 1987 : i64
 // CHECK-NEXT:       %23 = arith.constant 1988 : i64
 // CHECK-NEXT:       %24 = arith.constant 1 : i5
 // CHECK-NEXT:       %25 = arith.constant 0 : i5
-// CHECK-NEXT:       "llvm.inline_asm"(%22, %24) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
-// CHECK-NEXT:       "llvm.inline_asm"(%23, %25) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%22, %24) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%23, %25) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
 // CHECK-NEXT:       %26 = arith.constant 962 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%26, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%26, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }, {
 // CHECK-NEXT:       %27 = arith.constant 975 : i64
 // CHECK-NEXT:       %28 = arith.constant 1 : i5
-// CHECK-NEXT:       "llvm.inline_asm"(%27, %28) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%27, %28) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
 // CHECK-NEXT:       %29 = arith.constant 1987 : i64
 // CHECK-NEXT:       %30 = arith.constant 1988 : i64
 // CHECK-NEXT:       %31 = arith.constant 1 : i5
 // CHECK-NEXT:       %32 = arith.constant 0 : i5
-// CHECK-NEXT:       "llvm.inline_asm"(%29, %31) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
-// CHECK-NEXT:       "llvm.inline_asm"(%30, %32) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%29, %31) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%30, %32) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
 // CHECK-NEXT:       %33 = arith.constant 961 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%33, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%33, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:       %34 = arith.constant 962 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%34, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i32) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%34, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }) : (i1) -> ()
 // CHECK-NEXT:     %35 = arith.constant 975 : i64
 // CHECK-NEXT:     %36 = arith.constant 1 : i5
-// CHECK-NEXT:     "llvm.inline_asm"(%35, %36) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%35, %36) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
 // CHECK-NEXT:     %37 = arith.constant 1987 : i64
 // CHECK-NEXT:     %38 = arith.constant 1988 : i64
 // CHECK-NEXT:     %39 = arith.constant 1 : i5
 // CHECK-NEXT:     %40 = arith.constant 0 : i5
-// CHECK-NEXT:     "llvm.inline_asm"(%37, %39) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
-// CHECK-NEXT:     "llvm.inline_asm"(%38, %40) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64, "has_side_effects"}> : (i64, i5) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%37, %39) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%38, %40) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/convert-acc-to-csr.mlir
+++ b/tests/filecheck/transforms/convert-acc-to-csr.mlir
@@ -4,10 +4,9 @@ builtin.module {
 
   "acc2.accelerator"() <{
       name            = @snax_hwpe_mult,
-      fields          = {A=0x3c0, B=0x3c1, O=0x3c2, size=0x3c3},
-      launch_addr     = 0x3cf,
-      barrier_enable  = 0x7c3,
-      barrier_trigger = 0x7c4
+      fields          = {A=0x3d0, B=0x3d1, O=0x3d3, nr_iters=0x3d4, vector_length=0x3d5, mode=0x3d6},
+      launch_addr     = 0x3c0,
+      barrier_sw_barrier  = 0x3c3
   }> : () -> ()
 
   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>, %i1 : i1) {
@@ -20,7 +19,7 @@ builtin.module {
     %6 = "arith.index_cast"(%5) : (index) -> i32
     %7 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
     %8 = "arith.index_cast"(%7) : (index) -> i32
-    %9 = "acc2.setup"(%2, %4, %6, %8) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
+    %9 = "acc2.setup"(%2, %4, %6, %8) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
     %10 = "acc2.launch"(%9) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
     "acc2.await"(%10) : (!acc2.token<"snax_hwpe_mult">) -> ()
     %13 = "scf.if"(%i1) ({
@@ -41,6 +40,7 @@ builtin.module {
   }
 }
 
+
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>, %i1 : i1) {
 // CHECK-NEXT:     %0 = arith.constant 0 : index
@@ -52,63 +52,53 @@ builtin.module {
 // CHECK-NEXT:     %6 = "arith.index_cast"(%5) : (index) -> i32
 // CHECK-NEXT:     %7 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
 // CHECK-NEXT:     %8 = "arith.index_cast"(%7) : (index) -> i32
-// CHECK-NEXT:     %9 = arith.constant 960 : i64
+// CHECK-NEXT:     %9 = arith.constant 976 : i64
 // CHECK-NEXT:     "llvm.inline_asm"(%9, %2) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
-// CHECK-NEXT:     %10 = arith.constant 961 : i64
+// CHECK-NEXT:     %10 = arith.constant 977 : i64
 // CHECK-NEXT:     "llvm.inline_asm"(%10, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
-// CHECK-NEXT:     %11 = arith.constant 962 : i64
+// CHECK-NEXT:     %11 = arith.constant 979 : i64
 // CHECK-NEXT:     "llvm.inline_asm"(%11, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
-// CHECK-NEXT:     %12 = arith.constant 963 : i64
+// CHECK-NEXT:     %12 = arith.constant 980 : i64
 // CHECK-NEXT:     "llvm.inline_asm"(%12, %8) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
-// CHECK-NEXT:     %13 = arith.constant 975 : i64
+// CHECK-NEXT:     %13 = arith.constant 960 : i64
 // CHECK-NEXT:     %14 = arith.constant 1 : i5
 // CHECK-NEXT:     "llvm.inline_asm"(%13, %14) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:     %15 = arith.constant 1987 : i64
-// CHECK-NEXT:     %16 = arith.constant 1988 : i64
-// CHECK-NEXT:     %17 = arith.constant 1 : i5
-// CHECK-NEXT:     %18 = arith.constant 0 : i5
-// CHECK-NEXT:     "llvm.inline_asm"(%15, %17) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:     "llvm.inline_asm"(%16, %18) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:     %15 = arith.constant 963 : i64
+// CHECK-NEXT:     %16 = arith.constant 0 : i5
+// CHECK-NEXT:     "llvm.inline_asm"(%15, %16) <{"asm_string" = "\n  csrr a0, $0\n1:\n  bnez a0, 1b\n  csrwi 0x3c5, $1\n  nop\n  nop\n  nop\n", "constraints" = "I,K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
 // CHECK-NEXT:     "scf.if"(%i1) ({
-// CHECK-NEXT:       %19 = arith.constant 961 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%19, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
-// CHECK-NEXT:       %20 = arith.constant 975 : i64
-// CHECK-NEXT:       %21 = arith.constant 1 : i5
-// CHECK-NEXT:       "llvm.inline_asm"(%20, %21) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:       %22 = arith.constant 1987 : i64
-// CHECK-NEXT:       %23 = arith.constant 1988 : i64
-// CHECK-NEXT:       %24 = arith.constant 1 : i5
-// CHECK-NEXT:       %25 = arith.constant 0 : i5
-// CHECK-NEXT:       "llvm.inline_asm"(%22, %24) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:       "llvm.inline_asm"(%23, %25) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:       %26 = arith.constant 962 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%26, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:       %17 = arith.constant 977 : i64
+// CHECK-NEXT:       "llvm.inline_asm"(%17, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:       %18 = arith.constant 960 : i64
+// CHECK-NEXT:       %19 = arith.constant 1 : i5
+// CHECK-NEXT:       "llvm.inline_asm"(%18, %19) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:       %20 = arith.constant 963 : i64
+// CHECK-NEXT:       %21 = arith.constant 0 : i5
+// CHECK-NEXT:       "llvm.inline_asm"(%20, %21) <{"asm_string" = "\n  csrr a0, $0\n1:\n  bnez a0, 1b\n  csrwi 0x3c5, $1\n  nop\n  nop\n  nop\n", "constraints" = "I,K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:       %22 = arith.constant 979 : i64
+// CHECK-NEXT:       "llvm.inline_asm"(%22, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }, {
-// CHECK-NEXT:       %27 = arith.constant 975 : i64
-// CHECK-NEXT:       %28 = arith.constant 1 : i5
-// CHECK-NEXT:       "llvm.inline_asm"(%27, %28) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:       %29 = arith.constant 1987 : i64
-// CHECK-NEXT:       %30 = arith.constant 1988 : i64
-// CHECK-NEXT:       %31 = arith.constant 1 : i5
-// CHECK-NEXT:       %32 = arith.constant 0 : i5
-// CHECK-NEXT:       "llvm.inline_asm"(%29, %31) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:       "llvm.inline_asm"(%30, %32) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:       %33 = arith.constant 961 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%33, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
-// CHECK-NEXT:       %34 = arith.constant 962 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%34, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:       %23 = arith.constant 960 : i64
+// CHECK-NEXT:       %24 = arith.constant 1 : i5
+// CHECK-NEXT:       "llvm.inline_asm"(%23, %24) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:       %25 = arith.constant 963 : i64
+// CHECK-NEXT:       %26 = arith.constant 0 : i5
+// CHECK-NEXT:       "llvm.inline_asm"(%25, %26) <{"asm_string" = "\n  csrr a0, $0\n1:\n  bnez a0, 1b\n  csrwi 0x3c5, $1\n  nop\n  nop\n  nop\n", "constraints" = "I,K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:       %27 = arith.constant 977 : i64
+// CHECK-NEXT:       "llvm.inline_asm"(%27, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:       %28 = arith.constant 979 : i64
+// CHECK-NEXT:       "llvm.inline_asm"(%28, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }) : (i1) -> ()
-// CHECK-NEXT:     %35 = arith.constant 975 : i64
-// CHECK-NEXT:     %36 = arith.constant 1 : i5
-// CHECK-NEXT:     "llvm.inline_asm"(%35, %36) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:     %37 = arith.constant 1987 : i64
-// CHECK-NEXT:     %38 = arith.constant 1988 : i64
-// CHECK-NEXT:     %39 = arith.constant 1 : i5
-// CHECK-NEXT:     %40 = arith.constant 0 : i5
-// CHECK-NEXT:     "llvm.inline_asm"(%37, %39) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
-// CHECK-NEXT:     "llvm.inline_asm"(%38, %40) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:     %29 = arith.constant 960 : i64
+// CHECK-NEXT:     %30 = arith.constant 1 : i5
+// CHECK-NEXT:     "llvm.inline_asm"(%29, %30) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
+// CHECK-NEXT:     %31 = arith.constant 963 : i64
+// CHECK-NEXT:     %32 = arith.constant 0 : i5
+// CHECK-NEXT:     "llvm.inline_asm"(%31, %32) <{"asm_string" = "\n  csrr a0, $0\n1:\n  bnez a0, 1b\n  csrwi 0x3c5, $1\n  nop\n  nop\n  nop\n", "constraints" = "I,K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
+
+

--- a/tests/filecheck/transforms/convert-acc-to-csr.mlir
+++ b/tests/filecheck/transforms/convert-acc-to-csr.mlir
@@ -53,13 +53,13 @@ builtin.module {
 // CHECK-NEXT:     %7 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
 // CHECK-NEXT:     %8 = "arith.index_cast"(%7) : (index) -> i32
 // CHECK-NEXT:     %9 = arith.constant 976 : i64
-// CHECK-NEXT:     "llvm.inline_asm"(%9, %2) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%9, %2) <{"asm_string" = "csrw $0, $1", "constraints" = "I, rK", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:     %10 = arith.constant 977 : i64
-// CHECK-NEXT:     "llvm.inline_asm"(%10, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%10, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, rK", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:     %11 = arith.constant 979 : i64
-// CHECK-NEXT:     "llvm.inline_asm"(%11, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%11, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, rK", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:     %12 = arith.constant 980 : i64
-// CHECK-NEXT:     "llvm.inline_asm"(%12, %8) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%12, %8) <{"asm_string" = "csrw $0, $1", "constraints" = "I, rK", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:     %13 = arith.constant 960 : i64
 // CHECK-NEXT:     %14 = arith.constant 1 : i5
 // CHECK-NEXT:     "llvm.inline_asm"(%13, %14) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
@@ -74,13 +74,13 @@ builtin.module {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     %19 = arith.constant 965 : i12
 // CHECK-NEXT:     %20 = arith.constant 0 : i5
-// CHECK-NEXT:     "llvm.inline_asm"(%19, %20) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i12, i5) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%19, %20) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i12, i5) -> ()
 // CHECK-NEXT:     "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
 // CHECK-NEXT:     "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
 // CHECK-NEXT:     "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
 // CHECK-NEXT:     "scf.if"(%i1) ({
 // CHECK-NEXT:       %21 = arith.constant 977 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%21, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%21, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, rK", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:       %22 = arith.constant 960 : i64
 // CHECK-NEXT:       %23 = arith.constant 1 : i5
 // CHECK-NEXT:       "llvm.inline_asm"(%22, %23) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i5) -> ()
@@ -95,12 +95,12 @@ builtin.module {
 // CHECK-NEXT:       }
 // CHECK-NEXT:       %28 = arith.constant 965 : i12
 // CHECK-NEXT:       %29 = arith.constant 0 : i5
-// CHECK-NEXT:       "llvm.inline_asm"(%28, %29) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i12, i5) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%28, %29) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i12, i5) -> ()
 // CHECK-NEXT:       "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
 // CHECK-NEXT:       "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
 // CHECK-NEXT:       "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
 // CHECK-NEXT:       %30 = arith.constant 979 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%30, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%30, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, rK", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }, {
 // CHECK-NEXT:       %31 = arith.constant 960 : i64
@@ -117,14 +117,14 @@ builtin.module {
 // CHECK-NEXT:       }
 // CHECK-NEXT:       %37 = arith.constant 965 : i12
 // CHECK-NEXT:       %38 = arith.constant 0 : i5
-// CHECK-NEXT:       "llvm.inline_asm"(%37, %38) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i12, i5) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%37, %38) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i12, i5) -> ()
 // CHECK-NEXT:       "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
 // CHECK-NEXT:       "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
 // CHECK-NEXT:       "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
 // CHECK-NEXT:       %39 = arith.constant 977 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%39, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%39, %6) <{"asm_string" = "csrw $0, $1", "constraints" = "I, rK", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:       %40 = arith.constant 979 : i64
-// CHECK-NEXT:       "llvm.inline_asm"(%40, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
+// CHECK-NEXT:       "llvm.inline_asm"(%40, %4) <{"asm_string" = "csrw $0, $1", "constraints" = "I, rK", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i32) -> ()
 // CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }) : (i1) -> ()
 // CHECK-NEXT:     %41 = arith.constant 960 : i64
@@ -141,7 +141,7 @@ builtin.module {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     %47 = arith.constant 965 : i12
 // CHECK-NEXT:     %48 = arith.constant 0 : i5
-// CHECK-NEXT:     "llvm.inline_asm"(%47, %48) <{"asm_string" = "csrw $0, $1", "constraints" = "I, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i12, i5) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%47, %48) <{"asm_string" = "csrw $0, $1", "constraints" = "I, K", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i12, i5) -> ()
 // CHECK-NEXT:     "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
 // CHECK-NEXT:     "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()
 // CHECK-NEXT:     "llvm.inline_asm"() <{"asm_string" = "nop", "constraints" = "", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> ()

--- a/tests/filecheck/transforms/convert-linalg-to-acc.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-acc.mlir
@@ -85,4 +85,5 @@
 // CHECK-NEXT:     "acc2.await"(%17) : (!acc2.token) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
+// CHECK-NEXT:   "acc2.accelerator"() <{"name" = @snax_hwpe_mult, "fields" = {"A" = 960 : i32, "B" = 961 : i32, "O" = 962 : i32, "size" = 963 : i32}, "launch_addr" = 975 : i32, "barrier_enable" = 1987 : i32, "barrier_trigger" = 1988 : i32}> : () -> ()
 // CHECK-NEXT: }


### PR DESCRIPTION
This PR introduces a new pass `convert-acc-to-csr` that converts `acc` dialect ops to llvm inline assembly setting CSR register values.

It also adds a `acc2.accelerator` operation that defines acclerator specific addresses and such, which is used by the lowering.