### PR TITLE
make: Fix clean for mlperf tiny

### DIFF
--- a/kernels/mlperf_tiny_ad01/Makefile
+++ b/kernels/mlperf_tiny_ad01/Makefile
@@ -2,3 +2,6 @@ include ../../runtime/Makefile.rules
 
 ad01_int8.tflite:
 	../../runtime/get_model.py anomaly_detection $@
+
+clean:
+	rm -fr *.ll12 *.x *.o *.logs/ logs/ *.tflite

--- a/kernels/mlperf_tiny_ic/Makefile
+++ b/kernels/mlperf_tiny_ic/Makefile
@@ -2,3 +2,6 @@ include ../../runtime/Makefile.rules
 
 pretrainedResnet_quant.tflite:
 	../../runtime/get_model.py image_classification $@
+
+clean:
+	rm -fr *.ll12 *.x *.o *.logs/ logs/ *.tflite

--- a/kernels/mlperf_tiny_kws/Makefile
+++ b/kernels/mlperf_tiny_kws/Makefile
@@ -2,3 +2,6 @@ include ../../runtime/Makefile.rules
 
 kws_ref_model.tflite:
 	../../runtime/get_model.py keyword_spotting $@
+
+clean:
+	rm -fr *.ll12 *.x *.o *.logs/ logs/ *.tflite

--- a/kernels/mlperf_tiny_vww/Makefile
+++ b/kernels/mlperf_tiny_vww/Makefile
@@ -2,3 +2,6 @@ include ../../runtime/Makefile.rules
 
 vww_96_int8.tflite:
 	../../runtime/get_model.py visual_wake_words $@
+
+clean:
+	rm -fr *.ll12 *.x *.o *.logs/ logs/ *.tflite


### PR DESCRIPTION
this pr sets up a proper clean statement in the makefiles for the mlperf tiny benchmarks