### PR TITLE
acc2: Add values to launch field

### DIFF
--- a/compiler/accelerators/accelerator.py
+++ b/compiler/accelerators/accelerator.py
@@ -35,7 +35,7 @@ class Accelerator(ABC):
         "acc2.accelerator"() <{
             name            = @name_of_the_accelerator,
             fields          = {field_1=address_1, field_2=address2},
-            launch_addr     = launch_address,
+            launch_fields   = {launch_field_1=address_1,
             barrier         = barrier_address,
         }> : () -> ()
         """

--- a/compiler/accelerators/accelerator.py
+++ b/compiler/accelerators/accelerator.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
-from xdsl.ir import Operation, SSAValue
+from xdsl.ir import Operation
 
 from compiler.dialects import acc
 
@@ -15,15 +15,16 @@ class Accelerator(ABC):
     fields: tuple[str]
 
     @abstractmethod
-    def generate_setup_vals(
-        self, op: Operation
-    ) -> Sequence[tuple[Sequence[Operation], SSAValue]]:
+    def convert_to_acc_ops(self, op: type[Operation]) -> Sequence[Operation]:
         """
-        Produce a `Sequence[Operation], SSAValue` tuple
-        for each field that contains:
-
-        - a list of operations that calculate the field value
-        - a reference to the SSAValue containing the calculated field value
+        Lowers the operation op to a sequence of acc_ops.
+        acc_ops are:
+            - *.op that generates SSAValues consumed by acc2.setup
+            - acc2.setup
+            - acc2.launch
+            - acc2.await
+        These ops can further be lowered by specific instances of the
+        Accelerator interface
         """
         pass
 

--- a/compiler/accelerators/snax.py
+++ b/compiler/accelerators/snax.py
@@ -61,8 +61,12 @@ class SNAXAccelerator(Accelerator, ABC):
 
     @staticmethod
     def lower_acc_launch(acc_op: acc.AcceleratorOp) -> Sequence[Operation]:
+        launch_fields = acc_op.get_launch_fields()
+        # SNAX only has a single launch field
+        assert "launch" in launch_fields
+        assert len(launch_fields) == 1
         return [
-            addr_val := arith.Constant(acc_op.launch_addr),
+            addr_val := arith.Constant(launch_fields["launch"]),
             val := arith.Constant(builtin.IntegerAttr.from_int_and_width(0, 5)),
             llvm.InlineAsmOp(
                 "csrw $0, $1",

--- a/compiler/accelerators/snax_hwpe_mult.py
+++ b/compiler/accelerators/snax_hwpe_mult.py
@@ -52,7 +52,7 @@ class SNAXHWPEMultAccelerator(SNAXAccelerator):
             name            = @snax_hwpe_mult,
             fields          = {A=0x3d0, B=0x3d1, O=0x3d3, n_iters=0x3d4,
                                vector_length=0x3d5, mode=0x3d6},
-            launch_addr     = 0x3c0,
+            launch_fields   = {"launch"=0x3c0},
             barrier = 0x3c3,
         }> : () -> ()
         """
@@ -66,6 +66,6 @@ class SNAXHWPEMultAccelerator(SNAXAccelerator):
                 "nr_iters": 0x3D5,
                 "mode": 0x3D6,
             },
-            0x3C0,
+            {"launch": 0x3C0},
             0x3C3,
         )

--- a/compiler/accelerators/snax_hwpe_mult.py
+++ b/compiler/accelerators/snax_hwpe_mult.py
@@ -15,6 +15,7 @@ class SNAXHWPEMultAccelerator(SNAXAccelerator):
 
     name = "snax_hwpe_mult"
     fields = ("A", "B", "O", "vector_length", "nr_iters", "mode")
