### PR TITLE
Add DMA barrier hotfix

### DIFF
--- a/runtime/include/snax_rt.h
+++ b/runtime/include/snax_rt.h
@@ -65,6 +65,7 @@ void _mlir_ciface_snax_dma_2d_transfer(size_t *source, size_t *destination,
   //        size, source, destination, src_stride, dst_stride, repeat);
   snrt_dma_start_2d((void *)destination, (void *)source, size, dst_stride,
                     src_stride, repeat);
+  snrt_dma_wait_all();
 }
 
 int _mlir_ciface_snax_is_dm_core() { return snrt_is_dm_core(); }


### PR DESCRIPTION
There was a missing barrier in one of the runtime routines, resulting in fun-to-debug erronous behaviour.