### PR TITLE
dialects: (accfg) Add accfg.effects attribute

### DIFF
--- a/compiler/dialects/accfg.py
+++ b/compiler/dialects/accfg.py
@@ -44,6 +44,7 @@ class EffectsEnum(Enum):
     * NONE: There are no accfg side-effects to this operation
     * FULL: There are accfg side-effects to this operation
     """
+
     NONE = "none"
     FULL = "full"
 

--- a/compiler/dialects/accfg.py
+++ b/compiler/dialects/accfg.py
@@ -39,6 +39,11 @@ from xdsl.traits import SymbolOpInterface
 
 
 class EffectsEnum(Enum):
+    """
+    Specify to explicitly say:
+    * NONE: There are no accfg side-effects to this operation
+    * FULL: There are accfg side-effects to this operation
+    """
     NONE = "none"
     FULL = "full"
 

--- a/compiler/inference/helpers.py
+++ b/compiler/inference/helpers.py
@@ -10,7 +10,7 @@ def has_accfg_effects(op: Operation) -> bool:
     """
     Checks if an operation effects state managed by the accfg dialect, according to the following criteria:
 
-    - If provided, an attribute named `accfg_effects` of either of the two types will overwrite inference.
+    - If provided, an attribute named `accfg.effects` of either of the two types will overwrite inference.
       These attributes will need to be added by the provider of the IR, as only they know which functions may affect
       the accelerator.
     - By default we assume that function calls modify state (e.g. `func.call` and `llvm.call`).
@@ -18,7 +18,7 @@ def has_accfg_effects(op: Operation) -> bool:
       to above criterion.
     """
     # check if op is marked as effecting
-    effects_attr = op.attributes.get("accfg_effects", None)
+    effects_attr = op.attributes.get("accfg.effects", None)
     if isinstance(effects_attr, accfg.EffectsAttr):
         return effects_attr.effects != accfg.EffectsEnum.NONE
 

--- a/compiler/inference/helpers.py
+++ b/compiler/inference/helpers.py
@@ -29,7 +29,10 @@ def has_accfg_effects(op: Operation) -> bool:
 
     # Recurse into children to check them according to the same rules
     if any(
-        has_accfg_effects(op) for region in op.regions for block in region.blocks for op in block.ops
+        has_accfg_effects(op)
+        for region in op.regions
+        for block in region.blocks
+        for op in block.ops
     ):
         return True
     # all other ops are assumed to not have effects

--- a/compiler/transforms/convert_linalg_to_accfg.py
+++ b/compiler/transforms/convert_linalg_to_accfg.py
@@ -1,4 +1,3 @@
-import sys
 from dataclasses import dataclass, field
 
 from xdsl.dialects import builtin, func, linalg, scf

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -30,6 +30,10 @@ func.func @test() {
 
     "accfg.await"(%token) : (!accfg.token<"acc1">) -> ()
 
+    "test.op"() {"accfg.effects" = #accfg.effects<none>} : () -> ()
+
+    "test.op"() {"accfg.effects" = #accfg.effects<full>} : () -> ()
+
     func.return
 }
 
@@ -43,6 +47,8 @@ func.func @test() {
 // CHECK-NEXT:     %token = "accfg.launch"(%zero, %state) <{"param_names" = ["launch"], "accelerator" = "acc1"}> : (i32, !accfg.state<"acc1">) -> !accfg.token<"acc1">
 // CHECK-NEXT:     %state2 = accfg.setup "acc1" from %state to ("A" = %one : i32, "B" = %two : i32) : !accfg.state<"acc1">
 // CHECK-NEXT:     "accfg.await"(%token) : (!accfg.token<"acc1">) -> ()
+// CHECK-NEXT:    "test.op"() {"accfg.effects" = #accfg.effects<none>} : () -> ()
+// CHECK-NEXT:    "test.op"() {"accfg.effects" = #accfg.effects<full>} : () -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
@@ -57,6 +63,8 @@ func.func @test() {
 // CHECK-GENERIC:     %token = "accfg.launch"(%zero, %state) <{"param_names" = ["launch"], "accelerator" = "acc1"}> : (i32, !accfg.state<"acc1">) -> !accfg.token<"acc1">
 // CHECK-GENERIC:     %state2 = "accfg.setup"(%one, %two, %state) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 1>}> : (i32, i32, !accfg.state<"acc1">) -> !accfg.state<"acc1">
 // CHECK-GENERIC:     "accfg.await"(%token) : (!accfg.token<"acc1">) -> ()
+// CHECK-GENERIC:    "test.op"() {"accfg.effects" = #accfg.effects<none>} : () -> ()
+// CHECK-GENERIC:    "test.op"() {"accfg.effects" = #accfg.effects<full>} : () -> ()
 // CHECK-GENERIC:     "func.return"() : () -> ()
 // CHECK-GENERIC:   }) : () -> ()
 // CHECK-GENERIC: }) : () -> ()


### PR DESCRIPTION
The idea is that:

- function calls (`func.call` and `llvm.call`) are pessimistically assumed to effect the accelerator
- any other op does not effect the accelerator if ops in their body don't 
- Both of these assumptions can be overwritten by setting the `accfg_effects` attribute to `#accfg.effects<none>` or `#accfg.effects<full>`.