### PR TITLE
[WIP] Add gemmini's sp_tiled_matmul.mlir and run in spike

### DIFF
--- a/kernels/gemmini/Makefile
+++ b/kernels/gemmini/Makefile
@@ -1,6 +1,20 @@
-# Linking like this requires the binary to be compiled with -r for relocatable code
-sp_tiled_matmul_ws.o: 
-	compiler/snax-opt kernels/gemmini/sp_tiled_matmul_ws.mlir -p convert-acc-to-csr | mlir-opt-17 --test-lower-to-llvm | mlir-translate-17 --mlir-to-llvmir | clang-17 -x ir - -march=rv64g --target=riscv64-generic -nostdlib -r -o sp_tiled_matmul_ws.o
+GEMMINI_ROCC_TESTS := /home/josse/phd/gemmini-rocc-tests
+RISCV := /home/josse/phd/riscv-isa-sim/build
+SNAX-OPT:= /repo/compiler/snax-opt
+MLIR-OPT:= mlir-opt-17
+MLIR-TRANS:= mlir-translate-17
+CLANG := clang-17
+GCC := riscv64-unknown-elf-gcc
 
-mlp4_32-baremetal:
-	riscv64-unknown-elf-gcc  -DPREALLOCATE=1 -DMULTITHREAD=1 -mcmodel=medany -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns -march=rv64gc -Wa,-march=rv64gc -lm -lgcc -I/home/josse/phd/gemmini-rocc-tests/riscv-tests -I/home/josse/phd/gemmini-rocc-tests/riscv-tests/env -I/home/josse/phd/gemmini-rocc-tests -I/home/josse/phd/gemmini-rocc-tests/riscv-tests/benchmarks/common -DID_STRING=  -nostdlib -nostartfiles -static -T /home/josse/phd/gemmini-rocc-tests/riscv-tests/benchmarks/common/test.ld -DBAREMETAL=1  /home/josse/phd/gemmini-rocc-tests/mlps/mlp4_32.c  /home/josse/phd/snax-mlir/sp_tiled_matmul_ws.o  -o mlp4_32-baremetal /home/josse/phd/gemmini-rocc-tests/riscv-tests/benchmarks/common/syscalls.c /home/josse/phd/gemmini-rocc-tests/riscv-tests/benchmarks/common/crt.S
+# Linking like this requires the binary to be compiled with -r for relocatable code
+sp_tiled_matmul_ws.o: sp_tiled_matmul_ws.mlir
+	 ${SNAX-OPT} $< -p convert-acc-to-csr | ${MLIR-OPT} --test-lower-to-llvm | ${MLIR-TRANS} --mlir-to-llvmir | ${CLANG} -x ir - -march=rv64g --target=riscv64-generic -nostdlib -r -o $@
+
+APP := mlp4_32-baremetal
+SRCS := ${GEMMINI_ROCC_TESTS}/mlps/mlp4_32.c
+
+${APP}: sp_tiled_matmul_ws.o
+	${GCC} -DPREALLOCATE=1 -DMULTITHREAD=1 -mcmodel=medany -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns -march=rv64gc -Wa,-march=rv64gc -lm -lgcc -I${GEMMINI_ROCC_TESTS}/riscv-tests -I${GEMMINI_ROCC_TESTS}/riscv-tests/env -I${GEMMINI_ROCC_TESTS} -I${GEMMINI_ROCC_TESTS}/benchmarks/common -DID_STRING=  -nostdlib -nostartfiles -static -T ${GEMMINI_ROCC_TESTS}/riscv-tests/benchmarks/common/test.ld -DBAREMETAL=1  ${SRCS}  $<  -o mlp4_32-baremetal ${GEMMINI_ROCC_TESTS}/riscv-tests/benchmarks/common/syscalls.c ${GEMMINI_ROCC_TESTS}/riscv-tests/benchmarks/common/crt.S
+
+spike: mlp4_32-baremetal
+	${RISCV}/spike --extension=gemmini $<

