### PR TITLE
Add snax.mcycle op

### DIFF
--- a/compiler/dialects/snax.py
+++ b/compiler/dialects/snax.py
@@ -24,7 +24,6 @@ from xdsl.irdl import (
     result_def,
     var_operand_def,
 )
-from xdsl.traits import Pure
 from xdsl.utils.exceptions import VerifyException
 
 from compiler.util.memref_descriptor import LLVMMemrefDescriptor
@@ -41,12 +40,11 @@ class ClusterSyncOp(IRDLOperation):
 @irdl_op_definition
 class MCycleOp(IRDLOperation):
     """Utility operation that translates to risc-v mcycle instruction
-    for trace annotation.
-    This operation has no side effects, since it only reads from a register"""
-
-    traits = frozenset((Pure(),))
+    for trace annotation."""
 
     name = "snax.mcycle"
+
+    result: OpResult = result_def(i32)
 
 
 @irdl_op_definition

--- a/compiler/dialects/snax.py
+++ b/compiler/dialects/snax.py
@@ -24,6 +24,7 @@ from xdsl.irdl import (
     result_def,
     var_operand_def,
 )
+from xdsl.traits import Pure
 from xdsl.utils.exceptions import VerifyException
 
 from compiler.util.memref_descriptor import LLVMMemrefDescriptor
@@ -35,6 +36,17 @@ class ClusterSyncOp(IRDLOperation):
     translates directly to the C function snrt_cluster_hw_barrier()"""
 
     name = "snax.cluster_sync_op"
+
+
+@irdl_op_definition
+class MCycleOp(IRDLOperation):
+    """Utility operation that translates to risc-v mcycle instruction
+    for trace annotation.
+    This operation has no side effects, since it only reads from a register"""
+
+    traits = frozenset((Pure(),))
+
+    name = "snax.mcycle"
 
 
 @irdl_op_definition
@@ -133,4 +145,4 @@ class Alloc(IRDLOperation):
         descriptor.verify()
 
 
-Snax = Dialect("snax", [ClusterSyncOp, LayoutCast, Alloc], [])
+Snax = Dialect("snax", [ClusterSyncOp, MCycleOp, LayoutCast, Alloc], [])

--- a/compiler/dialects/snax.py
+++ b/compiler/dialects/snax.py
@@ -44,8 +44,6 @@ class MCycleOp(IRDLOperation):
 
     name = "snax.mcycle"
 
-    result: OpResult = result_def(i32)
-
 
 @irdl_op_definition
 class LayoutCast(IRDLOperation):

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -25,6 +25,7 @@ from compiler.transforms.realize_memref_casts import RealizeMemrefCastsPass
 from compiler.transforms.set_memory_layout import SetMemoryLayout
 from compiler.transforms.set_memory_space import SetMemorySpace
 from compiler.transforms.snax_copy_to_dma import SNAXCopyToDMA
+from compiler.transforms.snax_lower_mcycle import SNAXLowerMCycle
 from compiler.transforms.snax_to_func import SNAXToFunc
 
 
@@ -60,6 +61,7 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(DispatchRegions.name, lambda: DispatchRegions)
         super().register_pass(SNAXCopyToDMA.name, lambda: SNAXCopyToDMA)
         super().register_pass(SNAXToFunc.name, lambda: SNAXToFunc)
+        super().register_pass(SNAXLowerMCycle.name, lambda: SNAXLowerMCycle)
         super().register_pass(ClearMemorySpace.name, lambda: ClearMemorySpace)
         super().register_pass(
             RealizeMemrefCastsPass.name, lambda: RealizeMemrefCastsPass

--- a/compiler/transforms/snax_lower_mcycle.py
+++ b/compiler/transforms/snax_lower_mcycle.py
@@ -26,7 +26,8 @@ class ConvertMCycleToLLVM(RewritePattern):
                 has_side_effects=True,
             ),
         )
-        rewriter.replace_matched_op(riscv_mcycle)
+        rewriter.insert_op_before_matched_op(riscv_mcycle)
+        rewriter.erase_matched_op()
 
 
 class SNAXLowerMCycle(ModulePass):

