### PR TITLE
Add custom syntax for acc.setup

### DIFF
--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1,4 +1,5 @@
 // RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_GENERIC_ROUNDTRIP
 
 "acc2.accelerator"() <{
     name               = @acc1,
@@ -14,7 +15,7 @@ func.func @test() {
         param_names = ["A", "B"],
         accelerator = "acc1",
         operandSegmentSizes = array<i32: 2, 0>
-    }> : (i32, i32) -> !acc2.state<"acc1">
+    }> {"test_attr" = 100 : i64} : (i32, i32) -> !acc2.state<"acc1">
 
     %token = "acc2.launch"(%zero, %state) <{
         param_names = ["launch"], 
@@ -33,15 +34,29 @@ func.func @test() {
 }
 
 
-// CHECK-NEXT: "builtin.module"() ({
+// CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   "acc2.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_fields" = {"launch" = 975 : i64}, "barrier" = 1987 : i64}> : () -> ()
-// CHECK-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
+// CHECK-NEXT:   func.func @test() {
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
-// CHECK-NEXT:     %zero = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
-// CHECK-NEXT:     %state = "acc2.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !acc2.state<"acc1">
+// CHECK-NEXT:     %zero = arith.constant 0 : i32
+// CHECK-NEXT:     %state = acc2.setup on "acc1" ("A" = %one : i32, "B" = %two : i32) attrs {"test_attr" = 100 : i64} : !acc2.state<"acc1">
 // CHECK-NEXT:     %token = "acc2.launch"(%zero, %state) <{"param_names" = ["launch"], "accelerator" = "acc1"}> : (i32, !acc2.state<"acc1">) -> !acc2.token<"acc1">
-// CHECK-NEXT:     %state2 = "acc2.setup"(%one, %two, %state) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 1>}> : (i32, i32, !acc2.state<"acc1">) -> !acc2.state<"acc1">
+// CHECK-NEXT:     %state2 = acc2.setup on "acc1" ("A" = %one : i32, "B" = %two : i32) in_state(%state) : !acc2.state<"acc1">
 // CHECK-NEXT:     "acc2.await"(%token) : (!acc2.token<"acc1">) -> ()
-// CHECK-NEXT:     "func.return"() : () -> ()
-// CHECK-NEXT:   }) : () -> ()
-// CHECK-NEXT: }) : () -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+
+// CHECK-GENERIC: "builtin.module"() ({
+// CHECK-GENERIC:   "acc2.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_fields" = {"launch" = 975 : i64}, "barrier" = 1987 : i64}> : () -> ()
+// CHECK-GENERIC:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
+// CHECK-GENERIC:     %one, %two = "test.op"() : () -> (i32, i32)
+// CHECK-GENERIC:     %zero = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
+// CHECK-GENERIC:     %state = "acc2.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}>  {"test_attr" = 100 : i64}  : (i32, i32) -> !acc2.state<"acc1">
+// CHECK-GENERIC:     %token = "acc2.launch"(%zero, %state) <{"param_names" = ["launch"], "accelerator" = "acc1"}> : (i32, !acc2.state<"acc1">) -> !acc2.token<"acc1">
+// CHECK-GENERIC:     %state2 = "acc2.setup"(%one, %two, %state) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 1>}> : (i32, i32, !acc2.state<"acc1">) -> !acc2.state<"acc1">
+// CHECK-GENERIC:     "acc2.await"(%token) : (!acc2.token<"acc1">) -> ()
+// CHECK-GENERIC:     "func.return"() : () -> ()
+// CHECK-GENERIC:   }) : () -> ()
+// CHECK-GENERIC: }) : () -> ()

--- a/tests/filecheck/dialects/snax/snax_ops.mlir
+++ b/tests/filecheck/dialects/snax/snax_ops.mlir
@@ -9,9 +9,9 @@
 }) : () -> ()
 
 
-// CHECK-NEXT: "builtin.module"() ({
+// CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, 1 : i32>
 // CHECK-NEXT:   %1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, 1 : i32>) -> memref<8x8xi32, strided<[1, 16]>, 1 : i32>
 // CHECK-NEXT:   %2 = "test.op"() : () -> index
 // CHECK-NEXT:   %3 = "snax.alloc"(%2, %2, %2) <{"memory_space" = 0 : i32, "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
