### PR TITLE
acc2: Add registry for converting to acc2 dialect

### DIFF
--- a/compiler/accelerators/accelerator.py
+++ b/compiler/accelerators/accelerator.py
@@ -11,6 +11,9 @@ class Accelerator(ABC):
     Interface to lower to and from acc2 dialect.
     """
 
+    name: str
+    fields: tuple[str]
+
     @abstractmethod
     def generate_setup_vals(
         self, op: Operation

--- a/compiler/accelerators/registry.py
+++ b/compiler/accelerators/registry.py
@@ -1,11 +1,26 @@
+from collections.abc import Iterable, Mapping
+
 from compiler.accelerators.accelerator import Accelerator
 from compiler.accelerators.snax_hwpe_mult import SNAXHWPEMultAccelerator
 
 
-def get_registered_accelerators() -> dict[str, type[Accelerator]]:
+class AcceleratorRegistry:
     """
-    Get a reference to an Accelerator interface based on a symbol name
     This registry is used to get specific accelerator conversions from
     a query based on an acc2.acceleratorop.
     """
-    return {"snax_hwpe_mult": SNAXHWPEMultAccelerator}
+
+    registered_accelerators = {"snax_hwpe_mult": SNAXHWPEMultAccelerator}
+
+    def get_registry(self) -> Mapping[str, type[Accelerator]]:
+        """
+        Get a reference to an Accelerator interface based on a symbol name
+        """
+        return self.registered_accelerators
+
+    def get_names(self) -> Iterable[str]:
+        """
+        Get an Iterable of strings that contains the names of the
+        registered accelerators.
+        """
+        return self.registered_accelerators.keys()

--- a/compiler/accelerators/registry.py
+++ b/compiler/accelerators/registry.py
@@ -1,5 +1,8 @@
 from collections.abc import Iterable
 
+from xdsl.dialects.builtin import ModuleOp, StringAttr
+from xdsl.traits import SymbolTable
+
 from compiler.accelerators.accelerator import Accelerator
 from compiler.accelerators.snax_hwpe_mult import SNAXHWPEMultAccelerator
 from compiler.dialects.acc import AcceleratorOp
@@ -12,6 +15,26 @@ class AcceleratorRegistry:
     """
 
     registered_accelerators = {"snax_hwpe_mult": SNAXHWPEMultAccelerator}
+
+    def lookup_acc_info(
+        self, acc_query: StringAttr, module: ModuleOp
+    ) -> tuple[AcceleratorOp, type[Accelerator]]:
+        """
+        Perform a symbol table lookup for the accelerator op in the IR
+        and then get the corresponding the Accelerator interface from
+        the accelerator registry.
+        Returns both the looked up accelerator op and the Accelerator interface
+        """
+        trait = module.get_trait(SymbolTable)
+        assert trait is not None
+        acc_op = trait.lookup_symbol(module, acc_query)
+        if not isinstance(acc_op, AcceleratorOp):
+            raise RuntimeError(
+                f"Symbol Table lookup failed for accelerator '{acc_query.data}'. "
+                "Is the symbol declared by an acc2.accelerator op in the module?"
+            )
+        else:
+            return acc_op, self.get_acc_info(acc_op)
 
     def get_acc_info(self, acc_op: AcceleratorOp) -> type[Accelerator]:
         """

--- a/compiler/accelerators/registry.py
+++ b/compiler/accelerators/registry.py
@@ -1,7 +1,8 @@
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 
 from compiler.accelerators.accelerator import Accelerator
 from compiler.accelerators.snax_hwpe_mult import SNAXHWPEMultAccelerator
+from compiler.dialects.acc import AcceleratorOp
 
 
 class AcceleratorRegistry:
@@ -12,11 +13,20 @@ class AcceleratorRegistry:
 
     registered_accelerators = {"snax_hwpe_mult": SNAXHWPEMultAccelerator}
 
-    def get_registry(self) -> Mapping[str, type[Accelerator]]:
+    def get_acc_info(self, acc_op: AcceleratorOp) -> type[Accelerator]:
         """
         Get a reference to an Accelerator interface based on a symbol name
+        If the requested symbol name is not available, throw a RuntimeError
         """
-        return self.registered_accelerators
+        acc_name = acc_op.name_prop.string_value()
+        try:
+            acc_info = self.registered_accelerators[acc_name]
+        except KeyError:
+            raise RuntimeError(
+                f"'{acc_name}' is not a registered accelerator."
+                f"Registered accelerators: {','.join(self.get_names())}"
+            )
+        return acc_info
 
     def get_names(self) -> Iterable[str]:
         """

--- a/compiler/transforms/convert_acc_to_csr.py
+++ b/compiler/transforms/convert_acc_to_csr.py
@@ -48,7 +48,7 @@ class LowerAccBasePattern(RewritePattern, ABC):
                 " in the current module."
             )
         # Use the retrieved acc_op to retrieve information from the registry
