### PR TITLE
acc2: Refactor AcceleratorInterface

### DIFF
--- a/compiler/accelerators/accelerator.py
+++ b/compiler/accelerators/accelerator.py
@@ -6,30 +6,66 @@ from xdsl.ir import Operation, SSAValue
 from compiler.dialects import acc
 
 
-class AcceleratorInfo(ABC):
+class AcceleratorInterface(ABC):
+    """
+    Interface to lower to and from acc2 dialect.
+    """
+
     @abstractmethod
     def generate_setup_vals(
         self, op: Operation
     ) -> Sequence[tuple[Sequence[Operation], SSAValue]]:
+        """
+        Produce a `Sequence[Operation], SSAValue` tuple
+        for each field that contains:
+
+        - a list of operations that calculate the field value
+        - a reference to the SSAValue containing the calculated field value
+        """
         pass
 
     @abstractmethod
     def generate_acc_op(self) -> acc.AcceleratorOp:
+        """
+        Return an accelerator op:
+
+        "acc2.accelerator"() <{
+            name            = @name_of_the_accelerator,
+            fields          = {field_1=address_1, field_2=address2},
+            launch_addr     = launch_address,
+            barrier         = barrier_address,
+        }> : () -> ()
+        """
         pass
 
-    @abstractmethod
     @staticmethod