-// CHECK-NEXT: }) : () -> ()
+// CHECK-NEXT: }

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -10,6 +10,6 @@ config.suffixes = ['.test', '.mlir', '.py']
 
 config.substitutions.append(('XDSL_PARSING_DIAG', "./compiler/snax-opt %s --print-op-generic --parsing-diagnostics --split-input-file | filecheck %s"))
 config.substitutions.append(('XDSL_VERIFY_DIAG', "./compiler/snax-opt %s --print-op-generic --verify-diagnostics --split-input-file | filecheck %s"))
-config.substitutions.append(('XDSL_ROUNDTRIP', "./compiler/snax-opt %s --print-op-generic --split-input-file | ./compiler/snax-opt --print-op-generic --split-input-file | filecheck %s"))
-config.substitutions.append(('XDSL_SINGLETRIP', "./compiler/snax-opt %s --print-op-generic --split-input-file | filecheck %s"))
+config.substitutions.append(('XDSL_ROUNDTRIP', "./compiler/snax-opt %s --print-op-generic --split-input-file | ./compiler/snax-opt --split-input-file | filecheck %s"))
+config.substitutions.append(('XDSL_SINGLETRIP', "./compiler/snax-opt %s --split-input-file | filecheck %s"))
 config.substitutions.append(("XDSL_GENERIC_ROUNDTRIP", "./compiler/snax-opt %s --print-op-generic --split-input-file | filecheck %s --check-prefix=CHECK-GENERIC"))

--- a/tests/filecheck/transforms/acc-cse.mlir
+++ b/tests/filecheck/transforms/acc-cse.mlir
@@ -50,22 +50,22 @@ func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg
 // CHECK-NEXT:     %2 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
 // CHECK-NEXT:     %3 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
 // CHECK-NEXT:     %4 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
-// CHECK-NEXT:     %5 = "acc2.setup"(%1, %2, %3, %4) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     %5 = acc2.setup on "snax_hwpe_mult" ("A" = %1 : index, "B" = %2 : index, "O" = %3 : index, "size" = %4 : index) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     %6 = "acc2.launch"(%cst_0, %5) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
 // CHECK-NEXT:     "acc2.await"(%6) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:     %7 = "test.op"() : () -> i1
 // CHECK-NEXT:     %8, %9 = "scf.if"(%7) ({
-// CHECK-NEXT:       %10 = "acc2.setup"(%3, %5) <{"param_names" = ["B"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       %10 = acc2.setup on "snax_hwpe_mult" ("B" = %3 : index) in_state(%5) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:       %11 = "acc2.launch"(%cst_0, %10) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
 // CHECK-NEXT:       "acc2.await"(%11) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:       %12 = "test.op"() : () -> i32
-// CHECK-NEXT:       %13 = "acc2.setup"(%2, %10) <{"param_names" = ["O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       %13 = acc2.setup on "snax_hwpe_mult" ("O" = %2 : index) in_state(%10) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:       scf.yield %12, %13 : i32, !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     }, {
 // CHECK-NEXT:       %14 = "test.op"() : () -> i32
 // CHECK-NEXT:       %15 = "acc2.launch"(%cst_0, %5) <{"param_names" = ["launch"], "accelerator" = "snax_hwpe_mult"}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
 // CHECK-NEXT:       "acc2.await"(%15) : (!acc2.token<"snax_hwpe_mult">) -> ()
-// CHECK-NEXT:       %16 = "acc2.setup"(%3, %2, %5) <{"param_names" = ["B", "O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 2, 1>}> : (index, index, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       %16 = acc2.setup on "snax_hwpe_mult" ("B" = %3 : index, "O" = %2 : index) in_state(%5) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:       scf.yield %14, %16 : i32, !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     }) : (i1) -> (i32, !acc2.state<"snax_hwpe_mult">)
 // CHECK-NEXT:     "test.op"(%8) : (i32) -> ()

