### PR TITLE
Adapt sizes to new 64 bit pointers in streamer alu

### DIFF
--- a/kernels/streamer_alu/gendata.py
+++ b/kernels/streamer_alu/gendata.py
@@ -22,8 +22,7 @@ if __name__ == "__main__":
     B = np.random.randint(
         low_bound, high_bound, size=array_size, dtype=np.dtype("int64")
     )
-    # x2 to accommodate 128 bit outputs, as numpy does not understand int128
-    O = np.zeros(array_size * 2, dtype=np.dtype("int64"))
+    O = np.zeros(array_size, dtype=np.dtype("int64"))
     G = A + B
 
     sizes = {"MODE": 0, "DATA_LEN": array_size, "LOOP_ITER": loop_iter}

--- a/kernels/streamer_alu/main.c
+++ b/kernels/streamer_alu/main.c
@@ -3,27 +3,27 @@
 #include "snax_rt.h"
 #include "snrt.h"
 
-void _mlir_ciface_streamer_add(OneDMemrefI32_t *A, OneDMemrefI32_t *B,
-                               OneDMemrefI32_t *O);
+void _mlir_ciface_streamer_add(OneDMemrefI64_t *A, OneDMemrefI64_t *B,
+                               OneDMemrefI64_t *O);
 
 int main() {
   // Set err value for checking
   int err = 0;
 
   // Create memref objects for data stored in L3
-  OneDMemrefI32_t memrefA;
+  OneDMemrefI64_t memrefA;
   memrefA.data = &A;
   memrefA.aligned_data = memrefA.data;
   memrefA.offset = 0;
   memrefA.shape[0] = DATA_LEN;
 
-  OneDMemrefI32_t memrefB;
+  OneDMemrefI64_t memrefB;
   memrefB.data = &B;
   memrefB.aligned_data = memrefB.data;
   memrefB.offset = 0;
   memrefB.shape[0] = DATA_LEN;
 
-  OneDMemrefI32_t memrefO;
+  OneDMemrefI64_t memrefO;
   memrefO.data = &O;
   memrefO.aligned_data = memrefO.data;
   memrefO.offset = 0;
@@ -52,9 +52,7 @@ int main() {
   uint64_t check_val;
 
   for (uint32_t i = 0; i < DATA_LEN; i++) {
-
-    // memrefO is int32 type, but data is i64
-    check_val = memrefO.aligned_data[i * 2];
+    check_val = memrefO.aligned_data[i];
     if (check_val != G[i]) {
       err++;
     }
@@ -65,7 +63,5 @@ int main() {
 
   printf("Accelerator Done! \n");
   printf("Accelerator Cycles: %d \n", perf_count);
-  printf("Number of errors: %d \n", err);
-
   return err;
 }

--- a/kernels/streamer_alu/streamer_add.mlir
+++ b/kernels/streamer_alu/streamer_add.mlir
@@ -1,4 +1,4 @@
-#simple_mult_attributes = {
+#streamer_add_attributes = {
   indexing_maps = [
     affine_map<(n) -> (n)>,
     affine_map<(n) -> (n)>,
@@ -10,15 +10,13 @@
 
 func.func public @streamer_add(%A: memref<?xi64>,
                              %B: memref<?xi64>,
-                             %D: memref<?xi128>) -> () {
-  linalg.generic #simple_mult_attributes
+                             %D: memref<?xi64>) -> () {
+  linalg.generic #streamer_add_attributes
   ins(%A, %B: memref<?xi64>, memref<?xi64>)
-  outs(%D: memref<?xi128>) {
-  ^bb0(%a: i64, %b: i64, %d: i128):
-    %a_ext = arith.extsi %a: i64 to i128
-    %b_ext = arith.extsi %b: i64 to i128
-    %r0 = arith.addi %a_ext, %b_ext : i128
-    linalg.yield %r0 : i128
+  outs(%D: memref<?xi64>) {
+  ^bb0(%a: i64, %b: i64, %d: i64):
+    %r0 = arith.addi %a, %b : i64
+    linalg.yield %r0 : i64
   }
   return
 }

--- a/runtime/include/memref.h
+++ b/runtime/include/memref.h
@@ -12,6 +12,16 @@ struct OneDMemrefI32 {
   uint32_t stride[1];
 };
 
+struct OneDMemrefI64 {
+  int64_t *data; // allocated pointer: Pointer to data buffer as allocated,
+                 // only used for deallocating the memref
+  int64_t *aligned_data; // aligned pointer: Pointer to properly aligned data
+                         // that memref indexes
+  uint32_t offset;
+  uint32_t shape[1];
+  uint32_t stride[1];
+};
+
 struct TwoDMemrefI32 {
   int32_t *data; // allocated pointer: Pointer to data buffer as allocated,
                  // only used for deallocating the memref
@@ -33,5 +43,6 @@ struct TwoDMemrefI8 {
 };
 
 typedef struct OneDMemrefI32 OneDMemrefI32_t;
+typedef struct OneDMemrefI64 OneDMemrefI64_t;
 typedef struct TwoDMemrefI8 TwoDMemrefI8_t;
 typedef struct TwoDMemrefI32 TwoDMemrefI32_t;


### PR DESCRIPTION
I've corrected the pointers to not include the sign extension anymore and to also not use magic pointer arithmetic (to avoid future confusion)