+    @abstractmethod
     def lower_acc_barrier(acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
+        """
+        Based on the acc2.accelerator op, return the necessary sequence of
+        lower-level operations to perform
+        asynchronous await on the accelerator.
+        """
         pass
 
-    @abstractmethod
     @staticmethod
+    @abstractmethod
     def lower_acc_launch(acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
+        """
+        Based on the acc2.accelerator op, return the necessary sequence of
+        lower-level operations to perform an
+        asynchronous launch of the accelerator.
+        """
         pass
 
-    @abstractmethod
     @staticmethod
+    @abstractmethod
     def lower_setup_op(
         setup_op: acc.SetupOp, acc_op: acc.AcceleratorOp
     ) -> Sequence[Operation]:
+        """
+        Based on the acc2.accelerator op and the acc.SetupOp,
+        return the necessary sequence of lower-level operations to perform
+        accelerator configuration.
+        """
         pass

--- a/compiler/accelerators/accelerator.py
+++ b/compiler/accelerators/accelerator.py
@@ -6,7 +6,7 @@ from xdsl.ir import Operation, SSAValue
 from compiler.dialects import acc
 
 
-class AcceleratorInterface(ABC):
+class Accelerator(ABC):
     """
     Interface to lower to and from acc2 dialect.
     """
@@ -40,7 +40,7 @@ class AcceleratorInterface(ABC):
 
     @staticmethod
     @abstractmethod
-    def lower_acc_barrier(acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
+    def lower_acc_await(acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
         """
         Based on the acc2.accelerator op, return the necessary sequence of
         lower-level operations to perform
@@ -60,7 +60,7 @@ class AcceleratorInterface(ABC):
 
     @staticmethod
     @abstractmethod
-    def lower_setup_op(
+    def lower_acc_setup(
         setup_op: acc.SetupOp, acc_op: acc.AcceleratorOp
     ) -> Sequence[Operation]:
         """

--- a/compiler/accelerators/accelerator.py
+++ b/compiler/accelerators/accelerator.py
@@ -16,3 +16,20 @@ class AcceleratorInfo(ABC):
     @abstractmethod
     def generate_acc_op(self) -> acc.AcceleratorOp:
         pass
+
+    @abstractmethod
+    @staticmethod
+    def lower_acc_barrier(acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
+        pass
+
+    @abstractmethod
+    @staticmethod
+    def lower_acc_launch(acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
+        pass
+
+    @abstractmethod
+    @staticmethod
+    def lower_setup_op(
+        setup_op: acc.SetupOp, acc_op: acc.AcceleratorOp
+    ) -> Sequence[Operation]:
+        pass

--- a/compiler/accelerators/accelerator.py
+++ b/compiler/accelerators/accelerator.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+from xdsl.ir import Operation, SSAValue
+
+from compiler.dialects import acc
+
+
+class AcceleratorInfo(ABC):
+    @abstractmethod
+    def generate_setup_vals(
+        self, op: Operation
+    ) -> Sequence[tuple[Sequence[Operation], SSAValue]]:
+        pass
+
+    @abstractmethod
+    def generate_acc_op(self) -> acc.AcceleratorOp:
+        pass

--- a/compiler/accelerators/snax.py
+++ b/compiler/accelerators/snax.py
@@ -1,0 +1,97 @@
+from abc import ABC
+from collections.abc import Sequence
+
+from xdsl.dialects import arith, builtin, llvm
+from xdsl.dialects.builtin import i32
+from xdsl.dialects.scf import Condition, While, Yield
+from xdsl.ir import Operation
+
+from compiler.accelerators.accelerator import AcceleratorInterface
+from compiler.dialects import acc
+
+
+class SNAXAcceleratorInterface(AcceleratorInterface, ABC):
+    """
+    Abstract base class for extending AcceleratorInterfaces
+    with common SNAX lowerings.
+    """
+
+    @staticmethod
+    def lower_acc_barrier(acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
+        return [
+            While(
+                [],
+                [],
+                [
+                    barrier := arith.Constant(acc_op.barrier),
+                    zero := arith.Constant(
+                        builtin.IntegerAttr.from_int_and_width(0, 32)
+                    ),
+                    status := llvm.InlineAsmOp(
+                        "csrr $0, $1",
+                        # I = any 12 bit immediate
+                        # =r = store result in A 32- or 64-bit
+                        # general-purpose register (depending on the platform XLEN)
+                        "=r, I",
+                        [barrier],
+                        [i32],
+                        has_side_effects=True,
+                    ),
+                    # check if not equal to zero
+                    comparison := arith.Cmpi(status, zero, "ne"),
+                    Condition(comparison.results[0]),
+                ],
+                [
+                    Yield(),
+                ],
+            ),
+            addr_val := arith.Constant(builtin.IntegerAttr(965, 12)),  # 0x3c5 = 965
+            zero := arith.Constant(builtin.IntegerAttr.from_int_and_width(0, 5)),
+            llvm.InlineAsmOp(
+                "csrw $0, $1",
+                "I, K",
+                [addr_val, zero],
+                has_side_effects=True,
+            ),
+            # Three nops for random but important reasons
+            llvm.InlineAsmOp("nop", "", [], [], has_side_effects=True),
+            llvm.InlineAsmOp("nop", "", [], [], has_side_effects=True),
+            llvm.InlineAsmOp("nop", "", [], [], has_side_effects=True),
+        ]
+
+    @staticmethod
+    def lower_acc_launch(acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
+        return [
+            addr_val := arith.Constant(acc_op.launch_addr),
+            val := arith.Constant(builtin.IntegerAttr.from_int_and_width(0, 5)),
+            llvm.InlineAsmOp(
+                "csrw $0, $1",
+                # I = any 12 bit immediate, K = any 5 bit immediate
+                # The K allows LLVM to emit an `csrrwi` instruction,
+                # which has room for one 5 bit immediate only.
+                "I, K",
+                [addr_val, val],
+                has_side_effects=True,
+            ),
+        ]
+
+    @staticmethod
+    def lower_setup_op(
+        setup_op: acc.SetupOp, acc_op: acc.AcceleratorOp
+    ) -> Sequence[Operation]:
+        field_to_csr = dict(acc_op.field_items())
+        ops: Sequence[Operation] = []
+        for field, val in setup_op.iter_params():
+            addr = field_to_csr[field]
+            ops.extend(
+                [
+                    addr_val := arith.Constant(addr),
+                    llvm.InlineAsmOp(
+                        "csrw $0, $1",
+                        "I, rK",
+                        [addr_val, val],
+                        has_side_effects=True,
+                    ),
+                ]
+            )
+        return ops

--- a/compiler/accelerators/snax.py
+++ b/compiler/accelerators/snax.py
@@ -6,18 +6,18 @@ from xdsl.dialects.builtin import i32
 from xdsl.dialects.scf import Condition, While, Yield
 from xdsl.ir import Operation
 
-from compiler.accelerators.accelerator import AcceleratorInterface
+from compiler.accelerators.accelerator import Accelerator
 from compiler.dialects import acc
 
 
-class SNAXAcceleratorInterface(AcceleratorInterface, ABC):
+class SNAXAccelerator(Accelerator, ABC):
     """
     Abstract base class for extending AcceleratorInterfaces
     with common SNAX lowerings.
     """
 
     @staticmethod
-    def lower_acc_barrier(acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
+    def lower_acc_await(acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
         return [
             While(
                 [],
@@ -76,7 +76,7 @@ class SNAXAcceleratorInterface(AcceleratorInterface, ABC):
         ]
 
     @staticmethod
-    def lower_setup_op(
+    def lower_acc_setup(
         setup_op: acc.SetupOp, acc_op: acc.AcceleratorOp
     ) -> Sequence[Operation]:
         field_to_csr = dict(acc_op.field_items())

--- a/compiler/accelerators/snax_hwpe_mult.py
+++ b/compiler/accelerators/snax_hwpe_mult.py
@@ -5,11 +5,11 @@ from xdsl.dialects.builtin import i32
 from xdsl.dialects.scf import Condition, While, Yield
 from xdsl.ir import Operation, SSAValue
 
-from compiler.accelerators.accelerator import AcceleratorInfo
+from compiler.accelerators.accelerator import AcceleratorInterface
 from compiler.dialects import acc
 
 
-class HWPEAcceleratorInfo(AcceleratorInfo):
+class HWPEAcceleratorInfo(AcceleratorInterface):
     name = "snax_hwpe_mult"
 
     fields = ("A", "B", "O", "vector_length", "nr_iters", "mode")
@@ -17,12 +17,6 @@ class HWPEAcceleratorInfo(AcceleratorInfo):
     def generate_setup_vals(
         self, op: linalg.Generic
     ) -> Sequence[tuple[Sequence[Operation], SSAValue]]:
-        """
-        Produce a `Sequence[Operation], SSAValue` tuple for each field that contains:
-
-        - a list of operations that calculate the field value
-        - a reference to the SSAValue containing the calculated field value
-        """
         a, b, c = op.operands
 
         zero = arith.Constant.from_int_and_width(0, builtin.IndexType())

--- a/compiler/accelerators/snax_hwpe_mult.py
+++ b/compiler/accelerators/snax_hwpe_mult.py
@@ -1,17 +1,19 @@
 from collections.abc import Sequence
 
-from xdsl.dialects import arith, builtin, linalg, llvm, memref
-from xdsl.dialects.builtin import i32
-from xdsl.dialects.scf import Condition, While, Yield
+from xdsl.dialects import arith, builtin, linalg, memref
 from xdsl.ir import Operation, SSAValue
 
-from compiler.accelerators.accelerator import AcceleratorInterface
+from compiler.accelerators.snax import SNAXAcceleratorInterface
 from compiler.dialects import acc
 
 
-class HWPEAcceleratorInfo(AcceleratorInterface):
-    name = "snax_hwpe_mult"
+class SNAXHWPEMultAcceleratorInterface(SNAXAcceleratorInterface):
+    """
+    Accelerator Interface class for SNAX HWPE multiplier accelerator
+    CSR lowerings are inherited from SNAXAcceleratorInterface.
+    """
 
+    name = "snax_hwpe_mult"
     fields = ("A", "B", "O", "vector_length", "nr_iters", "mode")
 
     def generate_setup_vals(
@@ -67,83 +69,3 @@ class HWPEAcceleratorInfo(AcceleratorInterface):
             0x3C0,
             0x3C3,
         )
-
-    @staticmethod
-    def lower_acc_barrier(acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
-        return [
-            While(
-                [],
-                [],
-                [
-                    barrier := arith.Constant(acc_op.barrier),
-                    zero := arith.Constant(
-                        builtin.IntegerAttr.from_int_and_width(0, 32)
-                    ),
-                    status := llvm.InlineAsmOp(
-                        "csrr $0, $1",
-                        # I = any 12 bit immediate
-                        # =r = store result in A 32- or 64-bit
-                        # general-purpose register (depending on the platform XLEN)
-                        "=r, I",
-                        [barrier],
-                        [i32],
-                        has_side_effects=True,
-                    ),
-                    # check if not equal to zero
-                    comparison := arith.Cmpi(status, zero, "ne"),
-                    Condition(comparison.results[0]),
-                ],
-                [
-                    Yield(),
-                ],
-            ),
-            addr_val := arith.Constant(builtin.IntegerAttr(965, 12)),  # 0x3c5 = 965
-            zero := arith.Constant(builtin.IntegerAttr.from_int_and_width(0, 5)),
-            llvm.InlineAsmOp(
-                "csrw $0, $1",
-                "I, K",
-                [addr_val, zero],
-                has_side_effects=True,
-            ),
-            # Three nops for random but important reasons
-            llvm.InlineAsmOp("nop", "", [], [], has_side_effects=True),
-            llvm.InlineAsmOp("nop", "", [], [], has_side_effects=True),
-            llvm.InlineAsmOp("nop", "", [], [], has_side_effects=True),
-        ]
-
-    @staticmethod
-    def lower_acc_launch(acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
-        return [
-            addr_val := arith.Constant(acc_op.launch_addr),
-            val := arith.Constant(builtin.IntegerAttr.from_int_and_width(0, 5)),
-            llvm.InlineAsmOp(
-                "csrw $0, $1",
-                # I = any 12 bit immediate, K = any 5 bit immediate
-                # The K allows LLVM to emit an `csrrwi` instruction,
-                # which has room for one 5 bit immediate only.
-                "I, K",
-                [addr_val, val],
-                has_side_effects=True,
-            ),
-        ]
-
-    @staticmethod
-    def lower_setup_op(
-        setup_op: acc.SetupOp, acc_op: acc.AcceleratorOp
-    ) -> Sequence[Operation]:
-        field_to_csr = dict(acc_op.field_items())
-        ops: Sequence[Operation] = []
-        for field, val in setup_op.iter_params():
-            addr = field_to_csr[field]
-            ops.extend(
-                [
-                    addr_val := arith.Constant(addr),
-                    llvm.InlineAsmOp(
-                        "csrw $0, $1",
-                        "I, rK",
-                        [addr_val, val],
-                        has_side_effects=True,
-                    ),
-                ]
-            )
-        return ops

--- a/compiler/accelerators/snax_hwpe_mult.py
+++ b/compiler/accelerators/snax_hwpe_mult.py
@@ -1,0 +1,73 @@
+from collections.abc import Sequence
+
+from xdsl.dialects import arith, builtin, linalg, memref
+from xdsl.ir import Operation, SSAValue
+
+from compiler.accelerators.accelerator import AcceleratorInfo
+from compiler.dialects import acc
+
+
+class HWPEAcceleratorInfo(AcceleratorInfo):
+    name = "snax_hwpe_mult"
+
+    fields = ("A", "B", "O", "vector_length", "nr_iters", "mode")
+
+    def generate_setup_vals(
+        self, op: linalg.Generic
+    ) -> Sequence[tuple[Sequence[Operation], SSAValue]]:
+        """
+        Produce a `Sequence[Operation], SSAValue` tuple for each field that contains:
+
+        - a list of operations that calculate the field value
+        - a reference to the SSAValue containing the calculated field value
+        """
+        a, b, c = op.operands
+
+        zero = arith.Constant.from_int_and_width(0, builtin.IndexType())
+        iters_one = arith.Constant.from_int_and_width(1, 32)
+        mode_one = arith.Constant.from_int_and_width(1, 32)
+        dim = memref.Dim.from_source_and_index(a, zero)
+        dim_i32 = arith.IndexCastOp(dim, builtin.i32)
+        vector_length = [zero, dim, dim_i32], dim_i32.result
+
+        nr_iters = [iters_one], iters_one.result
+        mode = [mode_one], mode_one.result
+
+        ptrs = [
+            (
+                [
+                    ptr := memref.ExtractAlignedPointerAsIndexOp.get(ref),
+                    ptr_i32 := arith.IndexCastOp(ptr, builtin.i32),
+                ],
+                ptr_i32.result,
+            )
+            for ref in (a, b, c)
+        ]
+
+        return ptrs + [nr_iters] + [vector_length] + [mode]
+
+    def generate_acc_op(self) -> acc.AcceleratorOp:
+        """
+        Return this accelerator op:
+
+        "acc2.accelerator"() <{
+            name            = @snax_hwpe_mult,
+            fields          = {A=0x3d0, B=0x3d1, O=0x3d3, n_iters=0x3d4,
+                               vector_length=0x3d5, mode=0x3d6},
+            launch_addr     = 0x3c0,
+            barrier = 0x3c3,
+        }> : () -> ()
+        """
+        return acc.AcceleratorOp(
+            self.name,
+            {
+                "A": 0x3D0,
+                "B": 0x3D1,
+                "O": 0x3D3,
+                "vector_length": 0x3D4,
+                "nr_iters": 0x3D5,
+                "mode": 0x3D6,
+            },
+            0x3C0,
+            0x3C3,
+        )

--- a/compiler/accelerators/snax_hwpe_mult.py
+++ b/compiler/accelerators/snax_hwpe_mult.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 
 from xdsl.dialects import arith, builtin, linalg, llvm, memref
-from xdsl.dialects.builtin import i32
+from xdsl.dialects.builtin import IntegerAttr, i32
 from xdsl.dialects.scf import Condition, While, Yield
 from xdsl.ir import Operation, SSAValue
 
@@ -126,6 +126,17 @@ class HWPEAcceleratorInfo(AcceleratorInfo):
                 # The K allows LLVM to emit an `csrrwi` instruction,
                 # which has room for one 5 bit immediate only.
                 "I, K",
+                [addr_val, val],
+                has_side_effects=True,
+            ),
+        ]
+
+    def lower_setup_op(self, addr: IntegerAttr, val: SSAValue) -> Sequence[Operation]:
+        return [
+            addr_val := arith.Constant(addr),
+            llvm.InlineAsmOp(
+                "csrw $0, $1",
+                "I, rK",
                 [addr_val, val],
                 has_side_effects=True,
             ),

--- a/compiler/accelerators/snax_hwpe_mult.py
+++ b/compiler/accelerators/snax_hwpe_mult.py
@@ -74,7 +74,8 @@ class HWPEAcceleratorInfo(AcceleratorInfo):
             0x3C3,
         )
 
-    def lower_acc_barrier(self, acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
+    @staticmethod
+    def lower_acc_barrier(acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
         return [
             While(
                 [],
@@ -116,7 +117,8 @@ class HWPEAcceleratorInfo(AcceleratorInfo):
             llvm.InlineAsmOp("nop", "", [], [], has_side_effects=True),
         ]
 
-    def lower_acc_launch(self, acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
+    @staticmethod
+    def lower_acc_launch(acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
         return [
             addr_val := arith.Constant(acc_op.launch_addr),
             val := arith.Constant(builtin.IntegerAttr.from_int_and_width(0, 5)),
@@ -131,8 +133,9 @@ class HWPEAcceleratorInfo(AcceleratorInfo):
             ),
         ]
 
+    @staticmethod
     def lower_setup_op(
-        self, setup_op: acc.SetupOp, acc_op: acc.AcceleratorOp
+        setup_op: acc.SetupOp, acc_op: acc.AcceleratorOp
     ) -> Sequence[Operation]:
         field_to_csr = dict(acc_op.field_items())
         ops: Sequence[Operation] = []

--- a/compiler/accelerators/snax_hwpe_mult.py
+++ b/compiler/accelerators/snax_hwpe_mult.py
@@ -3,11 +3,11 @@ from collections.abc import Sequence
 from xdsl.dialects import arith, builtin, linalg, memref
 from xdsl.ir import Operation, SSAValue
 
-from compiler.accelerators.snax import SNAXAcceleratorInterface
+from compiler.accelerators.snax import SNAXAccelerator
 from compiler.dialects import acc
 
 
-class SNAXHWPEMultAcceleratorInterface(SNAXAcceleratorInterface):
+class SNAXHWPEMultAccelerator(SNAXAccelerator):
     """
     Accelerator Interface class for SNAX HWPE multiplier accelerator
     CSR lowerings are inherited from SNAXAcceleratorInterface.

--- a/compiler/transforms/convert_acc_to_csr.py
+++ b/compiler/transforms/convert_acc_to_csr.py
@@ -58,13 +58,11 @@ class LowerAccSetupToCsr(LowerAccBasePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: acc.SetupOp, rewriter: PatternRewriter, /):
         # grab a dict that translates field names to CSR addresses:
-        field_to_csr = dict(self.get_acc(op.accelerator).field_items())
         acc_info = HWPEAcceleratorInfo()
-
         # emit the llvm assembly code to set csr values:
-        for field, val in op.iter_params():
-            addr = field_to_csr[field]
-            rewriter.insert_op_before_matched_op(acc_info.lower_setup_op(addr, val))
+        rewriter.insert_op_before_matched_op(
+            acc_info.lower_setup_op(op, self.get_acc(op.accelerator))
+        )
         # delete the old setup op
         rewriter.erase_matched_op(safe_erase=False)
 

--- a/compiler/transforms/convert_acc_to_csr.py
+++ b/compiler/transforms/convert_acc_to_csr.py
@@ -15,7 +15,7 @@ from xdsl.pattern_rewriter import (
 )
 from xdsl.traits import SymbolTable
 
-from compiler.accelerators.snax_hwpe_mult import HWPEAcceleratorInfo
+from compiler.accelerators.snax_hwpe_mult import SNAXHWPEMultAcceleratorInterface
 from compiler.dialects import acc
 
 
@@ -58,7 +58,7 @@ class LowerAccSetupToCsr(LowerAccBasePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: acc.SetupOp, rewriter: PatternRewriter, /):
         # grab a dict that translates field names to CSR addresses:
-        acc_info = HWPEAcceleratorInfo()
+        acc_info = SNAXHWPEMultAcceleratorInterface()
         # emit the llvm assembly code to set csr values:
         rewriter.insert_op_before_matched_op(
             acc_info.lower_setup_op(op, self.get_acc(op.accelerator))
@@ -76,7 +76,7 @@ class LowerAccLaunchToCsr(LowerAccBasePattern):
     def match_and_rewrite(self, op: acc.LaunchOp, rewriter: PatternRewriter, /):
         assert isinstance(op.state.type, acc.StateType)
         acc_op = self.get_acc(op.state.type.accelerator)
-        acc_info = HWPEAcceleratorInfo()
+        acc_info = SNAXHWPEMultAcceleratorInterface()
 
         # insert an op that sets the launch CSR to 1
         rewriter.replace_matched_op(
@@ -94,7 +94,7 @@ class LowerAccAwaitToCsr(LowerAccBasePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: acc.AwaitOp, rewriter: PatternRewriter, /):
         assert isinstance(op.token.type, acc.StateType | acc.TokenType)
-        acc_info = HWPEAcceleratorInfo()
+        acc_info = SNAXHWPEMultAcceleratorInterface()
         acc_op = self.get_acc(op.token.type.accelerator)
 
         # emit a snax_hwpe-style barrier

--- a/compiler/transforms/convert_linalg_to_acc.py
+++ b/compiler/transforms/convert_linalg_to_acc.py
@@ -12,7 +12,7 @@ from xdsl.pattern_rewriter import (
 )
 from xdsl.traits import SymbolTable
 
-from compiler.accelerators.snax_hwpe_mult import HWPEAcceleratorInfo
+from compiler.accelerators.snax_hwpe_mult import SNAXHWPEMultAcceleratorInterface
 from compiler.dialects import acc
 
 
@@ -34,7 +34,7 @@ class ConvertLinalgToAcceleratorPattern(RewritePattern):
             return
 
         # grab accelerator
-        accelerator = HWPEAcceleratorInfo()
+        accelerator = SNAXHWPEMultAcceleratorInterface()
 
         t = self.module.get_trait(SymbolTable)
         assert t is not None

--- a/compiler/transforms/convert_linalg_to_acc.py
+++ b/compiler/transforms/convert_linalg_to_acc.py
@@ -12,7 +12,7 @@ from xdsl.pattern_rewriter import (
 )
 from xdsl.traits import SymbolTable
 
-from compiler.accelerators.snax_hwpe_mult import SNAXHWPEMultAcceleratorInterface
+from compiler.accelerators.snax_hwpe_mult import SNAXHWPEMultAccelerator
 from compiler.dialects import acc
 
 
@@ -34,7 +34,7 @@ class ConvertLinalgToAcceleratorPattern(RewritePattern):
             return
 
         # grab accelerator
-        accelerator = SNAXHWPEMultAcceleratorInterface()
+        accelerator = SNAXHWPEMultAccelerator()
 
         t = self.module.get_trait(SymbolTable)
         assert t is not None

--- a/compiler/transforms/convert_linalg_to_acc.py
+++ b/compiler/transforms/convert_linalg_to_acc.py
@@ -1,8 +1,7 @@
 import sys
-from collections.abc import Sequence
 from dataclasses import dataclass, field
 
-from xdsl.dialects import arith, builtin, func, linalg, memref, scf
+from xdsl.dialects import builtin, func, linalg, scf
 from xdsl.ir import Block, MLContext, Operation, Region, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -13,74 +12,8 @@ from xdsl.pattern_rewriter import (
 )
 from xdsl.traits import SymbolTable
 
-from compiler.accelerators.accelerator import AcceleratorInfo
+from compiler.accelerators.snax_hwpe_mult import HWPEAcceleratorInfo
 from compiler.dialects import acc
-
-
-class HWPEAcceleratorInfo(AcceleratorInfo):
-    name = "snax_hwpe_mult"
-
-    fields = ("A", "B", "O", "vector_length", "nr_iters", "mode")
-
-    def generate_setup_vals(
-        self, op: linalg.Generic
-    ) -> Sequence[tuple[Sequence[Operation], SSAValue]]:
-        """
-        Produce a `Sequence[Operation], SSAValue` tuple for each field that contains:
-
-        - a list of operations that calculate the field value
-        - a reference to the SSAValue containing the calculated field value
-        """
-        a, b, c = op.operands
-
-        zero = arith.Constant.from_int_and_width(0, builtin.IndexType())
-        iters_one = arith.Constant.from_int_and_width(1, 32)
-        mode_one = arith.Constant.from_int_and_width(1, 32)
-        dim = memref.Dim.from_source_and_index(a, zero)
-        dim_i32 = arith.IndexCastOp(dim, builtin.i32)
-        vector_length = [zero, dim, dim_i32], dim_i32.result
-
-        nr_iters = [iters_one], iters_one.result
-        mode = [mode_one], mode_one.result
-
-        ptrs = [
-            (
-                [
-                    ptr := memref.ExtractAlignedPointerAsIndexOp.get(ref),
-                    ptr_i32 := arith.IndexCastOp(ptr, builtin.i32),
-                ],
-                ptr_i32.result,
-            )
-            for ref in (a, b, c)
-        ]
-
-        return ptrs + [nr_iters] + [vector_length] + [mode]
-
-    def generate_acc_op(self) -> acc.AcceleratorOp:
-        """
-        Return this accelerator op:
-
-        "acc2.accelerator"() <{
-            name            = @snax_hwpe_mult,
-            fields          = {A=0x3d0, B=0x3d1, O=0x3d3, n_iters=0x3d4,
-                               vector_length=0x3d5, mode=0x3d6},
-            launch_addr     = 0x3c0,
-            barrier = 0x3c3,
-        }> : () -> ()
-        """
-        return acc.AcceleratorOp(
-            self.name,
-            {
-                "A": 0x3D0,
-                "B": 0x3D1,
-                "O": 0x3D3,
-                "vector_length": 0x3D4,
-                "nr_iters": 0x3D5,
-                "mode": 0x3D6,
-            },
-            0x3C0,
-            0x3C3,
-        )
 
 
 @dataclass
@@ -108,7 +41,7 @@ class ConvertLinalgToAcceleratorPattern(RewritePattern):
         t.insert_or_update(self.module, accelerator.generate_acc_op())
 
         # grab arguments
-        args = accelerator.generate_vals(op)
+        args = accelerator.generate_setup_vals(op)
 
         # insert ops to calculate arguments
         for new_ops, _ in args:

--- a/compiler/transforms/convert_linalg_to_acc.py
+++ b/compiler/transforms/convert_linalg_to_acc.py
@@ -1,5 +1,4 @@
 import sys
-from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 
@@ -14,19 +13,8 @@ from xdsl.pattern_rewriter import (
 )
 from xdsl.traits import SymbolTable
 
+from compiler.accelerators.accelerator import AcceleratorInfo
 from compiler.dialects import acc
-
-
-class AcceleratorInfo(ABC):
-    @abstractmethod
-    def generate_setup_vals(
-        self, op: Operation
-    ) -> Sequence[tuple[Sequence[Operation], SSAValue]]:
-        pass
-
-    @abstractmethod
-    def generate_acc_op(self) -> acc.AcceleratorOp:
-        pass
 
 
 class HWPEAcceleratorInfo(AcceleratorInfo):

--- a/compiler/transforms/convert_linalg_to_acc.py
+++ b/compiler/transforms/convert_linalg_to_acc.py
@@ -1,4 +1,5 @@
 import sys
+from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 
@@ -16,12 +17,24 @@ from xdsl.traits import SymbolTable
 from compiler.dialects import acc
 
 
-class HWPEAcceleratorInfo:
+class AcceleratorInfo(ABC):
+    @abstractmethod
+    def generate_setup_vals(
+        self, op: Operation
+    ) -> Sequence[tuple[Sequence[Operation], SSAValue]]:
+        pass
+
+    @abstractmethod
+    def generate_acc_op(self) -> acc.AcceleratorOp:
+        pass
+
+
+class HWPEAcceleratorInfo(AcceleratorInfo):
     name = "snax_hwpe_mult"
 
     fields = ("A", "B", "O", "vector_length", "nr_iters", "mode")
 
-    def generate_vals(
+    def generate_setup_vals(
         self, op: linalg.Generic
     ) -> Sequence[tuple[Sequence[Operation], SSAValue]]:
         """


### PR DESCRIPTION
This PR adds an abstract base class that implements an interface for converting to and from acc2 dialect.
The idea is that people adding new accelerators mainly add stuff in a subclass of `AcceleratorInterface` and that then they should be good to go. This should also enable people to add non-SNAX accelerators, or for us to more quickly adapt to general changes in SNAX architecture.

Going to acc2 dialect:
* `generate_setup_vals`: To insert the right values (coming from anywhere in the IR) to the SetupOp, I expect this part of the interface will have to be reworked soon.
* `generate_acc_op`: To create instances of an AcceleratoOp, the accelerator_op itself might need to be a bit more flexible in what types of barriers it supports etc. This might have repercussions on the lowering of barriers etc: To be seen.

Going out of acc2 dialect:
* `lower_setup_op`
* `lower_launch_op`
* `lower_await_op`
Lowerings to a bunch of IR that performs those operations

For this PR, i've implemented the ABC, together with a SNAXHWPEMultInterface. It inherits from SNAXInterface, an ABC that overrides the lowerings with common behaviour, since for SNAX these probably will all be the same anyway.

Some feedback would be nice on:
* Naming of everything
* Should I split the going in and out in two separate ABCs? Thanks!
* I've angered Pyright in the definition of the `generate_setup_vals` (Operation != linalg.Generic). Any thoughts on how to fix/how to make better? 
* I would love a way to properly "register" new accelerators. Right now the way the passes are implemented with a weird interplay between in-IR acceleratorOps and part of the info is gotten from the interface itself.
