### PR TITLE
acc2: Add deduplication recovery support for gemmini 

### DIFF
--- a/compiler/accelerators/rocc.py
+++ b/compiler/accelerators/rocc.py
@@ -39,9 +39,9 @@ class RoCCAccelerator(Accelerator, ABC):
         xcustom_acc = 3  # hardcoded to 3 for now
         vals = create_pairs(setup_op)
         # Only pass on the field names that are set in the current setup
-        instructions = set([name[:-4:] for name, _ in setup_op.iter_params()])
+        instructions = set([name[:-4] for name, _ in setup_op.iter_params()])
         current_fields = {
-            key: val for key, val in acc_op.field_items() if key[:-4:] in instructions
+            key: val for key, val in acc_op.field_items() if key[:-4] in instructions
         }.items()
         # Create the sequence of all operations that need to be emitted
         return combine_pairs_to_ops(current_fields, vals, xcustom_acc)
@@ -58,7 +58,7 @@ def create_pairs(
     (i.e. if one of the two operands of an instruction gets dedupped)
     """
     # Make a set of all the unique instruction names in the current operation
-    instructions = set([name[:-4:] for name, _ in fields_op.iter_params()])
+    instructions = set([name[:-4] for name, _ in fields_op.iter_params()])
     field_dict = dict(fields_op.iter_params())
 
     # For setup_ops, get the previous setup state, if necessary
@@ -78,13 +78,13 @@ def create_pairs(
         assert instruction + ".rs2" in field_dict, f"No rs2 found for {instruction}"
     # Create a dictionary that contains the two vals associated
     # to each single RoCC instruction
-    map: dict[str, tuple[SSAValue, SSAValue]] = {}
+    instruction_map: dict[str, tuple[SSAValue, SSAValue]] = {}
     for instruction in instructions:
-        map.setdefault(
+        instruction_map.setdefault(
             instruction,
             (field_dict[instruction + ".rs1"], field_dict[instruction + ".rs2"]),
         )
-    return map
+    return instruction_map
 
 
 def combine_pairs_to_ops(

--- a/tests/filecheck/transforms/rocc-dedup.mlir
+++ b/tests/filecheck/transforms/rocc-dedup.mlir
@@ -1,4 +1,3 @@
-// XFAIL: *
 // RUN: ./compiler/snax-opt %s -p convert-acc-to-csr | filecheck %s
 
 builtin.module {
@@ -9,13 +8,11 @@ builtin.module {
         k_LOOP_WS_CONFIG_ADDRS_DC.rs1=11,
         k_LOOP_WS_CONFIG_STRIDES_AB.rs1=12,
         k_LOOP_WS_CONFIG_STRIDES_DC.rs1=13,
-        k_LOOP_WS.rs1=8,
         k_LOOP_WS_CONFIG_BOUNDS.rs2=9,
         k_LOOP_WS_CONFIG_ADDRS_AB.rs2=10,
         k_LOOP_WS_CONFIG_ADDRS_DC.rs2=11,
         k_LOOP_WS_CONFIG_STRIDES_AB.rs2=12,
-        k_LOOP_WS_CONFIG_STRIDES_DC.rs2=13,
-        k_LOOP_WS.rs2=8
+        k_LOOP_WS_CONFIG_STRIDES_DC.rs2=13
         },
       launch_fields   = {
         k_LOOP_WS.rs1=8,
@@ -52,6 +49,7 @@ builtin.module {
         "k_LOOP_WS_CONFIG_ADDRS_AB.rs1",  // Both rs1 and rs2 set
         "k_LOOP_WS_CONFIG_ADDRS_AB.rs2",
         "k_LOOP_WS_CONFIG_ADDRS_DC.rs2"   // rs2 set, but rs1 not
+        // strides are not set, so can be reused from the previous one.
         ]}> : (i32, i32, i32, i32, !acc2.state<"gemmini">) -> !acc2.state<"gemmini">
     %12 = "acc2.launch"(%t,%t,%11) <{
     "param_names" = ["k_LOOP_WS.rs1", "k_LOOP_WS.rs2"],
@@ -61,3 +59,20 @@ builtin.module {
   }
 }
 
+// CHECK: builtin.module {
+// CHECK-NEXT:   func.func public @test() {
+// CHECK-NEXT:     %t = arith.constant 32 : i32
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 9 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 10 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 11 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 12 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 13 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 8 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
+// CHECK-NEXT:     %n = arith.constant 31 : i32
+// CHECK-NEXT:     "llvm.inline_asm"(%n, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 9 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%n, %n) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 10 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %n) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 11 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 8 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }


### PR DESCRIPTION
Note: stacked PR

This adds support to emit RoCC instructions for setup values that were previously deduplicated.
In certain cases this means that you need to trace back what the original rs1 was associated to an rs2 or vice versa.

Note that this changes a previously implemented test to not be failing anymore.