### PR TITLE
Add ScopedSetupWithInputs (stacked 2/3)

### DIFF
--- a/compiler/inference/helpers.py
+++ b/compiler/inference/helpers.py
@@ -1,0 +1,141 @@
+from collections.abc import Generator
+
+from xdsl.dialects import scf
+from xdsl.ir import Block, BlockArgument, Operation, OpResult, Region, SSAValue
+
+from compiler.dialects import accfg
+
+
+def get_initial_value_for_scf_for_lcv(loop: scf.For, var: SSAValue) -> SSAValue:
+    """
+    Given a loop-carried variable inside an scf for loop as the block argument,
+    return the SSA value that is passed as the initial value to it.
+    """
+    if var not in loop.body.block.args:
+        raise ValueError(
+            f"Given value {var} not a block argument of the for loop {loop}!"
+        )
+    idx = loop.body.block.args.index(var) - 1
+    return loop.iter_args[idx]
+
+
+def val_is_defined_in_block(val: SSAValue, block: Block) -> bool:
+    """
+    Check if val is defined in block or in blocks nested in block.
+    """
+    if isinstance(val, BlockArgument):
+        block_ptr: Block | None = val.owner
+        # walk upwards until we hit block or None
+        while block_ptr is not None and block_ptr != block:
+            # walk upwards
+            block_ptr = block_ptr.parent_block()
+        # we either ran out of blocks
+        return block_ptr is not None
+    elif isinstance(val, OpResult):
+        op_ptr: Operation | None = val.owner
+        # walk up until we either hit the right block, or run out of parents
+        while op_ptr is not None and op_ptr.parent_block() != block:
+            op_ptr = op_ptr.parent_op()
+        # iff we didn't hit the right block, ptr must be none
+        return op_ptr is not None
+    else:
+        raise ValueError(f"Unsupported SSA Value type: {val}")
+
+
+def calc_if_state_delta(
+    old_state: dict[str, SSAValue],
+    if_state: dict[str, SSAValue],
+    else_state: dict[str, SSAValue],
+) -> dict[str, tuple[SSAValue, SSAValue]]:
+    """
+    Given three state dictionaries (mapping accelerator names
+    to SSA vals containing their state, return a new dict that:
+
+    - Contains tuples (if_branch_val, else_branch_val)
+    - For all accelerators whose state val changed in *at least
+      one* of the branches
+    - And for all accelerator states that got introduced in *both*
+      branches
+    """
+    new_state: dict[str, tuple[SSAValue, SSAValue]] = {}
+
+    # for every key in the old state, find out if it changed
+    for k in old_state:
+        # get new vals (or None if dropped)
+        new_vals = (
+            if_state.pop(k, None),
+            else_state.pop(k, None),
+        )
+        # drop val if it is invalidated on one side
+        if any(v is None for v in new_vals):
+            continue
+        # if no val changed
+        if all(v == old_state[k] for v in new_vals):
+            continue
+        # pyright can't infer that we actually checked the argument type:
+        new_state[k] = new_vals  # pyright: ignore[reportArgumentType]
+
+    # check for states that are present in both branches
+    for k in if_state:
+        if k not in else_state:
+            continue
+        # add them to the new dict
+        new_state[k] = (if_state[k], else_state[k])
+
+    return new_state
+
+
+def find_all_acc_names_in_region(reg: Region) -> set[str]:
+    """
+    Walk a region and return a set of accelerator names are set up in that region.
+    """
+    acs: set[str] = set()
+    for op in reg.walk():
+        if isinstance(op, accfg.SetupOp):
+            acs.add(op.accelerator.data)
+    return acs
+
+
+def find_existing_block_arg(block: Block, accel: str) -> BlockArgument | None:
+    """
+    Inspect a block for block arguments of the correct accfg.StateType type, return the block arg if found.
+    """
+    for arg in block.args:
+        if isinstance(arg.type, accfg.StateType) and arg.type.accelerator.data == accel:
+            return arg
+    return None
+
+
+def iter_ops_range(
+    start_op: Operation | None, end_op: Operation | None
+) -> Generator[Operation, None, None]:
+    """
+    Create an iterator that goes from start_op (inclusive) to end_op (exclusive).
+
+    If start_op is None, iterate from the start of the block.
+
+    If end_op is None, iterate to the end of the block (inclusive).
+
+    Both ops cannot be none.
+
+    If provided, both start and end op must be in the same block.
+    """
+
+    if start_op is None:
+        assert end_op is not None, "Can't have both start and end_op be None!"
+        parent = end_op.parent_block()
+        assert parent is not None, "Provided operations must have parent blocks!"
+        start_op = parent.first_op
+
+    assert start_op is not None  # just for pyright
+
+    if end_op is not None:
+        assert (
+            start_op.parent_block() is end_op.parent_block()
+        ), "Cannot iterate between operations not within the same block!"
+
+    yield start_op
+    while start_op.next_op is not end_op:
+        assert start_op.next_op is not None  # just for pyright
+        yield start_op.next_op
+        start_op = start_op.next_op

