### PR TITLE
fix strided transform copy bug

### DIFF
--- a/compiler/transforms/snax_copy_to_dma.py
+++ b/compiler/transforms/snax_copy_to_dma.py
@@ -110,7 +110,9 @@ def extract_strides(memreftype: MemRefType):
     if isinstance(memreftype.layout, StridedLayoutAttr):
         strides = memreftype.layout.strides.data
         element_stride = memreftype.element_type.width.data // 8
-        strides = [x.data * element_stride if isinstance(x, IntAttr) else None for x in strides]
+        strides = [
+            x.data * element_stride if isinstance(x, IntAttr) else None for x in strides
+        ]
     elif isinstance(memreftype.layout, NoneAttr):
         # default to row-major layout, construct strides
         # based on shape of the memref type

--- a/compiler/transforms/snax_copy_to_dma.py
+++ b/compiler/transforms/snax_copy_to_dma.py
@@ -111,8 +111,6 @@ def extract_strides(memreftype: MemRefType):
         strides = memreftype.layout.strides.data
         element_stride = memreftype.element_type.width.data // 8
         strides = [x.data * element_stride if isinstance(x, IntAttr) else None for x in strides]
-        print("found strides")
-        print(strides)
     elif isinstance(memreftype.layout, NoneAttr):
         # default to row-major layout, construct strides
         # based on shape of the memref type

--- a/compiler/transforms/snax_copy_to_dma.py
+++ b/compiler/transforms/snax_copy_to_dma.py
@@ -109,7 +109,10 @@ def extract_strides(memreftype: MemRefType):
     """
     if isinstance(memreftype.layout, StridedLayoutAttr):
         strides = memreftype.layout.strides.data
-        strides = [x.data if isinstance(x, IntAttr) else None for x in strides]
+        element_stride = memreftype.element_type.width.data // 8
+        strides = [x.data * element_stride if isinstance(x, IntAttr) else None for x in strides]
+        print("found strides")
+        print(strides)
     elif isinstance(memreftype.layout, NoneAttr):
         # default to row-major layout, construct strides
         # based on shape of the memref type

--- a/compiler/transforms/snax_copy_to_dma.py
+++ b/compiler/transforms/snax_copy_to_dma.py
@@ -109,6 +109,7 @@ def extract_strides(memreftype: MemRefType):
     """
     if isinstance(memreftype.layout, StridedLayoutAttr):
         strides = memreftype.layout.strides.data
