### PR TITLE
acc2: Add an accelerator registry for lowering transforms

### DIFF
--- a/compiler/accelerators/registry.py
+++ b/compiler/accelerators/registry.py
@@ -3,4 +3,9 @@ from compiler.accelerators.snax_hwpe_mult import SNAXHWPEMultAccelerator
 
 
 def get_registered_accelerators() -> dict[str, type[Accelerator]]:
+    """
+    Get a reference to an Accelerator interface based on a symbol name
+    This registry is used to get specific accelerator conversions from
+    a query based on an acc2.acceleratorop.
+    """
     return {"snax_hwpe_mult": SNAXHWPEMultAccelerator}

--- a/compiler/accelerators/registry.py
+++ b/compiler/accelerators/registry.py
@@ -1,0 +1,6 @@
+from compiler.accelerators.accelerator import Accelerator
+from compiler.accelerators.snax_hwpe_mult import SNAXHWPEMultAccelerator
+
+
+def get_registered_accelerators() -> dict[str, type[Accelerator]]:
+    return {"snax_hwpe_mult": SNAXHWPEMultAccelerator}

--- a/compiler/transforms/convert_acc_to_csr.py
+++ b/compiler/transforms/convert_acc_to_csr.py
@@ -17,7 +17,6 @@ from xdsl.traits import SymbolTable
 
 from compiler.accelerators.accelerator import Accelerator
 from compiler.accelerators.registry import get_registered_accelerators
-from compiler.accelerators.snax_hwpe_mult import SNAXHWPEMultAccelerator
 from compiler.dialects import acc
 
 
@@ -191,15 +190,12 @@ class RemoveAcceleratorOps(RewritePattern):
         rewriter.erase_matched_op()
 
 
-@dataclass(frozen=True)
 class ConvertAccToCsrPass(ModulePass):
     """
     Converts acc2 dialect ops to series of SNAX-like csr sets.
     """
 
     name = "convert-acc-to-csr"
-
-    accelerator: type[Accelerator] = SNAXHWPEMultAccelerator
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         # first lower all acc2 ops and erase old SSA values

--- a/compiler/transforms/convert_acc_to_csr.py
+++ b/compiler/transforms/convert_acc_to_csr.py
@@ -15,6 +15,8 @@ from xdsl.pattern_rewriter import (
 )
 from xdsl.traits import SymbolTable
 
+from compiler.accelerators.accelerator import Accelerator
+from compiler.accelerators.registry import get_registered_accelerators
 from compiler.accelerators.snax_hwpe_mult import SNAXHWPEMultAccelerator
 from compiler.dialects import acc
 
@@ -30,7 +32,9 @@ class LowerAccBasePattern(RewritePattern, ABC):
     module: builtin.ModuleOp
 
     @cache
-    def get_acc(self, accelerator: StringAttr) -> acc.AcceleratorOp:
+    def get_acc(
+        self, accelerator: StringAttr
+    ) -> tuple[acc.AcceleratorOp, type[Accelerator]]:
         """
         Get a reference to the accelerator
         """
@@ -41,7 +45,9 @@ class LowerAccBasePattern(RewritePattern, ABC):
             raise RuntimeError(
                 f"Invalid IR: no accelerator op for @{accelerator.data} found in module"
             )
-        return acc_op
+        # Get accelerator interface with symbolref without @
+        acc_info = get_registered_accelerators()[str(acc_op.name_prop)[1:]]
+        return acc_op, acc_info
 
     def __hash__(self):
         return id(self)
@@ -57,12 +63,10 @@ class LowerAccSetupToCsr(LowerAccBasePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: acc.SetupOp, rewriter: PatternRewriter, /):
+        acc_op, acc_info = self.get_acc(op.accelerator)
         # grab a dict that translates field names to CSR addresses:
-        acc_info = SNAXHWPEMultAccelerator()
         # emit the llvm assembly code to set csr values:
-        rewriter.insert_op_before_matched_op(
-            acc_info.lower_acc_setup(op, self.get_acc(op.accelerator))
-        )
+        rewriter.insert_op_before_matched_op(acc_info.lower_acc_setup(op, acc_op))
         # delete the old setup op
         rewriter.erase_matched_op(safe_erase=False)
 
@@ -75,8 +79,7 @@ class LowerAccLaunchToCsr(LowerAccBasePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: acc.LaunchOp, rewriter: PatternRewriter, /):
         assert isinstance(op.state.type, acc.StateType)
-        acc_op = self.get_acc(op.state.type.accelerator)
-        acc_info = SNAXHWPEMultAccelerator()
+        acc_op, acc_info = self.get_acc(op.state.type.accelerator)
 
         # insert an op that sets the launch CSR to 1
         rewriter.replace_matched_op(
@@ -94,8 +97,7 @@ class LowerAccAwaitToCsr(LowerAccBasePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: acc.AwaitOp, rewriter: PatternRewriter, /):
         assert isinstance(op.token.type, acc.StateType | acc.TokenType)
-        acc_info = SNAXHWPEMultAccelerator()
-        acc_op = self.get_acc(op.token.type.accelerator)
+        acc_op, acc_info = self.get_acc(op.token.type.accelerator)
 
         # emit a snax_hwpe-style barrier
         rewriter.replace_matched_op(
@@ -185,12 +187,15 @@ class RemoveAcceleratorOps(RewritePattern):
         rewriter.erase_matched_op()
 
 
+@dataclass(frozen=True)
 class ConvertAccToCsrPass(ModulePass):
     """
     Converts acc2 dialect ops to series of SNAX-like csr sets.
     """
 
     name = "convert-acc-to-csr"
+
+    accelerator: type[Accelerator] = SNAXHWPEMultAccelerator
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         # first lower all acc2 ops and erase old SSA values

--- a/tests/filecheck/transforms/convert-linalg-to-acc.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-acc.mlir
@@ -1,5 +1,13 @@
 // RUN: ./compiler/snax-opt -p convert-linalg-to-acc,mlir-opt{executable=mlir-opt-17\ generic=true\ arguments='-cse,-canonicalize,-allow-unregistered-dialect,-mlir-print-op-generic'} %s | filecheck %s
 
+"acc2.accelerator"() <{
+    name            = @snax_hwpe_mult,
+    fields          = {A=0x3d0, B=0x3d1, O=0x3d3, vector_length=0x3d4, nr_iters=0x3d5, mode=0x3d6},
+    launch_addr     = 0x3c0,
+    barrier         = 0x3c3
+}> : () -> ()
+
+
 "builtin.module"() ({
   func.func public @simple_mult(
     %A: memref<?xi32>,

--- a/tests/filecheck/transforms/convert-linalg-to-acc.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-acc.mlir
@@ -1,14 +1,13 @@
 // RUN: ./compiler/snax-opt -p convert-linalg-to-acc,mlir-opt{executable=mlir-opt-17\ generic=true\ arguments='-cse,-canonicalize,-allow-unregistered-dialect,-mlir-print-op-generic'} %s | filecheck %s
 
-"acc2.accelerator"() <{
-    name            = @snax_hwpe_mult,
-    fields          = {A=0x3d0, B=0x3d1, O=0x3d3, vector_length=0x3d4, nr_iters=0x3d5, mode=0x3d6},
-    launch_addr     = 0x3c0,
-    barrier         = 0x3c3
-}> : () -> ()
-
-
 "builtin.module"() ({
+  "acc2.accelerator"() <{
+      name            = @snax_hwpe_mult,
+      fields          = {A=0x3d0, B=0x3d1, O=0x3d3, vector_length=0x3d4, nr_iters=0x3d5, mode=0x3d6},
+      launch_addr     = 0x3c0,
+      barrier         = 0x3c3
+  }> : () -> ()
+
   func.func public @simple_mult(
     %A: memref<?xi32>,
     %B: memref<?xi32>,
@@ -62,6 +61,7 @@
 }): () -> ()
 
 // CHECK-NEXT: builtin.module {
+// CHECK-NEXT:   "acc2.accelerator"() <{"barrier" = 963 : i32, "fields" = {"A" = 976 : i32, "B" = 977 : i32, "O" = 979 : i32, "mode" = 982 : i32, "nr_iters" = 981 : i32, "vector_length" = 980 : i32}, "launch_addr" = 960 : i32, "name" = @snax_hwpe_mult}> : () -> ()
 // CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
 // CHECK-NEXT:     %0 = arith.constant 0 : index
 // CHECK-NEXT:     %1 = arith.constant 1 : i32
@@ -96,5 +96,4 @@
 // CHECK-NEXT:     "acc2.await"(%22) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
-// CHECK-NEXT:   "acc2.accelerator"() <{"barrier" = 963 : i32, "fields" = {"A" = 976 : i32, "B" = 977 : i32, "O" = 979 : i32, "mode" = 982 : i32, "nr_iters" = 981 : i32, "vector_length" = 980 : i32}, "launch_addr" = 960 : i32, "name" = @snax_hwpe_mult}> : () -> ()
 // CHECK-NEXT: } 

--- a/tests/filecheck/transforms/convert-linalg-to-acc.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-acc.mlir
@@ -1,13 +1,6 @@
 // RUN: ./compiler/snax-opt -p convert-linalg-to-acc,mlir-opt{executable=mlir-opt-17\ generic=true\ arguments='-cse,-canonicalize,-allow-unregistered-dialect,-mlir-print-op-generic'} %s | filecheck %s
 
 "builtin.module"() ({
-  "acc2.accelerator"() <{
-      name            = @snax_hwpe_mult,
-      fields          = {A=0x3d0, B=0x3d1, O=0x3d3, vector_length=0x3d4, nr_iters=0x3d5, mode=0x3d6},
-      launch_addr     = 0x3c0,
-      barrier         = 0x3c3
-  }> : () -> ()
-
   func.func public @simple_mult(
     %A: memref<?xi32>,
     %B: memref<?xi32>,
@@ -61,7 +54,6 @@
 }): () -> ()
 
 // CHECK-NEXT: builtin.module {
-// CHECK-NEXT:   "acc2.accelerator"() <{"barrier" = 963 : i32, "fields" = {"A" = 976 : i32, "B" = 977 : i32, "O" = 979 : i32, "mode" = 982 : i32, "nr_iters" = 981 : i32, "vector_length" = 980 : i32}, "launch_addr" = 960 : i32, "name" = @snax_hwpe_mult}> : () -> ()
 // CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
 // CHECK-NEXT:     %0 = arith.constant 0 : index
 // CHECK-NEXT:     %1 = arith.constant 1 : i32
@@ -96,4 +88,5 @@
 // CHECK-NEXT:     "acc2.await"(%22) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
+// CHECK-NEXT:   "acc2.accelerator"() <{"barrier" = 963 : i32, "fields" = {"A" = 976 : i32, "B" = 977 : i32, "O" = 979 : i32, "mode" = 982 : i32, "nr_iters" = 981 : i32, "vector_length" = 980 : i32}, "launch_addr" = 960 : i32, "name" = @snax_hwpe_mult}> : () -> ()
 // CHECK-NEXT: } 


### PR DESCRIPTION
This PR solves the problem that if there are multiple accelerators in the IR they should be lowered in a different way.
It adds a "registry" = a dict that maps symbol names to the Accelerator interface introduced in #114 .
That way we can query the right lowering through the `accelerator.op`'s symbol at runtime.

Right now it's very simple, but this can be made more complex in the future if necessary.

Note that this requires the IR to be annotated with the acc.AcceleratorOp, otherwise the right passes can not be queried. Before they were hardcoded :) so it wasn't necessary to put them there.
Note that the lowerings from linalg are still hardcoded. This is work for the next PR.