--- a/kernels/gemmini/Makefile
+++ b/kernels/gemmini/Makefile
@@ -1,0 +1,6 @@
+# Linking like this requires the binary to be compiled with -r for relocatable code
+sp_tiled_matmul_ws.o: 
+	compiler/snax-opt kernels/gemmini/sp_tiled_matmul_ws.mlir -p convert-acc-to-csr | mlir-opt-17 --test-lower-to-llvm | mlir-translate-17 --mlir-to-llvmir | clang-17 -x ir - -march=rv64g --target=riscv64-generic -nostdlib -r -o sp_tiled_matmul_ws.o
+
+mlp4_32-baremetal:
+	riscv64-unknown-elf-gcc  -DPREALLOCATE=1 -DMULTITHREAD=1 -mcmodel=medany -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns -march=rv64gc -Wa,-march=rv64gc -lm -lgcc -I/home/josse/phd/gemmini-rocc-tests/riscv-tests -I/home/josse/phd/gemmini-rocc-tests/riscv-tests/env -I/home/josse/phd/gemmini-rocc-tests -I/home/josse/phd/gemmini-rocc-tests/riscv-tests/benchmarks/common -DID_STRING=  -nostdlib -nostartfiles -static -T /home/josse/phd/gemmini-rocc-tests/riscv-tests/benchmarks/common/test.ld -DBAREMETAL=1  /home/josse/phd/gemmini-rocc-tests/mlps/mlp4_32.c  /home/josse/phd/snax-mlir/sp_tiled_matmul_ws.o  -o mlp4_32-baremetal /home/josse/phd/gemmini-rocc-tests/riscv-tests/benchmarks/common/syscalls.c /home/josse/phd/gemmini-rocc-tests/riscv-tests/benchmarks/common/crt.S

--- a/kernels/gemmini/Makefile
+++ b/kernels/gemmini/Makefile
@@ -6,6 +6,12 @@ MLIR-TRANS:= mlir-translate-17
 CLANG := clang-17
 GCC := riscv64-unknown-elf-gcc
 
+.PHONY: patch spike
+
+# Patch gemmini.h to not use the provided implementation and disable inlining
+patch: ${GEMMINI_ROCC_TESTS}/include/gemmini.h
+	git -c ${GEMMINI_ROCC_TESTS} apply gemmini.h.patch
+
 # Linking like this requires the binary to be compiled with -r for relocatable code
 sp_tiled_matmul_ws.o: sp_tiled_matmul_ws.mlir
 	 ${SNAX-OPT} $< -p convert-acc-to-csr | ${MLIR-OPT} --test-lower-to-llvm | ${MLIR-TRANS} --mlir-to-llvmir | ${CLANG} -x ir - -march=rv64g --target=riscv64-generic -nostdlib -r -o $@