+        # bits to bytes:
         element_stride = memreftype.element_type.width.data // 8
         strides = [
             x.data * element_stride if isinstance(x, IntAttr) else None for x in strides

--- a/kernels/transform_copy/transform_from_strided.preprocfinal.mlir
+++ b/kernels/transform_copy/transform_from_strided.preprocfinal.mlir
@@ -1,6 +1,6 @@
 builtin.module {
-  func.func public @transform_copy(%arg0 : memref<?x?xi32, strided<[?, 4], offset: 0>, 0 : i32>, %arg1 : memref<?x?xi32, #tsl.tsl<[?, 4] -> (?, 16), [?, 4] -> (?, 4)>, 1 : i32>) {
-    "memref.copy"(%arg0, %arg1) : (memref<?x?xi32, strided<[?, 4], offset: 0>, 0 : i32>, memref<?x?xi32, #tsl.tsl<[?, 4] -> (?, 16), [?, 4] -> (?, 4)>, 1 : i32>) -> ()
+  func.func public @transform_copy(%arg0 : memref<?x?xi32, strided<[?, 1], offset: 0>, 0 : i32>, %arg1 : memref<?x?xi32, #tsl.tsl<[?, 4] -> (?, 16), [?, 4] -> (?, 4)>, 1 : i32>) {
+    "memref.copy"(%arg0, %arg1) : (memref<?x?xi32, strided<[?, 1], offset: 0>, 0 : i32>, memref<?x?xi32, #tsl.tsl<[?, 4] -> (?, 16), [?, 4] -> (?, 4)>, 1 : i32>) -> ()
     func.return
   }
 }

--- a/tests/filecheck/transforms/copy_to_dma.mlir
+++ b/tests/filecheck/transforms/copy_to_dma.mlir
@@ -74,24 +74,14 @@
 //CHECK-NEXT:     %5 = "memref.dim"(%arg0, %4) : (memref<5x5xi32, strided<[10, 1]>>, index) -> index
 //CHECK-NEXT:     %6 = "arith.constant"() <{"value" = 5 : index}> : () -> index
 //CHECK-NEXT:     %7 = "arith.constant"() <{"value" = 5 : index}> : () -> index
-//CHECK-NEXT:     %8 = "arith.constant"() <{"value" = 10 : index}> : () -> index
-//CHECK-NEXT:     %9 = "arith.constant"() <{"value" = 1 : index}> : () -> index
-//CHECK-NEXT:     %10 = "arith.constant"() <{"value" = 10 : index}> : () -> index
-//CHECK-NEXT:     %11 = "arith.constant"() <{"value" = 20 : index}> : () -> index
-//CHECK-NEXT:     %12 = "arith.constant"() <{"value" = 1 : index}> : () -> index
-//CHECK-NEXT:     %13 = "arith.constant"() <{"value" = 20 : index}> : () -> index
-//CHECK-NEXT:     %14 = "arith.constant"() <{"value" = 1 : index}> : () -> index
-//CHECK-NEXT:     %15 = "arith.constant"() <{"value" = 0 : index}> : () -> index
-//CHECK-NEXT:     %16 = "arith.constant"() <{"value" = 1 : index}> : () -> index
-//CHECK-NEXT:     "scf.for"(%15, %7, %16) ({
-//CHECK-NEXT:     ^1(%17 : index):
-//CHECK-NEXT:       %18 = "arith.muli"(%17, %9) : (index, index) -> index
-//CHECK-NEXT:       %19 = "arith.addi"(%0, %18) : (index, index) -> index
-//CHECK-NEXT:       %20 = "arith.muli"(%17, %12) : (index, index) -> index
-//CHECK-NEXT:       %21 = "arith.addi"(%1, %20) : (index, index) -> index
-//CHECK-NEXT:       "func.call"(%19, %21, %14, %10, %13, %6) <{"callee" = @snax_dma_2d_transfer}> : (index, index, index, index, index, index) -> ()
-//CHECK-NEXT:       "scf.yield"() : () -> ()
-//CHECK-NEXT:     }) : (index, index, index) -> ()
+//CHECK-NEXT:     %8 = "arith.constant"() <{"value" = 40 : index}> : () -> index
+//CHECK-NEXT:     %9 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+//CHECK-NEXT:     %10 = "arith.constant"() <{"value" = 40 : index}> : () -> index
+//CHECK-NEXT:     %11 = "arith.constant"() <{"value" = 80 : index}> : () -> index
+//CHECK-NEXT:     %12 = "arith.constant"() <{"value" = 4 : index}> : () -> index
+//CHECK-NEXT:     %13 = "arith.constant"() <{"value" = 80 : index}> : () -> index
+//CHECK-NEXT:     %14 = "arith.constant"() <{"value" = 20 : index}> : () -> index
+//CHECK-NEXT:     "func.call"(%0, %1, %14, %10, %13, %6) <{"callee" = @snax_dma_2d_transfer}> : (index, index, index, index, index, index) -> ()
 //CHECK-NEXT:     "func.return"() : () -> ()
 //CHECK-NEXT:   }) : () -> ()
 //CHECK-NEXT:   "func.func"() <{"sym_name" = "snax_dma_2d_transfer", "function_type" = (index, index, index, index, index, index) -> (), "sym_visibility" = "private"}> ({


### PR DESCRIPTION
Apply element strides for strided attribute when forming tsl from `StridedLayoutAttr`, as this accounts for element width, while tsl does not