+    launch_fields = ("launch",)
 
     def convert_to_acc_ops(self, op: linalg.Generic) -> Sequence[Operation]:
         """
@@ -37,7 +38,8 @@ class SNAXHWPEMultAccelerator(SNAXAccelerator):
         return [
             *ops_to_insert,
             setup := acc.SetupOp([val for _, val in args], self.fields, self.name),
-            token := acc.LaunchOp(setup),
+            launch_val := arith.Constant(builtin.IntegerAttr.from_int_and_width(0, 5)),
+            token := acc.LaunchOp([launch_val], self.launch_fields, setup),
             acc.AwaitOp(token),
         ]
 

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -3,7 +3,7 @@
 "acc2.accelerator"() <{
     name               = @acc1,
     fields             = {A=0x3c0, B=0x3c1},
-    launch_addr        = 0x3cf,
+    launch_fields      = {launch=0x3cf},
     barrier            = 0x7c3
 }> : () -> ()
 
@@ -31,7 +31,7 @@ func.func @test() {
 
 
 // CHECK-NEXT: "builtin.module"() ({
-// CHECK-NEXT:   "acc2.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_addr" = 975 : i64, "barrier" = 1987 : i64}> : () -> ()
+// CHECK-NEXT:   "acc2.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_fields" = {"launch" = 975 : i64}, "barrier" = 1987 : i64}> : () -> ()
 // CHECK-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:     %state = "acc2.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc2.state<"acc1">

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -9,14 +9,17 @@
 
 func.func @test() {
     %one, %two = "test.op"() : () -> (i32, i32)
-
+    %zero = arith.constant 0 : i32
     %state = "acc2.setup"(%one, %two) <{
         param_names = ["A", "B"],
         accelerator = "acc1",
         operandSegmentSizes = array<i32: 2, 0>
     }> : (i32, i32) -> !acc2.state<"acc1">
 
-    %token = "acc2.launch"(%state) <{accelerator = "acc1"}>: (!acc2.state<"acc1">) -> !acc2.token<"acc1">
+    %token = "acc2.launch"(%zero, %state) <{
+        param_names = ["launch"], 
+        accelerator = "acc1"
+    }>: (i32, !acc2.state<"acc1">) -> !acc2.token<"acc1">
 
     %state2 = "acc2.setup"(%one, %two, %state) <{
         param_names = ["A", "B"],
@@ -34,8 +37,9 @@ func.func @test() {
 // CHECK-NEXT:   "acc2.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_fields" = {"launch" = 975 : i64}, "barrier" = 1987 : i64}> : () -> ()
 // CHECK-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
+// CHECK-NEXT:     %zero = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
 // CHECK-NEXT:     %state = "acc2.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc2.state<"acc1">
-// CHECK-NEXT:     %token = "acc2.launch"(%state) <{"accelerator" = "acc1"}> : (!acc2.state<"acc1">) -> !acc2.token<"acc1">
+// CHECK-NEXT:     %token = "acc2.launch"(%zero, %state) <{"param_names" = ["launch"], "accelerator" = "acc1"}> : (i32, !acc2.state<"acc1">) -> !acc2.token<"acc1">
 // CHECK-NEXT:     %state2 = "acc2.setup"(%one, %two, %state) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 1>}> : (i32, i32, !acc2.state<"acc1">) -> !acc2.state<"acc1">
 // CHECK-NEXT:     "acc2.await"(%token) : (!acc2.token<"acc1">) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()

--- a/tests/filecheck/transforms/acc-cse.mlir
+++ b/tests/filecheck/transforms/acc-cse.mlir
@@ -2,20 +2,23 @@
 
 func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
   %0 = arith.constant 0 : index
+  %cst_0 = arith.constant 0 : i32
   %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
   %2 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
   %3 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
   %4 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
 
   %5 = "acc2.setup"(%1, %2, %3, %4) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index) -> !acc2.state<"snax_hwpe_mult">
-  %6 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+
+  %6 = "acc2.launch"(%cst_0, %5) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32,!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
   "acc2.await"(%6) : (!acc2.token<"snax_hwpe_mult">) -> ()
 
   %7 = "test.op"() : () -> i1
 
   %8, %9 = "scf.if"(%7) ({
     %10 = "acc2.setup"(%1, %3, %3, %4, %5) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-    %11 = "acc2.launch"(%10) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+
+    %11 = "acc2.launch"(%cst_0, %10) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32,!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
     "acc2.await"(%11) : (!acc2.token<"snax_hwpe_mult">) -> ()
 
     %12 = "test.op"() : () -> i32
@@ -24,7 +27,7 @@ func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg
     %13 = "test.op"() : () -> i32
 
     %14 = "acc2.setup"(%1, %2, %3, %4, %5) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-    %15 = "acc2.launch"(%14) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+    %15 = "acc2.launch"(%cst_0, %14) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32,!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
     "acc2.await"(%15) : (!acc2.token<"snax_hwpe_mult">) -> ()
 
     scf.yield %13, %14 : i32, !acc2.state<"snax_hwpe_mult">
@@ -33,59 +36,42 @@ func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg
   "test.op"(%8) : (i32) -> ()
 
   %16 = "acc2.setup"(%1, %3, %2, %4, %9) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-  %17 = "acc2.launch"(%16) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+  %17 = "acc2.launch"(%cst_0, %16) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32,!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
   "acc2.await"(%17) : (!acc2.token<"snax_hwpe_mult">) -> ()
 
   func.return
 }
 
-
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
 // CHECK-NEXT:     %0 = arith.constant 0 : index
+// CHECK-NEXT:     %cst_0 = arith.constant 0 : i32
 // CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
 // CHECK-NEXT:     %2 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
 // CHECK-NEXT:     %3 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
 // CHECK-NEXT:     %4 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
-
-                   // Full setup:
-
 // CHECK-NEXT:     %5 = "acc2.setup"(%1, %2, %3, %4) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:     %6 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:     %6 = "acc2.launch"(%cst_0, %5) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
 // CHECK-NEXT:     "acc2.await"(%6) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:     %7 = "test.op"() : () -> i1
 // CHECK-NEXT:     %8, %9 = "scf.if"(%7) ({
-
-                     // Elide A and O setups:
-
 // CHECK-NEXT:       %10 = "acc2.setup"(%3, %5) <{"param_names" = ["B"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:       %11 = "acc2.launch"(%10) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:       %11 = "acc2.launch"(%cst_0, %10) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
 // CHECK-NEXT:       "acc2.await"(%11) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:       %12 = "test.op"() : () -> i32
-
-                     // Hoisted into if, elided A, B
-
 // CHECK-NEXT:       %13 = "acc2.setup"(%2, %10) <{"param_names" = ["O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:       scf.yield %12, %13 : i32, !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     }, {
 // CHECK-NEXT:       %14 = "test.op"() : () -> i32
-
-                     // Elide full setup op
-
-// CHECK-NEXT:       %15 = "acc2.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:       %15 = "acc2.launch"(%cst_0, %5) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
 // CHECK-NEXT:       "acc2.await"(%15) : (!acc2.token<"snax_hwpe_mult">) -> ()
-
-                     // Hoisted into if, elided A
-
 // CHECK-NEXT:       %16 = "acc2.setup"(%3, %2, %5) <{"param_names" = ["B", "O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 2, 1>}> : (index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:       scf.yield %14, %16 : i32, !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     }) : (i1) -> (i32, !acc2.state<"snax_hwpe_mult">)
 // CHECK-NEXT:     "test.op"(%8) : (i32) -> ()
-
-                   // fully elided setup op
-
-// CHECK-NEXT:     %17 = "acc2.launch"(%9) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:     %17 = "acc2.launch"(%cst_0, %9) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
 // CHECK-NEXT:     "acc2.await"(%17) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
+

--- a/tests/filecheck/transforms/acc-cse.mlir
+++ b/tests/filecheck/transforms/acc-cse.mlir
@@ -2,7 +2,7 @@
 
 func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
   %0 = arith.constant 0 : index
-  %cst_0 = arith.constant 0 : i32
+  %cst_0 = arith.constant 0 : i5
   %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
   %2 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
   %3 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
@@ -10,7 +10,7 @@ func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg
 
   %5 = "acc2.setup"(%1, %2, %3, %4) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index) -> !acc2.state<"snax_hwpe_mult">
 
-  %6 = "acc2.launch"(%cst_0, %5) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32,!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+  %6 = "acc2.launch"(%cst_0, %5) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i5,!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
   "acc2.await"(%6) : (!acc2.token<"snax_hwpe_mult">) -> ()
 
   %7 = "test.op"() : () -> i1
@@ -18,7 +18,7 @@ func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg
   %8, %9 = "scf.if"(%7) ({
     %10 = "acc2.setup"(%1, %3, %3, %4, %5) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
 
-    %11 = "acc2.launch"(%cst_0, %10) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32,!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+    %11 = "acc2.launch"(%cst_0, %10) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i5,!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
     "acc2.await"(%11) : (!acc2.token<"snax_hwpe_mult">) -> ()
 
     %12 = "test.op"() : () -> i32
@@ -27,7 +27,7 @@ func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg
     %13 = "test.op"() : () -> i32
 
     %14 = "acc2.setup"(%1, %2, %3, %4, %5) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-    %15 = "acc2.launch"(%cst_0, %14) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32,!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+    %15 = "acc2.launch"(%cst_0, %14) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i5,!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
     "acc2.await"(%15) : (!acc2.token<"snax_hwpe_mult">) -> ()
 
     scf.yield %13, %14 : i32, !acc2.state<"snax_hwpe_mult">
@@ -36,7 +36,7 @@ func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg
   "test.op"(%8) : (i32) -> ()
 
   %16 = "acc2.setup"(%1, %3, %2, %4, %9) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-  %17 = "acc2.launch"(%cst_0, %16) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32,!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+  %17 = "acc2.launch"(%cst_0, %16) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i5,!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
   "acc2.await"(%17) : (!acc2.token<"snax_hwpe_mult">) -> ()
 
   func.return
@@ -45,31 +45,31 @@ func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
 // CHECK-NEXT:     %0 = arith.constant 0 : index
-// CHECK-NEXT:     %cst_0 = arith.constant 0 : i32
+// CHECK-NEXT:     %cst_0 = arith.constant 0 : i5
 // CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
 // CHECK-NEXT:     %2 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
 // CHECK-NEXT:     %3 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
 // CHECK-NEXT:     %4 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
 // CHECK-NEXT:     %5 = "acc2.setup"(%1, %2, %3, %4) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:     %6 = "acc2.launch"(%cst_0, %5) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:     %6 = "acc2.launch"(%cst_0, %5) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
 // CHECK-NEXT:     "acc2.await"(%6) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:     %7 = "test.op"() : () -> i1
 // CHECK-NEXT:     %8, %9 = "scf.if"(%7) ({
 // CHECK-NEXT:       %10 = "acc2.setup"(%3, %5) <{"param_names" = ["B"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:       %11 = "acc2.launch"(%cst_0, %10) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:       %11 = "acc2.launch"(%cst_0, %10) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
 // CHECK-NEXT:       "acc2.await"(%11) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:       %12 = "test.op"() : () -> i32
 // CHECK-NEXT:       %13 = "acc2.setup"(%2, %10) <{"param_names" = ["O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:       scf.yield %12, %13 : i32, !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     }, {
 // CHECK-NEXT:       %14 = "test.op"() : () -> i32
-// CHECK-NEXT:       %15 = "acc2.launch"(%cst_0, %5) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:       %15 = "acc2.launch"(%cst_0, %5) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
 // CHECK-NEXT:       "acc2.await"(%15) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:       %16 = "acc2.setup"(%3, %2, %5) <{"param_names" = ["B", "O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 2, 1>}> : (index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:       scf.yield %14, %16 : i32, !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     }) : (i1) -> (i32, !acc2.state<"snax_hwpe_mult">)
 // CHECK-NEXT:     "test.op"(%8) : (i32) -> ()
-// CHECK-NEXT:     %17 = "acc2.launch"(%cst_0, %9) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:     %17 = "acc2.launch"(%cst_0, %9) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
 // CHECK-NEXT:     "acc2.await"(%17) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }

--- a/tests/filecheck/transforms/convert-acc-to-csr.mlir
+++ b/tests/filecheck/transforms/convert-acc-to-csr.mlir
@@ -5,7 +5,7 @@ builtin.module {
   "acc2.accelerator"() <{
       name            = @snax_hwpe_mult,
       fields          = {A=0x3d0, B=0x3d1, O=0x3d3, vector_length=0x3d4, nr_iters=0x3d5, mode=0x3d6},
-      launch_addr     = 0x3c0,
+      launch_fields   = {launch=0x3c0},
       barrier         = 0x3c3
   }> : () -> ()
 

--- a/tests/filecheck/transforms/convert-acc-to-csr.mlir
+++ b/tests/filecheck/transforms/convert-acc-to-csr.mlir
@@ -11,6 +11,7 @@ builtin.module {
 
   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>, %i1 : i1) {
     %0 = arith.constant 0 : index
+    %cst_0 = arith.constant 0 : i32
     %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
     %2 = "arith.index_cast"(%1) : (index) -> i32
     %3 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
@@ -20,21 +21,21 @@ builtin.module {
     %7 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
     %8 = "arith.index_cast"(%7) : (index) -> i32
     %9 = "acc2.setup"(%2, %4, %6, %8) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
-    %10 = "acc2.launch"(%9) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+    %10 = "acc2.launch"(%cst_0, %9) <{"param_names" = ["launch"] ,"accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
     "acc2.await"(%10) : (!acc2.token<"snax_hwpe_mult">) -> ()
     %13 = "scf.if"(%i1) ({
       %14 = "acc2.setup"(%6, %9) <{"param_names" = ["B"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-      %15 = "acc2.launch"(%14) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+      %15 = "acc2.launch"(%cst_0, %14) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
       "acc2.await"(%15) : (!acc2.token<"snax_hwpe_mult">) -> ()
       %17 = "acc2.setup"(%4, %14) <{"param_names" = ["O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
       scf.yield %17 : !acc2.state<"snax_hwpe_mult">
     }, {
-      %19 = "acc2.launch"(%9) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+      %19 = "acc2.launch"(%cst_0, %9) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
       "acc2.await"(%19) : (!acc2.token<"snax_hwpe_mult">) -> ()
       %20 = "acc2.setup"(%6, %4, %9) <{"param_names" = ["B", "O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 2, 1>}> : (i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
       scf.yield %20 : !acc2.state<"snax_hwpe_mult">
     }) : (i1) -> (!acc2.state<"snax_hwpe_mult">)
-    %21 = "acc2.launch"(%13) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+    %21 = "acc2.launch"(%cst_0, %13) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
     "acc2.await"(%21) : (!acc2.token<"snax_hwpe_mult">) -> ()
     func.return
   }
@@ -43,6 +44,7 @@ builtin.module {
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>, %i1 : i1) {
 // CHECK-NEXT:     %0 = arith.constant 0 : index
+// CHECK-NEXT:     %cst_0 = arith.constant 0 : i32
 // CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
 // CHECK-NEXT:     %2 = "arith.index_cast"(%1) : (index) -> i32
 // CHECK-NEXT:     %3 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index

--- a/tests/filecheck/transforms/convert-acc-to-csr.mlir
+++ b/tests/filecheck/transforms/convert-acc-to-csr.mlir
@@ -11,7 +11,7 @@ builtin.module {
 
   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>, %i1 : i1) {
     %0 = arith.constant 0 : index
-    %cst_0 = arith.constant 0 : i32
+    %cst_0 = arith.constant 0 : i5
     %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
     %2 = "arith.index_cast"(%1) : (index) -> i32
     %3 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
@@ -21,21 +21,21 @@ builtin.module {
     %7 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
     %8 = "arith.index_cast"(%7) : (index) -> i32
     %9 = "acc2.setup"(%2, %4, %6, %8) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
-    %10 = "acc2.launch"(%cst_0, %9) <{"param_names" = ["launch"] ,"accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+    %10 = "acc2.launch"(%cst_0, %9) <{"param_names" = ["launch"] ,"accelerator" = "snax_hwpe_mult"}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
     "acc2.await"(%10) : (!acc2.token<"snax_hwpe_mult">) -> ()
     %13 = "scf.if"(%i1) ({
       %14 = "acc2.setup"(%6, %9) <{"param_names" = ["B"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-      %15 = "acc2.launch"(%cst_0, %14) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+      %15 = "acc2.launch"(%cst_0, %14) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
       "acc2.await"(%15) : (!acc2.token<"snax_hwpe_mult">) -> ()
       %17 = "acc2.setup"(%4, %14) <{"param_names" = ["O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
       scf.yield %17 : !acc2.state<"snax_hwpe_mult">
     }, {
-      %19 = "acc2.launch"(%cst_0, %9) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+      %19 = "acc2.launch"(%cst_0, %9) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
       "acc2.await"(%19) : (!acc2.token<"snax_hwpe_mult">) -> ()
       %20 = "acc2.setup"(%6, %4, %9) <{"param_names" = ["B", "O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 2, 1>}> : (i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
       scf.yield %20 : !acc2.state<"snax_hwpe_mult">
     }) : (i1) -> (!acc2.state<"snax_hwpe_mult">)
-    %21 = "acc2.launch"(%cst_0, %13) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+    %21 = "acc2.launch"(%cst_0, %13) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
     "acc2.await"(%21) : (!acc2.token<"snax_hwpe_mult">) -> ()
     func.return
   }
@@ -44,7 +44,7 @@ builtin.module {
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>, %i1 : i1) {
 // CHECK-NEXT:     %0 = arith.constant 0 : index
-// CHECK-NEXT:     %cst_0 = arith.constant 0 : i32
+// CHECK-NEXT:     %cst_0 = arith.constant 0 : i5
 // CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
 // CHECK-NEXT:     %2 = "arith.index_cast"(%1) : (index) -> i32
 // CHECK-NEXT:     %3 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index

--- a/tests/filecheck/transforms/convert-linalg-to-acc.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-acc.mlir
@@ -5,7 +5,7 @@
   "acc2.accelerator"() <{
       name            = @snax_hwpe_mult,
       fields          = {A=0x3d0, B=0x3d1, O=0x3d3, vector_length=0x3d4, nr_iters=0x3d5, mode=0x3d6},
-      launch_addr     = 0x3c0,
+      launch_fields   = {launch=0x3c0},
       barrier         = 0x3c3
   }> : () -> ()
 
@@ -62,7 +62,7 @@
 }): () -> ()
 
 // CHECK-NEXT: builtin.module {
-// CHECK-NEXT:   "acc2.accelerator"() <{"barrier" = 963 : i64, "fields" = {"A" = 976 : i64, "B" = 977 : i64, "O" = 979 : i64, "mode" = 982 : i64, "nr_iters" = 981 : i64, "vector_length" = 980 : i64}, "launch_addr" = 960 : i64, "name" = @snax_hwpe_mult}> : () -> ()
+// CHECK-NEXT:   "acc2.accelerator"() <{"barrier" = 963 : i64, "fields" = {"A" = 976 : i64, "B" = 977 : i64, "O" = 979 : i64, "mode" = 982 : i64, "nr_iters" = 981 : i64, "vector_length" = 980 : i64}, "launch_fields" = {"launch" = 960 : i64}, "name" = @snax_hwpe_mult}> : () -> ()
 // CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
 // CHECK-NEXT:     %0 = arith.constant 0 : index
 // CHECK-NEXT:     %1 = arith.constant 1 : i32

--- a/tests/filecheck/transforms/convert-linalg-to-acc.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-acc.mlir
@@ -61,40 +61,42 @@
   }
 }): () -> ()
 
+
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   "acc2.accelerator"() <{"barrier" = 963 : i64, "fields" = {"A" = 976 : i64, "B" = 977 : i64, "O" = 979 : i64, "mode" = 982 : i64, "nr_iters" = 981 : i64, "vector_length" = 980 : i64}, "launch_fields" = {"launch" = 960 : i64}, "name" = @snax_hwpe_mult}> : () -> ()
 // CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
-// CHECK-NEXT:     %0 = arith.constant 0 : index
-// CHECK-NEXT:     %1 = arith.constant 1 : i32
-// CHECK-NEXT:     %2 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
-// CHECK-NEXT:     %3 = "arith.index_cast"(%2) : (index) -> i32
-// CHECK-NEXT:     %4 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
-// CHECK-NEXT:     %5 = "arith.index_cast"(%4) : (index) -> i32
-// CHECK-NEXT:     %6 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
-// CHECK-NEXT:     %7 = "arith.index_cast"(%6) : (index) -> i32
-// CHECK-NEXT:     %8 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
-// CHECK-NEXT:     %9 = "arith.index_cast"(%8) : (index) -> i32
-// CHECK-NEXT:     %10 = "acc2.setup"(%3, %5, %7, %1, %9, %1) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 6, 0>, "param_names" = ["A", "B", "O", "vector_length", "nr_iters", "mode"]}> : (i32, i32, i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:     %11 = "acc2.launch"(%10) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
-// CHECK-NEXT:     "acc2.await"(%11) : (!acc2.token<"snax_hwpe_mult">) -> ()
-// CHECK-NEXT:     %12 = "test.op"() : () -> i1
-// CHECK-NEXT:     %13, %14 = "scf.if"(%12) ({
-// CHECK-NEXT:       %15 = "acc2.setup"(%3, %7, %7, %1, %9, %1, %10) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 6, 1>, "param_names" = ["A", "B", "O", "vector_length", "nr_iters", "mode"]}> : (i32, i32, i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:       %16 = "acc2.launch"(%15) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
-// CHECK-NEXT:       "acc2.await"(%16) : (!acc2.token<"snax_hwpe_mult">) -> ()
-// CHECK-NEXT:       %17 = "test.op"() : () -> i32
-// CHECK-NEXT:       scf.yield %17, %15 : i32, !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:     }, {
+// CHECK-NEXT:     %0 = arith.constant 0 : i5
+// CHECK-NEXT:     %1 = arith.constant 0 : index
+// CHECK-NEXT:     %2 = arith.constant 1 : i32
+// CHECK-NEXT:     %3 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %4 = "arith.index_cast"(%3) : (index) -> i32
+// CHECK-NEXT:     %5 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %6 = "arith.index_cast"(%5) : (index) -> i32
+// CHECK-NEXT:     %7 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %8 = "arith.index_cast"(%7) : (index) -> i32
+// CHECK-NEXT:     %9 = "memref.dim"(%arg0, %1) : (memref<?xi32>, index) -> index
+// CHECK-NEXT:     %10 = "arith.index_cast"(%9) : (index) -> i32
+// CHECK-NEXT:     %11 = "acc2.setup"(%4, %6, %8, %2, %10, %2) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 6, 0>, "param_names" = ["A", "B", "O", "vector_length", "nr_iters", "mode"]}> : (i32, i32, i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     %12 = "acc2.launch"(%0, %11) <{"accelerator" = "snax_hwpe_mult", "param_names" = ["launch"]}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:     "acc2.await"(%12) : (!acc2.token<"snax_hwpe_mult">) -> ()
+// CHECK-NEXT:     %13 = "test.op"() : () -> i1
+// CHECK-NEXT:     %14, %15 = "scf.if"(%13) ({
+// CHECK-NEXT:       %16 = "acc2.setup"(%4, %8, %8, %2, %10, %2, %11) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 6, 1>, "param_names" = ["A", "B", "O", "vector_length", "nr_iters", "mode"]}> : (i32, i32, i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       %17 = "acc2.launch"(%0, %16) <{"accelerator" = "snax_hwpe_mult", "param_names" = ["launch"]}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:       "acc2.await"(%17) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:       %18 = "test.op"() : () -> i32
-// CHECK-NEXT:       %19 = "acc2.setup"(%3, %5, %7, %1, %9, %1, %10) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 6, 1>, "param_names" = ["A", "B", "O", "vector_length", "nr_iters", "mode"]}> : (i32, i32, i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:       %20 = "acc2.launch"(%19) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
-// CHECK-NEXT:       "acc2.await"(%20) : (!acc2.token<"snax_hwpe_mult">) -> ()
-// CHECK-NEXT:       scf.yield %18, %19 : i32, !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       scf.yield %18, %16 : i32, !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     }, {
+// CHECK-NEXT:       %19 = "test.op"() : () -> i32
+// CHECK-NEXT:       %20 = "acc2.setup"(%4, %6, %8, %2, %10, %2, %11) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 6, 1>, "param_names" = ["A", "B", "O", "vector_length", "nr_iters", "mode"]}> : (i32, i32, i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       %21 = "acc2.launch"(%0, %20) <{"accelerator" = "snax_hwpe_mult", "param_names" = ["launch"]}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:       "acc2.await"(%21) : (!acc2.token<"snax_hwpe_mult">) -> ()
+// CHECK-NEXT:       scf.yield %19, %20 : i32, !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     }) : (i1) -> (i32, !acc2.state<"snax_hwpe_mult">)
-// CHECK-NEXT:     "test.op"(%13) : (i32) -> ()
-// CHECK-NEXT:     %21 = "acc2.setup"(%3, %7, %5, %1, %9, %1, %14) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 6, 1>, "param_names" = ["A", "B", "O", "vector_length", "nr_iters", "mode"]}> : (i32, i32, i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:     %22 = "acc2.launch"(%21) <{"accelerator" = "snax_hwpe_mult"}> : (!acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
-// CHECK-NEXT:     "acc2.await"(%22) : (!acc2.token<"snax_hwpe_mult">) -> ()
+// CHECK-NEXT:     "test.op"(%14) : (i32) -> ()
+// CHECK-NEXT:     %22 = "acc2.setup"(%4, %8, %6, %2, %10, %2, %15) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 6, 1>, "param_names" = ["A", "B", "O", "vector_length", "nr_iters", "mode"]}> : (i32, i32, i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     %23 = "acc2.launch"(%0, %22) <{"accelerator" = "snax_hwpe_mult", "param_names" = ["launch"]}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
+// CHECK-NEXT:     "acc2.await"(%23) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
-// CHECK-NEXT: } 
+// CHECK-NEXT: }

--- a/tests/filecheck/transforms/insert-acc-op.mlir
+++ b/tests/filecheck/transforms/insert-acc-op.mlir
@@ -3,7 +3,7 @@
 builtin.module{}
 
 // CHECK-NEXT: builtin.module {
-// CHECK-NEXT:   "acc2.accelerator"() <{"name" = @snax_hwpe_mult, "fields" = {"A" = 976 : i32, "B" = 977 : i32, "O" = 979 : i32, "vector_length" = 980 : i32, "nr_iters" = 981 : i32, "mode" = 982 : i32}, "launch_addr" = 960 : i32, "barrier" = 963 : i32}> : () -> ()
+// CHECK-NEXT:   "acc2.accelerator"() <{"name" = @snax_hwpe_mult, "fields" = {"A" = 976 : i32, "B" = 977 : i32, "O" = 979 : i32, "vector_length" = 980 : i32, "nr_iters" = 981 : i32, "mode" = 982 : i32}, "launch_fields" = {"launch" = 960 : i32}, "barrier" = 963 : i32}> : () -> ()
 // CHECK-NEXT: }
 
 


### PR DESCRIPTION
This PR adds the possibility of adding SSAValues and fields to the acc2.LaunchOp.
This is to fix the case where some accelerators also perform some setup implicit on each launch.
The nice thing is that encoding it like this immediatly makes it impossible to deduplicate those calls (that never have to be deduplicated in the first place) but still allows us to perform some configuration inside the launching of accelerators.
This is necessary to be pushed first to allow for #118 to be added

This also replaces the generate_setup_vals with an even more opaque mechanism in the interface to generate the entire sequence of setup, launch and await ops instead, which is required in this case, since some setup operations are not tied to just the setup op anymore