--- a/kernels/gemmini/gemmini.h.patch
+++ b/kernels/gemmini/gemmini.h.patch
@@ -1,0 +1,49 @@
+diff --git a/include/gemmini.h b/include/gemmini.h
+index 710aa97..ecc80eb 100644
+--- a/include/gemmini.h
++++ b/include/gemmini.h
+@@ -499,7 +499,7 @@ static void sp_tiled_matmul_os(const elem_t * A, const elem_t * B, const void *
+ }
+ 
+ 
+-static void sp_tiled_matmul_ws(const elem_t * A, const elem_t * B,
++extern void sp_tiled_matmul_ws(const elem_t * A, const elem_t * B,
+         const void * D, void * C,
+         scale_t A_scale_factor, scale_t B_scale_factor, scale_acc_t D_scale_factor,
+         size_t I, size_t J, size_t K, size_t pad_I, size_t pad_J, size_t pad_K,
+@@ -508,7 +508,7 @@ static void sp_tiled_matmul_ws(const elem_t * A, const elem_t * B,
+         bool full_C, bool low_D,
+         bool no_bias, bool repeating_bias,
+         int act,
+-        int a_spad_id, int b_spad_id) {
++        int a_spad_id, int b_spad_id) ;//{
+ /*
+   const uint32_t A_sp_addr_start = 0;
+   const uint32_t B_sp_addr_start = BANK_NUM * BANK_ROWS - K * J * DIM;
+@@ -679,17 +679,17 @@ static void sp_tiled_matmul_ws(const elem_t * A, const elem_t * B,
+     }
+   }
+ */
+-
+-  // Combined loop
+-  gemmini_loop_ws(I, J, K, pad_I, pad_J, pad_K, A, B, no_bias ? NULL : D, C,
+-    A_row_stride, B_row_stride, repeating_bias ? 0 : D_row_stride, C_row_stride,
+-    a_transpose, b_transpose,
+-    full_C, low_D, !no_bias || D == NULL,
+-    act, a_spad_id, b_spad_id, false);
+-}
++//
++//  // Combined loop
++//  gemmini_loop_ws(I, J, K, pad_I, pad_J, pad_K, A, B, no_bias ? NULL : D, C,
++//    A_row_stride, B_row_stride, repeating_bias ? 0 : D_row_stride, C_row_stride,
++//    a_transpose, b_transpose,
++//    full_C, low_D, !no_bias || D == NULL,
++//    act, a_spad_id, b_spad_id, false);
++//}
+ 
+ 
+-static void tiled_matmul_outer(size_t dim_I, size_t dim_J, size_t dim_K,
++void tiled_matmul_outer(size_t dim_I, size_t dim_J, size_t dim_K,
+         const elem_t* A, const elem_t* B,
+         const void * D, void * C,
+         size_t stride_A, size_t stride_B, size_t stride_D, size_t stride_C,

--- a/kernels/gemmini/sp_tiled_matmul_ws.mlir
+++ b/kernels/gemmini/sp_tiled_matmul_ws.mlir
@@ -1,0 +1,141 @@
+builtin.module {
+  "acc2.accelerator"() <{
+      name            = @gemmini,
+      fields = { k_LOOP_WS_CONFIG_BOUNDS.rs1=9, k_LOOP_WS_CONFIG_ADDRS_AB.rs1=10,
+        k_LOOP_WS_CONFIG_ADDRS_DC.rs1=11,
+        k_LOOP_WS_CONFIG_STRIDES_AB.rs1=12,
+        k_LOOP_WS_CONFIG_STRIDES_DC.rs1=13,
+        k_LOOP_WS_CONFIG_BOUNDS.rs2=9,
+        k_LOOP_WS_CONFIG_ADDRS_AB.rs2=10,
+        k_LOOP_WS_CONFIG_ADDRS_DC.rs2=11,
+        k_LOOP_WS_CONFIG_STRIDES_AB.rs2=12,
+        k_LOOP_WS_CONFIG_STRIDES_DC.rs2=13
+        },
+      launch_fields   = {
+        k_LOOP_WS.rs1=8,
+        k_LOOP_WS.rs2=8},
+      barrier         = 0x0BAD
+  }> : () -> ()
+  func.func public @sp_tiled_matmul_ws(
+    %A: index, %B : index, %D: index, %C: index, 
+    %A_scale_factor: f64, %B_scale_factor: f64, %D_scale_factor: f64,
+    %I: index , %J: index, %K: index,
+    %pad_I: index, %pad_J: index, %pad_K: index,
+    %A_row_stride: index, %B_row_stride: index, %D_row_stride: index, %C_row_stride: index,
+    %a_transpose: i1, %b_transpose: i1, %full_C: i1, %low_D: i1,
+    %no_bias: i1, %repeating_bias: i1, %act: i32,
+    %a_spad_id: i32, %b_spad_id: i32
+   ) {
+    %t = arith.constant 32 : i64
+    %c_32 = arith.constant 32 : index
+    %c_18 = arith.constant 18 : index
+    %c_16 = arith.constant 16 : index
+    %c_8 = arith.constant 8 : index
+    %c_2 = arith.constant 2 : index
+    %c_1 = arith.constant 1 : index
+    %false = arith.constant 0 : i1
+    %true = arith.constant 1 : i1
+    %NULL = arith.constant 0 : index
+
+    // ((uint64_t)(pad_K) << 32) | ((uint64_t)(pad_J) << 16) | (uint64_t)(pad_I)
+    %pad_K_shift_32 = arith.shli %pad_K, %c_32 : index
+    %pad_J_shift_16 = arith.shli %pad_J, %c_16 : index
+    %pad_K_shift_or_pad_J_shift = arith.ori %pad_K_shift_32, %pad_J_shift_16 : index
+    %pad_K_shift_or_pad_J_shift_or_pad_I_shift= arith.ori %pad_K_shift_or_pad_J_shift, %pad_I : index
+
+    // ((uint64_t)(K) << 32) | ((uint64_t)(J) << 16) | (uint64_t)(I)
+    %K_shift_32 = arith.shli %K, %c_32 : index
+    %J_shift_16 = arith.shli %J, %c_16 : index
+    %K_shift_or_J_shift = arith.ori %K_shift_32, %J_shift_16 : index
+    %K_shift_or_J_shift_or_I_shift = arith.ori %pad_K_shift_or_pad_J_shift, %pad_J : index
+
+    // no_bias ? NULL : D
+    %D_selected = arith.select %no_bias, %NULL, %D : index
+
+    //%= "arith.index_cast"(%b_transpose) : (i1) -> index
+    //%= "arith.index_cast"(%a_transpose) : (i1) -> index
+
+    // Convert to LLVM compatible types
+    %pad_K_shift_or_pad_J_shift_or_pad_I_shift_i64 = "arith.index_cast"(%pad_K_shift_or_pad_J_shift_or_pad_I_shift) : (index) -> i64
+    %K_shift_or_J_shift_or_I_shift_i64 = "arith.index_cast"(%K_shift_or_J_shift_or_I_shift) : (index) -> i64
+    %A_i64 = "arith.index_cast"(%A) : (index) -> i64
+    %B_i64 = "arith.index_cast"(%B) : (index) -> i64
+    %D_selected_i64 = "arith.index_cast"(%D_selected) : (index) -> i64
+    %C_i64 = "arith.index_cast"(%C) : (index) -> i64
+    %A_row_stride_i64 = "arith.index_cast"(%A_row_stride) : (index) -> i64
+    %B_row_stride_i64 = "arith.index_cast"(%B_row_stride) : (index) -> i64
+    %D_row_stride_i64 = "arith.index_cast"(%D_row_stride) : (index) -> i64
+    %C_row_stride_i64 = "arith.index_cast"(%C_row_stride) : (index) -> i64
+
+
+    %setup_state = "acc2.setup"(
+        %pad_K_shift_or_pad_J_shift_or_pad_I_shift_i64,
+        %K_shift_or_J_shift_or_I_shift_i64,
+        %A_i64,
+        %B_i64,
+        %D_selected_i64,
+        %C_i64,
+        %A_row_stride_i64,
+        %B_row_stride_i64,
+        %D_row_stride_i64,
+        %C_row_stride_i64) 
+        <{"accelerator" = "gemmini", "operandSegmentSizes" = array<i32: 10, 0>, 
+        "param_names" = [ 
+            "k_LOOP_WS_CONFIG_BOUNDS.rs1",
+            "k_LOOP_WS_CONFIG_BOUNDS.rs2",
+            "k_LOOP_WS_CONFIG_ADDRS_AB.rs1",
+            "k_LOOP_WS_CONFIG_ADDRS_AB.rs2",
+            "k_LOOP_WS_CONFIG_ADDRS_DC.rs1",
+            "k_LOOP_WS_CONFIG_ADDRS_DC.rs2",
+            "k_LOOP_WS_CONFIG_STRIDES_AB.rs1",
+            "k_LOOP_WS_CONFIG_STRIDES_AB.rs2",
+            "k_LOOP_WS_CONFIG_STRIDES_DC.rs1",
+            "k_LOOP_WS_CONFIG_STRIDES_DC.rs2"
+          ]}> : (i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> !acc2.state<"gemmini">
+
+   // ((uint64_t)(a_spad_id) << 18) | ((uint64_t)(b_spad_id) << 16) | ((uint64_t)(act) << 8) | ((low_D) << 2) | ((full_C) << 1) | (ex_accumulate) 
+   %a_spad_id_cast = "arith.index_cast"(%a_spad_id) : (i32) -> index
+   %b_spad_id_cast = "arith.index_cast"(%b_spad_id) : (i32) -> index
+   %act_cast = "arith.index_cast"(%act) : (i32) -> index
+   %full_C_cast = "arith.index_cast"(%full_C) : (i1) -> index
+   %low_D_cast = "arith.index_cast"(%low_D) : (i1) -> index
+   // invert no_bias
+   %inv_no_bias = arith.xori %no_bias, %true : i1
+   %D_eq_NULL = arith.cmpi eq, %D, %NULL : index
+   %ex_accumulate = arith.ori %D_eq_NULL, %inv_no_bias : i1
+   %ex_accumulate_cast = "arith.index_cast"(%ex_accumulate) : (i1) -> index
+
+   %a_spad_id_shift_18 = arith.shli %a_spad_id_cast, %c_18 : index
+   %b_spad_id_shift_16 = arith.shli %b_spad_id_cast, %c_16 : index
+   %act_shift_8 = arith.shli %act_cast, %c_8 : index
+   %low_D_shift_2 = arith.shli %low_D_cast, %c_2 : index
+   %full_C_shift_1 = arith.shli %full_C_cast, %c_1 : index
+
+   %or_1 = arith.ori %a_spad_id_shift_18, %b_spad_id_shift_16 : index
+   %or_2 = arith.ori %or_1, %act_shift_8 : index
+   %or_3 = arith.ori %or_2, %low_D_shift_2 : index
+   %or_4 = arith.ori %or_3, %full_C_shift_1 : index
+   %or_5 = arith.ori %or_4, %ex_accumulate_cast : index
+   %or_5_i64 = "arith.index_cast"(%or_5) : (index) -> i64
+
+
+   // ((is_resadd) << 2) | ((B_transpose) << 1) | (A_transpose), k_LOOP_WS) 
+   %is_resadd_cast = "arith.index_cast"(%false) : (i1) -> index
+   %b_transpose_cast = "arith.index_cast"(%b_transpose) : (i1) -> index
+   %a_transpose_cast = "arith.index_cast"(%a_transpose) : (i1) -> index
+   %is_resadd_shift_2 = arith.shli %is_resadd_cast, %c_2 : index
+   %b_transpose_shift_1 = arith.shli %b_transpose_cast , %c_16 : index
+   %or_1_1 = arith.ori %is_resadd_shift_2, %b_transpose_cast: index
+   %or_1_2 = arith.ori %or_1_1, %a_transpose_cast: index
+   %or_1_2_i64 = "arith.index_cast"(%or_1_2) : (index) -> i64
+
+
+    %token = "acc2.launch"(%or_5_i64, %or_1_2_i64, %setup_state) <{
+    "param_names" = ["k_LOOP_WS.rs1", "k_LOOP_WS.rs2"],
+    "accelerator" = "gemmini"}> : (i64, i64, !acc2.state<"gemmini">) -> !acc2.token<"gemmini">
+      "acc2.await"(%token) : (!acc2.token<"gemmini">) -> ()
+    func.return
+  }
+}
+
+


### PR DESCRIPTION
This is a dirty patch to yeet in an MLIR-provided implementation of the `sp_tiled_matmul_ws`, which mainly calls custom assembly. This currently only works on my machine, and requires installations of:

* https://github.com/ucb-bar/gemmini-rocc-tests
* https://github.com/riscv-software-src/riscv-isa-sim
* https://github.com/ucb-bar/libgemmini/

Steps to reproduce:

1. Make sure you build the gemmini-rocc-tests and are able to simulate them with spike.
2. Afterwards you can overwrite the gemmini header file with the provided patch. (see Makefile)
3. Then you compile the MLIR (with clang) file to a relocatable object file.
4. Then you use GCC to compile one of the bare-metal tests (this one uses the `mlp4_32-baremetal` in the makefile) whilst linking in the provided object file. This will yeet in `sp_tiled_matmul_ws` compiled by mlir.

CC @AntonLydike @jorendumoulin 

Problems:
There's one pointer comparison for which i need the LLVM cmpi operation in LLVM dialect which is currently unsupported in xdsl.