### PR TITLE
support strided copies

### DIFF
--- a/compiler/ir/tsl/tiled_strided_layout.py
+++ b/compiler/ir/tsl/tiled_strided_layout.py
@@ -27,7 +27,7 @@ class TiledStridedLayout:
 
     @staticmethod
     def from_strides(
-        strides: list[int], tile_bounds: list[int], offset: int = 0
+        strides: list[int | None], tile_bounds: list[list[int | None]], offset: int = 0
     ) -> TiledStridedLayout:
         """Create a TiledStridedLayout from a list of strides and tile bounds
 

--- a/compiler/transforms/snax_copy_to_dma.py
+++ b/compiler/transforms/snax_copy_to_dma.py
@@ -156,7 +156,7 @@ class TransformDMA(RewritePattern):
                 return
             if isinstance(op.destination.type.layout, TiledStridedLayoutAttr):
                 # if destination is tsl, use those tile sizes
-                tile_bounds = op.destination.type.layout.tile_bounds()
+                tile_bounds = op.destination.type.layout.data.tile_bounds()
             else:
                 # otherwise, shape can be used as single-dimension tile sizes
                 tile_bounds = [shape.data for shape in op.source.type.shape.data]
@@ -176,7 +176,7 @@ class TransformDMA(RewritePattern):
                 return
             if isinstance(op.source.type.layout, TiledStridedLayoutAttr):
                 # if destination is tsl, use those tile sizes
-                tile_bounds = op.source.type.layout.tile_bounds()
+                tile_bounds = op.source.type.layout.data.tile_bounds()
             else:
                 # otherwise, shape can be used as single-dimension tile sizes
                 tile_bounds = [shape.data for shape in op.destination.type.shape.data]

--- a/compiler/transforms/snax_copy_to_dma.py
+++ b/compiler/transforms/snax_copy_to_dma.py
@@ -151,32 +151,40 @@ class TransformDMA(RewritePattern):
         if isinstance(op.source.type.layout, TiledStridedLayoutAttr):
             tsl_source = op.source.type.layout
         else:
-            # destination should be tsl
-            if not isinstance(op.destination.type.layout, TiledStridedLayoutAttr):
-                return
             strides = extract_strides(op.source.type)
             if not strides:
                 return
+            if isinstance(op.destination.type.layout, TiledStridedLayoutAttr):
+               # if destination is tsl, use those tile sizes
+               tile_bounds = op.destination.type.layout.tile_bounds()
+            else:
+                # otherwise, shape can be used as single-dimension tile sizes
+                tile_bounds = [shape.data for shape in op.source.type.shape.data]
+                # change dynamic size -1 to None
+                tile_bounds = [[x] if x > 0 else [None] for x in tile_bounds]
+                pass
             tsl_source = TiledStridedLayoutAttr(
-                TiledStridedLayout.from_strides(
-                    strides, op.destination.type.layout.data.tile_bounds()
-                )
+                TiledStridedLayout.from_strides(strides, tile_bounds)
             )
 
         # if dest is not tsl, construct representation:
         if isinstance(op.destination.type.layout, TiledStridedLayoutAttr):
             tsl_dest = op.destination.type.layout
         else:
-            # source should be tsl
-            if not isinstance(op.source.type.layout, TiledStridedLayoutAttr):
-                return
             strides = extract_strides(op.destination.type)
             if not strides:
                 return
+            if isinstance(op.source.type.layout, TiledStridedLayoutAttr):
+               # if destination is tsl, use those tile sizes
+               tile_bounds = op.source.type.layout.tile_bounds()
+            else:
+                # otherwise, shape can be used as single-dimension tile sizes
+                tile_bounds = [shape.data for shape in op.destination.type.shape.data]
+                # change dynamic size -1 to None
+                tile_bounds = [[x] if x > 0 else [None] for x in tile_bounds]
+                pass
             tsl_dest = TiledStridedLayoutAttr(
-                TiledStridedLayout.from_strides(
-                    strides, op.source.type.layout.data.tile_bounds()
-                )
+                TiledStridedLayout.from_strides(strides, tile_bounds)
             )
 
         # list of all ops that need to be inserted

--- a/compiler/transforms/snax_copy_to_dma.py
+++ b/compiler/transforms/snax_copy_to_dma.py
@@ -155,8 +155,8 @@ class TransformDMA(RewritePattern):
             if not strides:
                 return
             if isinstance(op.destination.type.layout, TiledStridedLayoutAttr):
-               # if destination is tsl, use those tile sizes
-               tile_bounds = op.destination.type.layout.tile_bounds()
+                # if destination is tsl, use those tile sizes
+                tile_bounds = op.destination.type.layout.tile_bounds()
             else:
                 # otherwise, shape can be used as single-dimension tile sizes
                 tile_bounds = [shape.data for shape in op.source.type.shape.data]
@@ -175,8 +175,8 @@ class TransformDMA(RewritePattern):
             if not strides:
                 return
             if isinstance(op.source.type.layout, TiledStridedLayoutAttr):
-               # if destination is tsl, use those tile sizes
-               tile_bounds = op.source.type.layout.tile_bounds()
+                # if destination is tsl, use those tile sizes
+                tile_bounds = op.source.type.layout.tile_bounds()
             else:
                 # otherwise, shape can be used as single-dimension tile sizes
                 tile_bounds = [shape.data for shape in op.destination.type.shape.data]

--- a/tests/filecheck/transforms/copy_to_dma.mlir
+++ b/tests/filecheck/transforms/copy_to_dma.mlir
@@ -53,6 +53,50 @@
 //CHECK-NEXT:   }) : () -> ()
 //CHECK-NEXT: }) : () -> ()
 
+// -----
+
+"builtin.module"() ({
+  "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<5x5xi32, strided<[10, 1]>>, memref<5x5xi32, strided<[20, 1]>>) -> (), "sym_visibility" = "public"}> ({
+  ^0(%arg0 : memref<5x5xi32, strided<[10, 1]>>, %arg1 : memref<5x5xi32, strided<[20, 1]>>):
+    "memref.copy"(%arg0, %arg1) : (memref<5x5xi32, strided<[10, 1]>>, memref<5x5xi32, strided<[20, 1]>>) -> ()
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+//CHECK: "builtin.module"() ({
+//CHECK-NEXT:   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<5x5xi32, strided<[10, 1]>>, memref<5x5xi32, strided<[20, 1]>>) -> (), "sym_visibility" = "public"}> ({
+//CHECK-NEXT:   ^0(%arg0 : memref<5x5xi32, strided<[10, 1]>>, %arg1 : memref<5x5xi32, strided<[20, 1]>>):
+//CHECK-NEXT:     %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<5x5xi32, strided<[10, 1]>>) -> index
+//CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<5x5xi32, strided<[20, 1]>>) -> index
+//CHECK-NEXT:     %2 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+//CHECK-NEXT:     %3 = "memref.dim"(%arg0, %2) : (memref<5x5xi32, strided<[10, 1]>>, index) -> index
+//CHECK-NEXT:     %4 = "arith.constant"() <{"value" = 1 : index}> : () -> index
+//CHECK-NEXT:     %5 = "memref.dim"(%arg0, %4) : (memref<5x5xi32, strided<[10, 1]>>, index) -> index
+//CHECK-NEXT:     %6 = "arith.constant"() <{"value" = 5 : index}> : () -> index
+//CHECK-NEXT:     %7 = "arith.constant"() <{"value" = 5 : index}> : () -> index
+//CHECK-NEXT:     %8 = "arith.constant"() <{"value" = 10 : index}> : () -> index
+//CHECK-NEXT:     %9 = "arith.constant"() <{"value" = 1 : index}> : () -> index
+//CHECK-NEXT:     %10 = "arith.constant"() <{"value" = 10 : index}> : () -> index
+//CHECK-NEXT:     %11 = "arith.constant"() <{"value" = 20 : index}> : () -> index
+//CHECK-NEXT:     %12 = "arith.constant"() <{"value" = 1 : index}> : () -> index
+//CHECK-NEXT:     %13 = "arith.constant"() <{"value" = 20 : index}> : () -> index
+//CHECK-NEXT:     %14 = "arith.constant"() <{"value" = 1 : index}> : () -> index
+//CHECK-NEXT:     %15 = "arith.constant"() <{"value" = 0 : index}> : () -> index
+//CHECK-NEXT:     %16 = "arith.constant"() <{"value" = 1 : index}> : () -> index
+//CHECK-NEXT:     "scf.for"(%15, %7, %16) ({
+//CHECK-NEXT:     ^1(%17 : index):
+//CHECK-NEXT:       %18 = "arith.muli"(%17, %9) : (index, index) -> index
+//CHECK-NEXT:       %19 = "arith.addi"(%0, %18) : (index, index) -> index
+//CHECK-NEXT:       %20 = "arith.muli"(%17, %12) : (index, index) -> index
+//CHECK-NEXT:       %21 = "arith.addi"(%1, %20) : (index, index) -> index
+//CHECK-NEXT:       "func.call"(%19, %21, %14, %10, %13, %6) <{"callee" = @snax_dma_2d_transfer}> : (index, index, index, index, index, index) -> ()
+//CHECK-NEXT:       "scf.yield"() : () -> ()
+//CHECK-NEXT:     }) : (index, index, index) -> ()
+//CHECK-NEXT:     "func.return"() : () -> ()
+//CHECK-NEXT:   }) : () -> ()
+//CHECK-NEXT:   "func.func"() <{"sym_name" = "snax_dma_2d_transfer", "function_type" = (index, index, index, index, index, index) -> (), "sym_visibility" = "private"}> ({
+//CHECK-NEXT:   }) : () -> ()
+//CHECK-NEXT: }) : () -> ()
 
 // -----
 


### PR DESCRIPTION
This PR implements support for copying strided memrefs, including those with transformations. This works by creating a TSL representation of the stridedlayoutattr and then applying the existing algorithm on the tsl representations.