-        acc_info = AcceleratorRegistry().get_registry()[acc_op.name_prop.string_value()]
+        acc_info = AcceleratorRegistry().get_acc_info(acc_op)
         return acc_op, acc_info
 
     def __hash__(self):

--- a/compiler/transforms/convert_acc_to_csr.py
+++ b/compiler/transforms/convert_acc_to_csr.py
@@ -13,7 +13,6 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
-from xdsl.traits import SymbolTable
 
 from compiler.accelerators.accelerator import Accelerator
 from compiler.accelerators.registry import AcceleratorRegistry
@@ -34,21 +33,9 @@ class LowerAccBasePattern(RewritePattern, ABC):
     def get_acc(
         self, accelerator: StringAttr
     ) -> tuple[acc.AcceleratorOp, type[Accelerator]]:
-        """
-        Get a reference to the accelerator
-        """
-        trait = self.module.get_trait(SymbolTable)
-        assert trait is not None
-        acc_op = trait.lookup_symbol(self.module, accelerator)
-        if not isinstance(acc_op, acc.AcceleratorOp):
-            raise RuntimeError(
-                f"Invalid IR: Lowering acc2 for accelerator '{accelerator.data}'"
-                " requires an acc2.accelerator op to declare a symbol for "
-                f"@{accelerator.data}, but no such symbol was found"
-                " in the current module."
-            )
-        # Use the retrieved acc_op to retrieve information from the registry
-        acc_info = AcceleratorRegistry().get_acc_info(acc_op)
+        acc_op, acc_info = AcceleratorRegistry().lookup_acc_info(
+            accelerator, self.module
+        )
         return acc_op, acc_info
 
     def __hash__(self):

--- a/compiler/transforms/convert_acc_to_csr.py
+++ b/compiler/transforms/convert_acc_to_csr.py
@@ -16,7 +16,7 @@ from xdsl.pattern_rewriter import (
 from xdsl.traits import SymbolTable
 
 from compiler.accelerators.accelerator import Accelerator
-from compiler.accelerators.registry import get_registered_accelerators
+from compiler.accelerators.registry import AcceleratorRegistry
 from compiler.dialects import acc
 
 
@@ -48,7 +48,7 @@ class LowerAccBasePattern(RewritePattern, ABC):
                 " in the current module."
             )
         # Use the retrieved acc_op to retrieve information from the registry
-        acc_info = get_registered_accelerators()[acc_op.name_prop.string_value()]
+        acc_info = AcceleratorRegistry().get_registry()[acc_op.name_prop.string_value()]
         return acc_op, acc_info
 
     def __hash__(self):

--- a/tests/filecheck/transforms/convert-linalg-to-acc.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-acc.mlir
@@ -1,6 +1,14 @@
 // RUN: ./compiler/snax-opt -p convert-linalg-to-acc,mlir-opt{executable=mlir-opt-17\ generic=true\ arguments='-cse,-canonicalize,-allow-unregistered-dialect,-mlir-print-op-generic'} %s | filecheck %s
 
 "builtin.module"() ({
+
+  "acc2.accelerator"() <{
+      name            = @snax_hwpe_mult,
+      fields          = {A=0x3d0, B=0x3d1, O=0x3d3, vector_length=0x3d4, nr_iters=0x3d5, mode=0x3d6},
+      launch_addr     = 0x3c0,
+      barrier         = 0x3c3
+  }> : () -> ()
+
   func.func public @simple_mult(
     %A: memref<?xi32>,
     %B: memref<?xi32>,
@@ -54,6 +62,7 @@
 }): () -> ()
 
 // CHECK-NEXT: builtin.module {
+// CHECK-NEXT:   "acc2.accelerator"() <{"barrier" = 963 : i64, "fields" = {"A" = 976 : i64, "B" = 977 : i64, "O" = 979 : i64, "mode" = 982 : i64, "nr_iters" = 981 : i64, "vector_length" = 980 : i64}, "launch_addr" = 960 : i64, "name" = @snax_hwpe_mult}> : () -> ()
 // CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
 // CHECK-NEXT:     %0 = arith.constant 0 : index
 // CHECK-NEXT:     %1 = arith.constant 1 : i32
@@ -88,5 +97,4 @@
 // CHECK-NEXT:     "acc2.await"(%22) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
-// CHECK-NEXT:   "acc2.accelerator"() <{"barrier" = 963 : i32, "fields" = {"A" = 976 : i32, "B" = 977 : i32, "O" = 979 : i32, "mode" = 982 : i32, "nr_iters" = 981 : i32, "vector_length" = 980 : i32}, "launch_addr" = 960 : i32, "name" = @snax_hwpe_mult}> : () -> ()
 // CHECK-NEXT: } 


### PR DESCRIPTION
This adds the remaining part that needs to be queried from the AcceleratorRegistry to go to the acc2 dialect.