--- a/tests/filecheck/transforms/accfg-trace-states.mlir
+++ b/tests/filecheck/transforms/accfg-trace-states.mlir
@@ -17,9 +17,9 @@ func.func @simple() {
 // check that %s1 is added as an input to the second setup op
 // CHECK-NEXT:  func.func @simple() {
 // CHECK-NEXT:    %A, %B, %O, %nr_iters = "test.op"() : () -> (i32, i32, i32, i32)
-// CHECK-NEXT:    %s1 = "acc2.setup"(%A, %B, %O, %nr_iters) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:    %s2 = "acc2.setup"(%A, %B, %O, %nr_iters, %s1) <{"param_names" = ["A", "B", "O", "nr_iters"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>}> : (i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-//                                                          ^^^
+// CHECK-NEXT:    %s1 = acc2.setup on "snax_hwpe_mult" ("A" = %A : i32, "B" = %B : i32, "O" = %O : i32, "nr_iters" = %nr_iters : i32) : !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:    %s2 = acc2.setup on "snax_hwpe_mult" ("A" = %A : i32, "B" = %B : i32, "O" = %O : i32, "nr_iters" = %nr_iters : i32) in_state(%s1) : !acc2.state<"snax_hwpe_mult">
+//                                                                                                                                    ^^^^^^^^^^^^^
 // CHECK-NEXT:    func.return
 // CHECK-NEXT:  }
 
@@ -40,11 +40,11 @@ func.func @double_acc_simple() {
 // check that the two different accelerator states have not been mixed up:
 // CHECK-NEXT:  func.func @double_acc_simple() {
 // CHECK-NEXT:    %A_1, %B_1, %O_1, %nr_iters_1 = "test.op"() : () -> (i32, i32, i32, i32)
-// CHECK-NEXT:    %s1_1 = "acc2.setup"(%A_1, %B_1, %O_1, %nr_iters_1) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:    %s2_1 = "acc2.setup"(%B_1, %A_1, %O_1, %nr_iters_1) <{"accelerator" = "snax_hwpe_mult_2", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult_2">
-//                                                                  ^ no added state argument, as this is the first "snax_hwpe_mult_2" setup
-// CHECK-NEXT:    %s1_2 = "acc2.setup"(%A_1, %B_1, %O_1, %nr_iters_1, %s1_1) <{"param_names" = ["A", "B", "O", "nr_iters"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>}> : (i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-//                                                                    ^^^^^ state of the first setup call here
+// CHECK-NEXT:    %s1_1 = acc2.setup on "snax_hwpe_mult" ("A" = %A_1 : i32, "B" = %B_1 : i32, "O" = %O_1 : i32, "nr_iters" = %nr_iters_1 : i32) : !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:    %s2_1 = acc2.setup on "snax_hwpe_mult_2" ("A" = %B_1 : i32, "B" = %A_1 : i32, "O" = %O_1 : i32, "nr_iters" = %nr_iters_1 : i32) : !acc2.state<"snax_hwpe_mult_2">
+//                                                                        no added state argument, as this is the first "snax_hwpe_mult_2" setup ^
+// CHECK-NEXT:    %s1_2 = acc2.setup on "snax_hwpe_mult" ("A" = %A_1 : i32, "B" = %B_1 : i32, "O" = %O_1 : i32, "nr_iters" = %nr_iters_1 : i32) in_state(%s1_1) : !acc2.state<"snax_hwpe_mult">
+//                                                                                                           state of the first setup call here ^^^^^^^^^^^^^^^
 // CHECK-NEXT:    func.return
 // CHECK-NEXT:  }
 
@@ -71,14 +71,14 @@ func.func @simple_if() {
 // CHECK-NEXT:  func.func @simple_if() {
 // CHECK-NEXT:    %A_2, %B_2, %O_2, %nr_iters_2 = "test.op"() : () -> (i32, i32, i32, i32)
 // CHECK-NEXT:    %cond = "test.op"() : () -> i1
-// CHECK-NEXT:    %s1_1 = "acc2.setup"(%A_2, %B_2, %O_2, %nr_iters_2) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:    %s1_1 = acc2.setup on "snax_hwpe_mult" ("A" = %A_2 : i32, "B" = %B_2 : i32, "O" = %O_2 : i32, "nr_iters" = %nr_iters_2 : i32) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:    %0 = "scf.if"(%cond) ({
 //                ^^
-// CHECK-NEXT:      %s2_1 = "acc2.setup"(%A_2, %B_2, %O_2, %nr_iters_2, %s1_1) <{"param_names" = ["A", "B", "O", "nr_iters"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>}> : (i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:      %s2_1 = acc2.setup on "snax_hwpe_mult" ("A" = %A_2 : i32, "B" = %B_2 : i32, "O" = %O_2 : i32, "nr_iters" = %nr_iters_2 : i32) in_state(%s1_1) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:      scf.yield %s2_1 : !acc2.state<"snax_hwpe_mult">
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 // CHECK-NEXT:    }, {
-// CHECK-NEXT:      %s2_2 = "acc2.setup"(%A_2, %B_2, %O_2, %nr_iters_2, %s1_1) <{"param_names" = ["A", "B", "O", "nr_iters"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>}> : (i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:      %s2_2 = acc2.setup on "snax_hwpe_mult" ("A" = %A_2 : i32, "B" = %B_2 : i32, "O" = %O_2 : i32, "nr_iters" = %nr_iters_2 : i32) in_state(%s1_1) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:      scf.yield %s2_2 : !acc2.state<"snax_hwpe_mult">
 //                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 // CHECK-NEXT:    }) : (i1) -> !acc2.state<"snax_hwpe_mult">
@@ -113,16 +113,16 @@ func.func @simple_if_double_acc() {
 // CHECK-NEXT:  func.func @simple_if_double_acc() {
 // CHECK-NEXT:    %A_3, %B_3, %O_3, %nr_iters_3 = "test.op"() : () -> (i32, i32, i32, i32)
 // CHECK-NEXT:    %cond_1 = "test.op"() : () -> i1
-// CHECK-NEXT:    %s1_1_1 = "acc2.setup"(%A_3, %B_3, %O_3, %nr_iters_3) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:    %s2_1_1 = "acc2.setup"(%A_3, %B_3, %O_3, %nr_iters_3) <{"accelerator" = "snax_hwpe_mult_2", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult_2">
-//                                                                    ^ no added state
+// CHECK-NEXT:       %s1_1_1 = acc2.setup on "snax_hwpe_mult" ("A" = %A_3 : i32, "B" = %B_3 : i32, "O" = %O_3 : i32, "nr_iters" = %nr_iters_3 : i32) : !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       %s2_1_1 = acc2.setup on "snax_hwpe_mult_2" ("A" = %A_3 : i32, "B" = %B_3 : i32, "O" = %O_3 : i32, "nr_iters" = %nr_iters_3 : i32) : !acc2.state<"snax_hwpe_mult_2">
+//                                                                                                                                                    ^ no added state
 // CHECK-NEXT:    %1, %2 = "scf.if"(%cond_1) ({
-// CHECK-NEXT:      %s1_2_1 = "acc2.setup"(%A_3, %B_3, %O_3, %nr_iters_3, %s1_1_1) <{"param_names" = ["A", "B", "O", "nr_iters"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>}> : (i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:      %s1_2_1 = acc2.setup on "snax_hwpe_mult" ("A" = %A_3 : i32, "B" = %B_3 : i32, "O" = %O_3 : i32, "nr_iters" = %nr_iters_3 : i32) in_state(%s1_1_1) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:      scf.yield %s1_2_1, %s2_1_1 : !acc2.state<"snax_hwpe_mult">, !acc2.state<"snax_hwpe_mult_2">
 //                                     ^^^^^^^ yield outer state                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ correct type
 // CHECK-NEXT:    }, {
-// CHECK-NEXT:      %s2_2 = "acc2.setup"(%B_3, %A_3, %O_3, %nr_iters_3, %s2_1_1) <{"param_names" = ["A", "B", "O", "nr_iters"], "accelerator" = "snax_hwpe_mult_2", "operandSegmentSizes" = array<i32: 4, 1>}> : (i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult_2">) -> !acc2.state<"snax_hwpe_mult_2">
-// CHECK-NEXT:      %s1_2_2 = "acc2.setup"(%A_3, %B_3, %O_3, %nr_iters_3, %s1_1_1) <{"param_names" = ["A", "B", "O", "nr_iters"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>}> : (i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:      %s2_2 = acc2.setup on "snax_hwpe_mult_2" ("A" = %B_3 : i32, "B" = %A_3 : i32, "O" = %O_3 : i32, "nr_iters" = %nr_iters_3 : i32) in_state(%s2_1_1) : !acc2.state<"snax_hwpe_mult_2">
+// CHECK-NEXT:      %s1_2_2 = acc2.setup on "snax_hwpe_mult" ("A" = %A_3 : i32, "B" = %B_3 : i32, "O" = %O_3 : i32, "nr_iters" = %nr_iters_3 : i32) in_state(%s1_1_1) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:      scf.yield %s1_2_2, %s2_2 : !acc2.state<"snax_hwpe_mult">, !acc2.state<"snax_hwpe_mult_2">
 //                                     ^^^^^ yield inner state                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ correct type
 // CHECK-NEXT:    }) : (i1) -> (!acc2.state<"snax_hwpe_mult">, !acc2.state<"snax_hwpe_mult_2">)
@@ -166,29 +166,29 @@ func.func @nested_if() {
 // CHECK-NEXT:  func.func @nested_if() {
 // CHECK-NEXT:    %A_4, %B_4, %O_4, %nr_iters_4 = "test.op"() : () -> (i32, i32, i32, i32)
 // CHECK-NEXT:    %cond_2, %cond2 = "test.op"() : () -> (i1, i1)
-// CHECK-NEXT:    %s1_2 = "acc2.setup"(%A_4, %B_4, %O_4, %nr_iters_4) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:    %s1_2 = acc2.setup on "snax_hwpe_mult" ("A" = %A_4 : i32, "B" = %B_4 : i32, "O" = %O_4 : i32, "nr_iters" = %nr_iters_4 : i32) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:    %thing, %thing_1 = "scf.if"(%cond_2) ({
 //                        ^^^^^^^^
-// CHECK-NEXT:      %s2_3 = "acc2.setup"(%A_4, %B_4, %O_4, %nr_iters_4, %s1_2) <{"param_names" = ["A", "B", "O", "nr_iters"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>}> : (i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-//                                                                      ^^^^^
+// CHECK-NEXT:      %s2_3 = acc2.setup on "snax_hwpe_mult" ("A" = %A_4 : i32, "B" = %B_4 : i32, "O" = %O_4 : i32, "nr_iters" = %nr_iters_4 : i32) in_state(%s1_2) : !acc2.state<"snax_hwpe_mult">
+//                                                                                                                                                ^^^^^^^^^^^^^^^
 // CHECK-NEXT:      %c, %c_1 = "scf.if"(%cond2) ({
-// CHECK-NEXT:        %s3 = "acc2.setup"(%A_4, %B_4, %O_4, %nr_iters_4, %s2_3) <{"param_names" = ["A", "B", "O", "nr_iters"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>}> : (i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-//                                                                      ^^^^^
+// CHECK-NEXT:        %s3 = acc2.setup on "snax_hwpe_mult" ("A" = %A_4 : i32, "B" = %B_4 : i32, "O" = %O_4 : i32, "nr_iters" = %nr_iters_4 : i32) in_state(%s2_3) : !acc2.state<"snax_hwpe_mult">
+//                                                                                                                                                ^^^^^^^^^^^^^^^
 // CHECK-NEXT:        scf.yield %A_4, %s3 : i32, !acc2.state<"snax_hwpe_mult">
 //                                    ^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 // CHECK-NEXT:      }, {
-// CHECK-NEXT:        %s4 = "acc2.setup"(%A_4, %B_4, %O_4, %nr_iters_4, %s2_3) <{"param_names" = ["A", "B", "O", "nr_iters"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>}> : (i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-//                                                                      ^^^^^
+// CHECK-NEXT:        %s4 = acc2.setup on "snax_hwpe_mult" ("A" = %A_4 : i32, "B" = %B_4 : i32, "O" = %O_4 : i32, "nr_iters" = %nr_iters_4 : i32) in_state(%s2_3) : !acc2.state<"snax_hwpe_mult">
+//                                                                                                                                                ^^^^^^^^^^^^^^^
 // CHECK-NEXT:        scf.yield %B_4, %s4 : i32, !acc2.state<"snax_hwpe_mult">
 //                                    ^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 // CHECK-NEXT:      }) : (i1) -> (i32, !acc2.state<"snax_hwpe_mult">)
-// CHECK-NEXT:      %s3_1 = "acc2.setup"(%A_4, %B_4, %O_4, %nr_iters_4, %c_1) <{"param_names" = ["A", "B", "O", "nr_iters"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>}> : (i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-//                                                                      ^^^^^
+// CHECK-NEXT:      %s3_1 = acc2.setup on "snax_hwpe_mult" ("A" = %A_4 : i32, "B" = %B_4 : i32, "O" = %O_4 : i32, "nr_iters" = %nr_iters_4 : i32) in_state(%c_1) : !acc2.state<"snax_hwpe_mult">
+//                                                                                                                                                ^^^^^^^^^^^^^^^
 // CHECK-NEXT:      scf.yield %c, %s3_1 : i32, !acc2.state<"snax_hwpe_mult">
 //                                ^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 // CHECK-NEXT:    }, {
-// CHECK-NEXT:      %s2_4 = "acc2.setup"(%A_4, %B_4, %O_4, %nr_iters_4, %s1_2) <{"param_names" = ["A", "B", "O", "nr_iters"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>}> : (i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-//                                                                      ^^^^^
+// CHECK-NEXT:      %s2_4 = acc2.setup on "snax_hwpe_mult" ("A" = %A_4 : i32, "B" = %B_4 : i32, "O" = %O_4 : i32, "nr_iters" = %nr_iters_4 : i32) in_state(%s1_2) : !acc2.state<"snax_hwpe_mult">
+//                                                                                                                                                ^^^^^^^^^^^^^^^
 // CHECK-NEXT:      scf.yield %A_4, %s2_4 : i32, !acc2.state<"snax_hwpe_mult">
 //                                  ^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 // CHECK-NEXT:    }) : (i1) -> (i32, !acc2.state<"snax_hwpe_mult">)
@@ -217,12 +217,12 @@ func.func @simple_loop() {
 // check that a new loop-carried state variable was introduced to the scf.for loop:
 // CHECK-NEXT:  func.func @simple_loop() {
 // CHECK-NEXT:    %A_5, %B_5, %O_5, %nr_iters_5 = "test.op"() : () -> (i32, i32, i32, i32)
-// CHECK-NEXT:    %s1_3 = "acc2.setup"(%A_5, %B_5, %O_5, %nr_iters_5) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:    %s1_3 = acc2.setup on "snax_hwpe_mult" ("A" = %A_5 : i32, "B" = %B_5 : i32, "O" = %O_5 : i32, "nr_iters" = %nr_iters_5 : i32) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:    %lb, %ub, %step, %carry = "test.op"() : () -> (i32, i32, i32, i32)
 // CHECK-NEXT:    %res, %3 = scf.for %i = %lb to %ub step %step iter_args(%arg0 = %carry, %s1_4 = %s1_3) -> (i32, !acc2.state<"snax_hwpe_mult">) : i32 {
 //                      ^^                                                                ^^^^^^^^^^^^^           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-// CHECK-NEXT:      %s2_5 = "acc2.setup"(%A_5, %B_5, %O_5, %nr_iters_5, %s1_4) <{"param_names" = ["A", "B", "O", "nr_iters"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>}> : (i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-//                                                                      ^^^^^
+// CHECK-NEXT:      %s2_5 = acc2.setup on "snax_hwpe_mult" ("A" = %A_5 : i32, "B" = %B_5 : i32, "O" = %O_5 : i32, "nr_iters" = %nr_iters_5 : i32) in_state(%s1_4) : !acc2.state<"snax_hwpe_mult">
+//                                                                                                                                                ^^^^^^^^^^^^^^^
 // CHECK-NEXT:      scf.yield %arg0, %s2_5 : i32, !acc2.state<"snax_hwpe_mult">
 //                                   ^^^^^        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 // CHECK-NEXT:    }
@@ -251,14 +251,14 @@ func.func @nested_loop() {
 // check that both loops receive a new loop-carried variable:
 // CHECK-NEXT:  func.func @nested_loop() {
 // CHECK-NEXT:    %A_6, %B_6, %O_6, %nr_iters_6 = "test.op"() : () -> (i32, i32, i32, i32)
-// CHECK-NEXT:    %s1_5 = "acc2.setup"(%A_6, %B_6, %O_6, %nr_iters_6) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:    %s1_5 = acc2.setup on "snax_hwpe_mult" ("A" = %A_6 : i32, "B" = %B_6 : i32, "O" = %O_6 : i32, "nr_iters" = %nr_iters_6 : i32) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:    %lb_1, %ub_1, %step_1, %carry_1 = "test.op"() : () -> (i32, i32, i32, i32)
 // CHECK-NEXT:    %res_1, %4 = scf.for %i_1 = %lb_1 to %ub_1 step %step_1 iter_args(%arg0_1 = %carry_1, %s1_6 = %s1_5) -> (i32, !acc2.state<"snax_hwpe_mult">) : i32 {
 //                        ^^                                                                            ^^^^^^^^^^^^^           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 // CHECK-NEXT:      %5 = scf.for %y = %lb_1 to %ub_1 step %step_1 iter_args(%6 = %s1_6) -> (!acc2.state<"snax_hwpe_mult">) : i32 {
 //                  ^^                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-// CHECK-NEXT:        %s2_6 = "acc2.setup"(%A_6, %B_6, %O_6, %nr_iters_6, %6) <{"param_names" = ["A", "B", "O", "nr_iters"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>}> : (i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
-//                                                                        ^^
+// CHECK-NEXT:        %s2_6 = acc2.setup on "snax_hwpe_mult" ("A" = %A_6 : i32, "B" = %B_6 : i32, "O" = %O_6 : i32, "nr_iters" = %nr_iters_6 : i32) in_state(%6) : !acc2.state<"snax_hwpe_mult">
+//                                                                                                                                                  ^^^^^^^^^^^^
 // CHECK-NEXT:        scf.yield %s2_6 : !acc2.state<"snax_hwpe_mult">
 //                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 // CHECK-NEXT:      }
@@ -290,12 +290,12 @@ func.func @loop_with_multiple_input_states() {
 // check that only accelerator "b" is passed into the loop:
 // CHECK-NEXT:  func.func @loop_with_multiple_input_states() {
 // CHECK-NEXT:    %A_7, %B_7, %O_7, %nr_iters_7 = "test.op"() : () -> (i32, i32, i32, i32)
-// CHECK-NEXT:    %s1_7 = "acc2.setup"(%A_7, %B_7, %O_7, %nr_iters_7) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
-// CHECK-NEXT:    %sb = "acc2.setup"(%A_7, %B_7, %O_7, %nr_iters_7) <{"accelerator" = "b", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !acc2.state<"b">
+// CHECK-NEXT:    %s1_7 = acc2.setup on "snax_hwpe_mult" ("A" = %A_7 : i32, "B" = %B_7 : i32, "O" = %O_7 : i32, "nr_iters" = %nr_iters_7 : i32) : !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:    %sb = acc2.setup on "b" ("A" = %A_7 : i32, "B" = %B_7 : i32, "O" = %O_7 : i32, "nr_iters" = %nr_iters_7 : i32) : !acc2.state<"b">
 // CHECK-NEXT:    %lb_2, %ub_2, %step_2, %carry_2 = "test.op"() : () -> (i32, i32, i32, i32)
 // CHECK-NEXT:    %res_2, %7 = scf.for %i_2 = %lb_2 to %ub_2 step %step_2 iter_args(%arg0_2 = %carry_2, %sb_1 = %sb) -> (i32, !acc2.state<"b">) : i32 {
 //                                                                                                      ^^^^^^^^^^^           ^^^^^^^^^^^^^^^^
-// CHECK-NEXT:      %s2b = "acc2.setup"(%A_7, %B_7, %O_7, %nr_iters_7, %sb_1) <{"param_names" = ["A", "B", "O", "nr_iters"], "accelerator" = "b", "operandSegmentSizes" = array<i32: 4, 1>}> : (i32, i32, i32, i32, !acc2.state<"b">) -> !acc2.state<"b">
+// CHECK-NEXT:      %s2b = acc2.setup on "b" ("A" = %A_7 : i32, "B" = %B_7 : i32, "O" = %O_7 : i32, "nr_iters" = %nr_iters_7 : i32) in_state(%sb_1) : !acc2.state<"b">
 // CHECK-NEXT:      scf.yield %arg0_2, %s2b : i32, !acc2.state<"b">
 // CHECK-NEXT:    }
 // CHECK-NEXT:    func.return

--- a/tests/filecheck/transforms/convert-linalg-to-acc.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-acc.mlir
@@ -76,25 +76,25 @@
 // CHECK-NEXT:     %8 = "arith.index_cast"(%7) : (index) -> i32
 // CHECK-NEXT:     %9 = "memref.dim"(%arg0, %1) : (memref<?xi32>, index) -> index
 // CHECK-NEXT:     %10 = "arith.index_cast"(%9) : (index) -> i32
-// CHECK-NEXT:     %11 = "acc2.setup"(%4, %6, %8, %2, %10, %2) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 6, 0>, "param_names" = ["A", "B", "O", "vector_length", "nr_iters", "mode"]}> : (i32, i32, i32, i32, i32, i32) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     %11 = acc2.setup on "snax_hwpe_mult" ("A" = %4 : i32, "B" = %6 : i32, "O" = %8 : i32, "vector_length" = %2 : i32, "nr_iters" = %10 : i32, "mode" = %2 : i32) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     %12 = "acc2.launch"(%0, %11) <{"accelerator" = "snax_hwpe_mult", "param_names" = ["launch"]}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
 // CHECK-NEXT:     "acc2.await"(%12) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:     %13 = "test.op"() : () -> i1
 // CHECK-NEXT:     %14, %15 = "scf.if"(%13) ({
-// CHECK-NEXT:       %16 = "acc2.setup"(%4, %8, %8, %2, %10, %2, %11) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 6, 1>, "param_names" = ["A", "B", "O", "vector_length", "nr_iters", "mode"]}> : (i32, i32, i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       %16 = acc2.setup on "snax_hwpe_mult" ("A" = %4 : i32, "B" = %8 : i32, "O" = %8 : i32, "vector_length" = %2 : i32, "nr_iters" = %10 : i32, "mode" = %2 : i32) in_state(%11) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:       %17 = "acc2.launch"(%0, %16) <{"accelerator" = "snax_hwpe_mult", "param_names" = ["launch"]}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
 // CHECK-NEXT:       "acc2.await"(%17) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:       %18 = "test.op"() : () -> i32
 // CHECK-NEXT:       scf.yield %18, %16 : i32, !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     }, {
 // CHECK-NEXT:       %19 = "test.op"() : () -> i32
-// CHECK-NEXT:       %20 = "acc2.setup"(%4, %6, %8, %2, %10, %2, %11) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 6, 1>, "param_names" = ["A", "B", "O", "vector_length", "nr_iters", "mode"]}> : (i32, i32, i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:       %20 = acc2.setup on "snax_hwpe_mult" ("A" = %4 : i32, "B" = %6 : i32, "O" = %8 : i32, "vector_length" = %2 : i32, "nr_iters" = %10 : i32, "mode" = %2 : i32) in_state(%11) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:       %21 = "acc2.launch"(%0, %20) <{"accelerator" = "snax_hwpe_mult", "param_names" = ["launch"]}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
 // CHECK-NEXT:       "acc2.await"(%21) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:       scf.yield %19, %20 : i32, !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     }) : (i1) -> (i32, !acc2.state<"snax_hwpe_mult">)
 // CHECK-NEXT:     "test.op"(%14) : (i32) -> ()
-// CHECK-NEXT:     %22 = "acc2.setup"(%4, %8, %6, %2, %10, %2, %15) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 6, 1>, "param_names" = ["A", "B", "O", "vector_length", "nr_iters", "mode"]}> : (i32, i32, i32, i32, i32, i32, !acc2.state<"snax_hwpe_mult">) -> !acc2.state<"snax_hwpe_mult">
+// CHECK-NEXT:     %22 = acc2.setup on "snax_hwpe_mult" ("A" = %4 : i32, "B" = %8 : i32, "O" = %6 : i32, "vector_length" = %2 : i32, "nr_iters" = %10 : i32, "mode" = %2 : i32) in_state(%15) : !acc2.state<"snax_hwpe_mult">
 // CHECK-NEXT:     %23 = "acc2.launch"(%0, %22) <{"accelerator" = "snax_hwpe_mult", "param_names" = ["launch"]}> : (i5, !acc2.state<"snax_hwpe_mult">) -> !acc2.token<"snax_hwpe_mult">
 // CHECK-NEXT:     "acc2.await"(%23) : (!acc2.token<"snax_hwpe_mult">) -> ()
 // CHECK-NEXT:     func.return


### PR DESCRIPTION
Broke this out of #129 because it's already a chonker

This makes it easier to understand setup ops (e.g. the input state is no longer mixed with the values, and the "key = value" pairs are closer together.