--- a/compiler/inference/scoped_setups.py
+++ b/compiler/inference/scoped_setups.py
@@ -75,7 +75,7 @@ def get_scoped_setup_inputs(
     while vals_to_inspect:
         # grab a value to inspect
         val = vals_to_inspect.pop(0)
-        # check if it's one of the loop dependent variables we are looking at
+        # check if it's one of the block arguments we are looking at
         if val in input_vars:
             # if it is, we have walked the use-def chain to its conclusion
             continue

--- a/compiler/inference/scoped_setups.py
+++ b/compiler/inference/scoped_setups.py
@@ -115,7 +115,7 @@ def get_scoped_setup_inputs(
 @dataclass
 class ScopedSetupWithInputs:
     """
-    This dataclass represents a setup inside a loop that is loop variable dependent.
+    This dataclass represents a setup inside a block that is block-argument dependent.
 
     - setup: The setup operation
     - dependent_vars: SSA values that we know are loop-dependent

--- a/compiler/inference/scoped_setups.py
+++ b/compiler/inference/scoped_setups.py
@@ -86,7 +86,7 @@ def get_scoped_setup_inputs(
         if isinstance(val.owner, Block):
             # shrug, idk what to do here
             print(
-                f"constructung pure input tree for setup {setup_op} failed on block argument {val} of:\n"
+                f"constructing pure input tree for setup {setup_op} failed on block argument {val} of:\n"
                 f"{val.owner.parent_op()}",
                 file=sys.stderr,
             )

--- a/compiler/inference/scoped_setups.py
+++ b/compiler/inference/scoped_setups.py
@@ -1,0 +1,163 @@
+"""
+This file contains helpers that allow us to reason about "scoped setups"
+
+A scoped setup is a setup and all associated operations needed to calculate its values. It can be
+thought of as the sequence of operations needed to set up the accelerator. Given the following IR:
+
+```
+func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
+  %0 = arith.constant 0 : index
+  %cst_0 = arith.constant 0 : i5
+  %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
+  %2 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
+  %3 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
+  %4 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
+
+  %5 = accfg.setup "snax_hwpe_mult" to ("A" = %1 : index, "B" = %2 : index, "O" = %3 : index, "size" = %4 : index) : ...
+
+  // ...
+```
+
+The scoped setup of %5 would be:
+```
+ScopedSetupWithInputs(
+    setup = %5 = accfg.setup ...
+    dependent_vars = tuple(%arg0, %arg1, %arg2)
+    inputs = (
+        %0 = arith.constant 0 : index
+        %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
+        %2 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
+        %3 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
+        %4 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
+    )
+)
+```
+
+With `%cst_0` being absent, as it's not used as part of the setup sequence.
+
+Some further restrictions:
+
+- A scoped setup is always scoped to within a block, no operations outside that block are considered.
+- A scoped setup may only contain operations that are side effect free, as we only care to argue about
+  setup sequences that we can move around or copy.
+
+A scoped setup can be:
+
+- Moved
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+
+from xdsl.ir import Block, Operation, SSAValue
+from xdsl.pattern_rewriter import PatternRewriter
+from xdsl.rewriter import InsertPoint
+from xdsl.traits import is_side_effect_free
+
+from compiler.dialects import accfg
+from compiler.inference.helpers import val_is_defined_in_block
+
+
+def get_scoped_setup_inputs(
+    setup_op: accfg.SetupOp, scope: Block
+) -> ScopedSetupWithInputs | None:
+    """
+    Takes a setup op and a set of known input variables, and looks at all inputs to the setup op to determine
+    """
+    input_vars = scope.args
+    inputs = []
+
+    # value inspection starts at all inputs to the setup op:
+    vals_to_inspect = [*setup_op.values]
+    # until we are out of values to inspect, we:
+    while vals_to_inspect:
+        # grab a value to inspect
+        val = vals_to_inspect.pop(0)
+        # check if it's one of the loop dependent variables we are looking at
+        if val in input_vars:
+            # if it is, we have walked the use-def chain to its conclusion
+            continue
+        # if the value is defined outside our scope, we don't need to dig any further
+        if not val_is_defined_in_block(val, scope):
+            continue
+        # if it's another block argument, we just give up
+        if isinstance(val.owner, Block):
+            # shrug, idk what to do here
+            print(
+                f"constructung pure input tree for setup {setup_op} failed on block argument {val} of:\n"
+                f"{val.owner.parent_op()}",
+                file=sys.stderr,
+            )
+            return None
+        # if it's an operation
+        elif isinstance(val.owner, Operation):
+            # we check that it's effect free
+            if is_side_effect_free(val.owner):
+                # if it is effect free, we recurse on it's operands
+                vals_to_inspect.extend(val.owner.operands)
+                # and note the operation down as one that computes our input variables
+                inputs.append(val.owner)
+            else:
+                # impure operations represent a problem for us. Print a warning.
+                print(
+                    f"Op with effects in use-def chain upwards of setup {setup_op}: {val.owner}",
+                    file=sys.stderr,
+                )
+                return None
+
+    return ScopedSetupWithInputs(
+        setup_op, input_vars, tuple(reversed(inputs))  # reverse order
+    )
+
+
+@dataclass
+class ScopedSetupWithInputs:
+    """
+    This dataclass represents a setup inside a loop that is loop variable dependent.
+
+    - setup: The setup operation
+    - dependent_vars: SSA values that we know are loop-dependent
+    - inputs: A sequence of Operations that are dependent on the depdendent_var and need to be moved with the setup op
+
+    Has three helpers to:
+
+    1. Move the setup and inputs to be at least above a certain point
+    """
+
+    setup: accfg.SetupOp
+    dependent_vars: tuple[SSAValue, ...]
+    inputs: tuple[Operation, ...]
+
+    def lazy_move_up(self, scope: Block, pt: InsertPoint, rewriter: PatternRewriter):
+        """
+        This method will move operations such that all inputs are located above the insertion point.
+
+        Operations that are already above the insertion point won't be moved.
+        """
+        assert (
+            pt.insert_before is not None
+        ), "can't move to end of block! (malformed IR)"
+        assert (
+            pt.insert_before.parent_block() is scope
+        ), "Can't move operations to an insertion point that is not directly in $scope!"
+
+        # don't do anything if the insertion point is one of our ops:
+        if pt.insert_before in self.inputs or pt.insert_before is self.setup:
+            return
+
+        positions: dict[Operation, int] = dict(
+            (op, i) for i, op in enumerate(scope.ops)
+        )
+
+        insertion_point_position = positions[pt.insert_before]
+
+        # only move operations that are below the insertion point
+        for op in (*self.inputs, self.setup):
+            assert op in positions
+            idx = positions[op]
+            if idx <= insertion_point_position:
+                continue
+            op.detach()
+            rewriter.insert_op(op, pt)

--- a/compiler/inference/scoped_setups.py
+++ b/compiler/inference/scoped_setups.py
@@ -141,7 +141,7 @@ class ScopedSetupWithInputs:
         ), "can't move to end of block! (malformed IR)"
         assert (
             pt.insert_before.parent_block() is scope
-        ), "Can't move operations to an insertion point that is not directly in $scope!"
+        ), "Can't move operations to an insertion point that is not directly in scope!"
 
         # don't do anything if the insertion point is one of our ops:
         if pt.insert_before in self.inputs or pt.insert_before is self.setup:

--- a/compiler/transforms/accfg_config_overlap.py
+++ b/compiler/transforms/accfg_config_overlap.py
@@ -71,7 +71,9 @@ class BlockLevelSetupAwaitOverlapPattern(RewritePattern):
             return
 
         # if all the ops between launch and setup are input ops, then there's nothing to move!
-        if all(between_op in inputs.inputs for between_op in iter_ops_range(launch, op)):
+        if all(
+            between_op in inputs.inputs for between_op in iter_ops_range(launch, op)
+        ):
             return
 
         inputs.lazy_move_up(  # and move the setup and inputs to be right behind the launch

--- a/compiler/transforms/accfg_config_overlap.py
+++ b/compiler/transforms/accfg_config_overlap.py
@@ -81,7 +81,6 @@ class BlockLevelSetupAwaitOverlapPattern(RewritePattern):
         )
 
 
-
 class AccfgConfigOverlapPass(ModulePass):
     """
     This pass moves setup ops upward in code to enable setup-computation overlap.

--- a/compiler/transforms/accfg_config_overlap.py
+++ b/compiler/transforms/accfg_config_overlap.py
@@ -71,7 +71,7 @@ class BlockLevelSetupAwaitOverlapPattern(RewritePattern):
             return
 
         # if all the ops between launch and setup are input ops, then there's nothing to move!
-        if all(betwee_op in inputs.inputs for betwee_op in iter_ops_range(launch, op)):
+        if all(between_op in inputs.inputs for between_op in iter_ops_range(launch, op)):
             return
 
         inputs.lazy_move_up(  # and move the setup and inputs to be right behind the launch

--- a/compiler/transforms/accfg_config_overlap.py
+++ b/compiler/transforms/accfg_config_overlap.py
@@ -2,13 +2,17 @@ from xdsl.dialects import builtin
 from xdsl.ir import MLContext, Operation, Use
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
     PatternRewriter,
     PatternRewriteWalker,
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 
 from compiler.dialects import accfg
+from compiler.inference.helpers import iter_ops_range
+from compiler.inference.scoped_setups import get_scoped_setup_inputs
 
 
 class BlockLevelSetupAwaitOverlapPattern(RewritePattern):
@@ -53,10 +57,29 @@ class BlockLevelSetupAwaitOverlapPattern(RewritePattern):
         if launch.next_op is op:
             return
 
-        # detach the setup op
-        op.detach()
-        # insert the op right after the launch
-        rewriter.insert_op_after(op, launch)
+        # grab the parent block, which can't be none (we know that)
+        parent_block = op.parent_block()
+        assert parent_block is not None
+
+        # grab the setup op with all inputs in this block
+        inputs = get_scoped_setup_inputs(op, parent_block)
+
+        # if we have immovable inputs, abort
+        # TODO: it is fine if the immovable inputs are *before* the launch op anyway, as we only
+        #       care about ops up until the launch op. We can implement this later if it's a problem.
+        if inputs is None:
+            return
+
+        # if all the ops between launch and setup are input ops, then there's nothing to move!
+        if all(betwee_op in inputs.inputs for betwee_op in iter_ops_range(launch, op)):
+            return
+
+        inputs.lazy_move_up(  # and move the setup and inputs to be right behind the launch
+            parent_block,
+            InsertPoint.after(launch),
+            rewriter,
+        )
+
 
 
 class AccfgConfigOverlapPass(ModulePass):
@@ -67,7 +90,13 @@ class AccfgConfigOverlapPass(ModulePass):
     name = "accfg-config-overlap"
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
-        PatternRewriteWalker(BlockLevelSetupAwaitOverlapPattern()).rewrite_module(op)
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    BlockLevelSetupAwaitOverlapPattern(),
+                ]
+            )
+        ).rewrite_module(op)
 
 
 def get_ops_from_uses(uses: set[Use]) -> tuple[Operation, ...]:

--- a/compiler/transforms/accfg_config_overlap.py
+++ b/compiler/transforms/accfg_config_overlap.py
@@ -76,7 +76,8 @@ class BlockLevelSetupAwaitOverlapPattern(RewritePattern):
         ):
             return
 
-        inputs.lazy_move_up(  # and move the setup and inputs to be right behind the launch
+        # and move the setup and inputs to be right behind the launch
+        inputs.lazy_move_up(
             parent_block,
             InsertPoint.after(launch),
             rewriter,

--- a/compiler/transforms/accfg_dedup.py
+++ b/compiler/transforms/accfg_dedup.py
@@ -63,7 +63,7 @@ class MergeSetupOps(RewritePattern):
                 and prev_op.accelerator == op.accelerator
             ):
                 break
-            # if we encounter a not-pure op, we abort
+            # if we encounter an op with side effects, we abort
             if not is_side_effect_free(prev_op):
                 return
             prev_op = prev_op.prev_op

--- a/compiler/transforms/accfg_dedup.py
+++ b/compiler/transforms/accfg_dedup.py
@@ -1,14 +1,7 @@
 from dataclasses import dataclass
 
 from xdsl.dialects import builtin, scf
-from xdsl.ir import (
-    Block,
-    BlockArgument,
-    MLContext,
-    Operation,
-    OpResult,
-    SSAValue,
-)
+from xdsl.ir import MLContext, OpResult, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -17,13 +10,14 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
-from xdsl.traits import Pure
+from xdsl.traits import is_side_effect_free
 
 from compiler.dialects import accfg
-from compiler.inference.trace_acc_state import (
-    all_setup_ops_in_region,
-    infer_state_of,
+from compiler.inference.helpers import (
+    get_initial_value_for_scf_for_lcv,
+    val_is_defined_in_block,
 )
+from compiler.inference.trace_acc_state import all_setup_ops_in_region, infer_state_of
 
 
 class SimplifyRedundantSetupCalls(RewritePattern):
@@ -70,7 +64,7 @@ class MergeSetupOps(RewritePattern):
             ):
                 break
             # if we encounter a not-pure op, we abort
-            if not prev_op.has_trait(Pure):
+            if not is_side_effect_free(prev_op):
                 return
             prev_op = prev_op.prev_op
         if prev_op is None:
@@ -277,39 +271,3 @@ class AccfgDeduplicate(ModulePass):
             GreedyRewritePatternApplier(patterns),
             walk_reverse=True,
         ).rewrite_module(op)
-
-
-def get_initial_value_for_scf_for_lcv(loop: scf.For, var: SSAValue) -> SSAValue:
-    """
-    Given a loop-carried variable inside an scf for loop as the block argument,
-    return the SSA value that is passed as the initial value to it.
-    """
-    if var not in loop.body.block.args:
-        raise ValueError(
-            f"Given value {var} not a block argument of the for loop {loop}!"
-        )
-    idx = loop.body.block.args.index(var) - 1
-    return loop.iter_args[idx]
-
-
-def val_is_defined_in_block(val: SSAValue, block: Block) -> bool:
-    """
-    Check if val is defined in block or in blocks nested in block.
-    """
-    if isinstance(val, BlockArgument):
-        block_ptr: Block | None = val.owner
-        # walk upwards until we hit block or None
-        while block_ptr is not None and block_ptr != block:
-            # walk upwards
-            block_ptr = block_ptr.parent_block()
-        # we either ran out of blocks
-        return block_ptr is not None
-    elif isinstance(val, OpResult):
-        op_ptr: Operation | None = val.owner
-        # walk up until we either hit the right block, or run out of parents
-        while op_ptr is not None and op_ptr.parent_block() != block:
-            op_ptr = op_ptr.parent_op()
-        # iff we didn't hit the right block, ptr must be none
-        return op_ptr is not None
-    else:
-        raise ValueError(f"Unsupported SSA Value type: {val}")

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1718396522,
+        "narHash": "sha256-C0re6ZtCqC1ndL7ib7vOqmgwvZDhOhJ1W0wQgX1tTIo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e6b9369165397184774a4b7c5e8e5e46531b53f",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "snax devshell";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+          };
+          conf_basebath = "/tmp/pycharm-snax";
+        in
+          {
+            devShells.default = with pkgs; mkShell {
+              LD_LIBRARY_PATH = "${stdenv.cc.cc.lib}/lib";
+              buildInputs = [
+                nodejs_22 ruff black isort llvmPackages_17.mlir
+              ];
+	      name = "snax-nix";
+              JAVA_TOOL_OPTIONS = "-Didea.config.path=${conf_basebath}/conf -Didea.system.path=${conf_basebath}/sys -Didea.plugins.path=${conf_basebath}/plugins -Didea.log.path=${conf_basebath}/sys/logs";
+            };
+          }
+    );
+}

--- a/tests/filecheck/transforms/accfg-trace-states.mlir
+++ b/tests/filecheck/transforms/accfg-trace-states.mlir
@@ -7,9 +7,13 @@
 func.func @simple() {
     %A, %B, %O, %nr_iters = "test.op"() : () -> (i32, i32, i32, i32)
 
-    %s1 = "accfg.setup"(%A, %B, %O, %nr_iters) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !accfg.state<"snax_hwpe_mult">
+    %s1 = accfg.setup "snax_hwpe_mult" to (
+        "A" = %A : i32, "B" = %B : i32, "O" = %O : i32, "nr_iters" = %nr_iters : i32
+    ) : !accfg.state<"snax_hwpe_mult">
 
-    %s2 = "accfg.setup"(%A, %B, %O, %nr_iters) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "nr_iters"]}> : (i32, i32, i32, i32) -> !accfg.state<"snax_hwpe_mult">
+    %s2 = accfg.setup "snax_hwpe_mult" to (
+        "A" = %A : i32, "B" = %B : i32, "O" = %O : i32, "nr_iters" = %nr_iters : i32
+    ) : !accfg.state<"snax_hwpe_mult">
 
     return
 }


### PR DESCRIPTION
This PR adds ScopedSetupWithInputs and moves a bunch of helpers out of the rewrites and into the `inference` module.

ScopedSetupWithInputs represents a setup op together with operations that calculate it's inputs. These operations must be pure, and be contained within a block (usually the block at which the operation is located).

This helper class is needed for stacked PR 3/3, and will also be helpful to simplify some other rewrites I'm sure,