### PR TITLE
ruff: increase line length

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ ignore = [
     "PT015", # https://beta.ruff.rs/docs/rules/pytest-assert-always-false/
 ]
 target-version = "py310"
+line-length = 120
 
 [tool.ruff.flake8-tidy-imports.banned-api]
 "xdsl.parser.core".msg = "Use xdsl.parser instead."


### PR DESCRIPTION
because anton is a modern man with a modern terminal

is 120 enough? 300 like you have in xDSL seems outrageous