--- a/compiler/transforms/snax_lower_mcycle.py
+++ b/compiler/transforms/snax_lower_mcycle.py
@@ -1,0 +1,36 @@
+from xdsl.dialects import builtin, llvm
+from xdsl.ir import MLContext
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+from compiler.dialects import snax
+
+
+class ConvertMCycleToLLVM(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, mcycle_op: snax.MCycleOp, rewriter: PatternRewriter):
+        """Swap op with call"""
+        riscv_mcycle = (
+            llvm.InlineAsmOp(
+                "csrr $0, mcycle",
+                # =r = store result in A 32- or 64-bit
+                # general-purpose register (depending on the platform XLEN)
+                "=r,~{memory}",
+                [],
+                [builtin.i32],
+                has_side_effects=True,
+            ),
+        )
+        rewriter.replace_matched_op(riscv_mcycle)
+
+
+class SNAXLowerMCycle(ModulePass):
+    name = "snax-lower-mcycle"
+
+    def apply(self, ctx: MLContext, module: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(ConvertMCycleToLLVM()).rewrite_module(module)

--- a/tests/filecheck/dialects/snax/snax_ops.mlir
+++ b/tests/filecheck/dialects/snax/snax_ops.mlir
@@ -4,16 +4,16 @@
 "builtin.module"() ({
   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, "L1">
   %1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, "L1">) -> memref<8x8xi32, strided<[1, 16]>, "L1">
-  "snax.mcycle"() : () -> ()
-  %2 = "test.op"() : () -> index
-  %3 = "snax.alloc"(%2, %2, %2) <{"memory_space" = "L3", "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+  %2 = "snax.mcycle"() : () -> i32
+  %3 = "test.op"() : () -> index
+  %4 = "snax.alloc"(%3, %3, %3) <{"memory_space" = "L3", "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 }) : () -> ()
 
 
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, "L1">
 // CHECK-NEXT:   %1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, "L1">) -> memref<8x8xi32, strided<[1, 16]>, "L1">
-// CHECK-NEXT:   "snax.mcycle"() : () -> ()
-// CHECK-NEXT:   %2 = "test.op"() : () -> index
-// CHECK-NEXT:   %3 = "snax.alloc"(%2, %2, %2) <{"memory_space" = "L3", "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %2 = "snax.mcycle"() : () -> i32
+// CHECK-NEXT:   %3 = "test.op"() : () -> index
+// CHECK-NEXT:   %4 = "snax.alloc"(%3, %3, %3) <{"memory_space" = "L3", "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/snax/snax_ops.mlir
+++ b/tests/filecheck/dialects/snax/snax_ops.mlir
@@ -4,6 +4,7 @@
 "builtin.module"() ({
   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, "L1">
   %1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, "L1">) -> memref<8x8xi32, strided<[1, 16]>, "L1">
+  "snax.mcycle"() : () -> ()
   %2 = "test.op"() : () -> index
   %3 = "snax.alloc"(%2, %2, %2) <{"memory_space" = "L3", "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 }) : () -> ()
@@ -12,6 +13,7 @@
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, "L1">
 // CHECK-NEXT:   %1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, "L1">) -> memref<8x8xi32, strided<[1, 16]>, "L1">
+// CHECK-NEXT:   "snax.mcycle"() : () -> ()
 // CHECK-NEXT:   %2 = "test.op"() : () -> index
 // CHECK-NEXT:   %3 = "snax.alloc"(%2, %2, %2) <{"memory_space" = "L3", "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/snax/snax_ops.mlir
+++ b/tests/filecheck/dialects/snax/snax_ops.mlir
@@ -4,16 +4,16 @@
 "builtin.module"() ({
   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, "L1">
   %1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, "L1">) -> memref<8x8xi32, strided<[1, 16]>, "L1">
-  %2 = "snax.mcycle"() : () -> i32
-  %3 = "test.op"() : () -> index
-  %4 = "snax.alloc"(%3, %3, %3) <{"memory_space" = "L3", "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+  "snax.mcycle"() : () -> ()
+  %2 = "test.op"() : () -> index
+  %3 = "snax.alloc"(%2, %2, %2) <{"memory_space" = "L3", "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 }) : () -> ()
 
 
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, "L1">
 // CHECK-NEXT:   %1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, "L1">) -> memref<8x8xi32, strided<[1, 16]>, "L1">
-// CHECK-NEXT:   %2 = "snax.mcycle"() : () -> i32
-// CHECK-NEXT:   %3 = "test.op"() : () -> index
-// CHECK-NEXT:   %4 = "snax.alloc"(%3, %3, %3) <{"memory_space" = "L3", "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   "snax.mcycle"() : () -> ()
+// CHECK-NEXT:   %2 = "test.op"() : () -> index
+// CHECK-NEXT:   %3 = "snax.alloc"(%2, %2, %2) <{"memory_space" = "L3", "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/snax_lower_mcycle.mlir
+++ b/tests/filecheck/transforms/snax_lower_mcycle.mlir
@@ -1,0 +1,8 @@
+// RUN: ./compiler/snax-opt %s -p snax-lower-mcycle --print-op-generic | filecheck %s
+func.func @mcycle () -> i32 {
+  %0 = "snax.mcycle"() : () -> i32
+  func.return %0 : i32
+  }
+
+// CHECK: 0 = "llvm.inline_asm"() <{"asm_string" = "csrr $0, mcycle", "constraints" = "=r,~{memory}", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> i32
+

--- a/tests/filecheck/transforms/snax_lower_mcycle.mlir
+++ b/tests/filecheck/transforms/snax_lower_mcycle.mlir
@@ -1,8 +1,8 @@
 // RUN: ./compiler/snax-opt %s -p snax-lower-mcycle --print-op-generic | filecheck %s
-func.func @mcycle () -> i32 {
-  %0 = "snax.mcycle"() : () -> i32
-  func.return %0 : i32
+func.func @mcycle () -> () {
+  "snax.mcycle"() : () -> ()
+  func.return
   }
 
-// CHECK: 0 = "llvm.inline_asm"() <{"asm_string" = "csrr $0, mcycle", "constraints" = "=r,~{memory}", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> i32
+// CHECK: %0 = "llvm.inline_asm"() <{"asm_string" = "csrr $0, mcycle", "constraints" = "=r,~{memory}", "asm_dialect" = 0 : i64}> {"has_side_effects"} : () -> i32
 


### PR DESCRIPTION
This PR adds an operation that adds a utility mcycle operation to the snax dialect.
This is useful to split up traces in multiple sections