### PR TITLE
add snax-stream dialect

### DIFF
--- a/compiler/dialects/snax_stream.py
+++ b/compiler/dialects/snax_stream.py
@@ -22,6 +22,7 @@ from xdsl.irdl import (
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
 
+
 @irdl_attr_definition
 class StridePattern(ParametrizedAttribute):
     """

--- a/compiler/dialects/snax_stream.py
+++ b/compiler/dialects/snax_stream.py
@@ -1,7 +1,14 @@
 from collections.abc import Sequence
 
 from xdsl.dialects.builtin import ArrayAttr, IndexType, IntAttr
-from xdsl.ir import Attribute, Dialect, NoTerminator, ParametrizedAttribute, Region, SSAValue
+from xdsl.ir import (
+    Attribute,
+    Dialect,
+    NoTerminator,
+    ParametrizedAttribute,
+    Region,
+    SSAValue,
+)
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
@@ -46,9 +53,13 @@ class StridePattern(ParametrizedAttribute):
             printer.print_string("ub = [")
             printer.print_list(self.upper_bounds, lambda attr: printer.print(attr.data))
             printer.print_string("], ts = [")
-            printer.print_list(self.temporal_strides, lambda attr: printer.print(attr.data))
+            printer.print_list(
+                self.temporal_strides, lambda attr: printer.print(attr.data)
+            )
             printer.print_string("], ss = [")
-            printer.print_list(self.spatial_strides, lambda attr: printer.print(attr.data))
+            printer.print_list(
+                self.spatial_strides, lambda attr: printer.print(attr.data)
+            )
             printer.print_string("]")
 
     @classmethod
@@ -57,19 +68,28 @@ class StridePattern(ParametrizedAttribute):
             parser.parse_identifier("ub")
             parser.parse_punctuation("=")
             ub = ArrayAttr(
-                IntAttr(i) for i in parser.parse_comma_separated_list(parser.Delimiter.SQUARE, parser.parse_integer)
+                IntAttr(i)
+                for i in parser.parse_comma_separated_list(
+                    parser.Delimiter.SQUARE, parser.parse_integer
+                )
             )
             parser.parse_punctuation(",")
             parser.parse_identifier("ts")
             parser.parse_punctuation("=")
             ts = ArrayAttr(
-                IntAttr(i) for i in parser.parse_comma_separated_list(parser.Delimiter.SQUARE, parser.parse_integer)
+                IntAttr(i)
+                for i in parser.parse_comma_separated_list(
+                    parser.Delimiter.SQUARE, parser.parse_integer
+                )
             )
             parser.parse_punctuation(",")
             parser.parse_identifier("ss")
             parser.parse_punctuation("=")
             ss = ArrayAttr(
-                IntAttr(i) for i in parser.parse_comma_separated_list(parser.Delimiter.SQUARE, parser.parse_integer)
+                IntAttr(i)
+                for i in parser.parse_comma_separated_list(
+                    parser.Delimiter.SQUARE, parser.parse_integer
+                )
             )
             return (ub, ts, ss)
 
@@ -102,7 +122,11 @@ class StreamingRegionOp(IRDLOperation):
     ) -> None:
         if not isinstance(stride_patterns, ArrayAttr):
             stride_patterns = ArrayAttr(stride_patterns)
-        super().__init__(operands=[inputs, outputs], regions=[body], properties={"stride_patterns": stride_patterns})
+        super().__init__(
+            operands=[inputs, outputs],
+            regions=[body],
+            properties={"stride_patterns": stride_patterns},
+        )
 
 
 SnaxStream = Dialect("snax_stream", [StreamingRegionOp], [StridePattern])

--- a/compiler/dialects/snax_stream.py
+++ b/compiler/dialects/snax_stream.py
@@ -14,13 +14,12 @@ from xdsl.irdl import (
     IRDLOperation,
     ParameterDef,
     irdl_attr_definition,
+    irdl_op_definition,
     prop_def,
     region_def,
     var_operand_def,
 )
-from xdsl.irdl.irdl import irdl_op_definition
 from xdsl.parser import AttrParser
-from xdsl.printer import Printer
 
 
 @irdl_attr_definition

--- a/compiler/dialects/snax_stream.py
+++ b/compiler/dialects/snax_stream.py
@@ -57,34 +57,25 @@ class StridePattern(ParametrizedAttribute):
             parser.parse_identifier("ub")
             parser.parse_punctuation("=")
             ub = ArrayAttr(
-                IntAttr(i)
-                for i in parser.parse_comma_separated_list(
-                    parser.Delimiter.SQUARE, parser.parse_integer
-                )
+                IntAttr(i) for i in parser.parse_comma_separated_list(parser.Delimiter.SQUARE, parser.parse_integer)
             )
             parser.parse_punctuation(",")
             parser.parse_identifier("ts")
             parser.parse_punctuation("=")
             ts = ArrayAttr(
-                IntAttr(i)
-                for i in parser.parse_comma_separated_list(
-                    parser.Delimiter.SQUARE, parser.parse_integer
-                )
+                IntAttr(i) for i in parser.parse_comma_separated_list(parser.Delimiter.SQUARE, parser.parse_integer)
             )
             parser.parse_punctuation(",")
             parser.parse_identifier("ss")
             parser.parse_punctuation("=")
             ss = ArrayAttr(
-                IntAttr(i)
-                for i in parser.parse_comma_separated_list(
-                    parser.Delimiter.SQUARE, parser.parse_integer
-                )
+                IntAttr(i) for i in parser.parse_comma_separated_list(parser.Delimiter.SQUARE, parser.parse_integer)
             )
             return (ub, ts, ss)
 
+
 @irdl_op_definition
 class StreamingRegionOp(IRDLOperation):
-
     name = "snax_stream.streaming_region"
 
     # inputs and outputs are pointers to the base address of the data in memory
@@ -112,8 +103,6 @@ class StreamingRegionOp(IRDLOperation):
         if not isinstance(stride_patterns, ArrayAttr):
             stride_patterns = ArrayAttr(stride_patterns)
         super().__init__(operands=[inputs, outputs], regions=[body], properties={"stride_patterns": stride_patterns})
-
-
 
 
 SnaxStream = Dialect("snax_stream", [StreamingRegionOp], [StridePattern])

--- a/compiler/dialects/snax_stream.py
+++ b/compiler/dialects/snax_stream.py
@@ -1,0 +1,119 @@
+from collections.abc import Sequence
+
+from xdsl.dialects.builtin import ArrayAttr, IndexType, IntAttr
+from xdsl.ir import Attribute, Dialect, NoTerminator, ParametrizedAttribute, Region, SSAValue
+from xdsl.irdl import (
+    AttrSizedOperandSegments,
+    IRDLOperation,
+    ParameterDef,
+    irdl_attr_definition,
+    prop_def,
+    region_def,
+    var_operand_def,
+)
+from xdsl.irdl.irdl import irdl_op_definition
+from xdsl.parser import AttrParser
+from xdsl.printer import Printer
+
+
+@irdl_attr_definition
+class StridePattern(ParametrizedAttribute):
+    """
+    Attribute representing a strided streaming pattern in SNAX.
+    """
+
+    name = "snax_stream.stride_pattern"
+
+    upper_bounds: ParameterDef[ArrayAttr[IntAttr]]
+    temporal_strides: ParameterDef[ArrayAttr[IntAttr]]
+    spatial_strides: ParameterDef[ArrayAttr[IntAttr]]
+
+    def __init__(
+        self,
+        upper_bounds: ParameterDef[ArrayAttr[IntAttr]] | Sequence[int],
+        temporal_strides: ParameterDef[ArrayAttr[IntAttr]] | Sequence[int],
+        spatial_strides: ParameterDef[ArrayAttr[IntAttr]] | Sequence[int],
+    ):
+        parameters: Sequence[Attribute] = []
+        for arg in (upper_bounds, temporal_strides, spatial_strides):
+            if not isinstance(arg, ArrayAttr):
+                arg = ArrayAttr([IntAttr(x) for x in arg])
+            parameters.append(arg)
+        super().__init__(parameters)
+
+    def print_parameters(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print_string("ub = [")
+            printer.print_list(self.upper_bounds, lambda attr: printer.print(attr.data))
+            printer.print_string("], ts = [")
+            printer.print_list(self.temporal_strides, lambda attr: printer.print(attr.data))
+            printer.print_string("], ss = [")
+            printer.print_list(self.spatial_strides, lambda attr: printer.print(attr.data))
+            printer.print_string("]")
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
+        with parser.in_angle_brackets():
+            parser.parse_identifier("ub")
+            parser.parse_punctuation("=")
+            ub = ArrayAttr(
+                IntAttr(i)
+                for i in parser.parse_comma_separated_list(
+                    parser.Delimiter.SQUARE, parser.parse_integer
+                )
+            )
+            parser.parse_punctuation(",")
+            parser.parse_identifier("ts")
+            parser.parse_punctuation("=")
+            ts = ArrayAttr(
+                IntAttr(i)
+                for i in parser.parse_comma_separated_list(
+                    parser.Delimiter.SQUARE, parser.parse_integer
+                )
+            )
+            parser.parse_punctuation(",")
+            parser.parse_identifier("ss")
+            parser.parse_punctuation("=")
+            ss = ArrayAttr(
+                IntAttr(i)
+                for i in parser.parse_comma_separated_list(
+                    parser.Delimiter.SQUARE, parser.parse_integer
+                )
+            )
+            return (ub, ts, ss)
+
+@irdl_op_definition
+class StreamingRegionOp(IRDLOperation):
+
+    name = "snax_stream.streaming_region"
+
+    # inputs and outputs are pointers to the base address of the data in memory
+    inputs = var_operand_def(IndexType)
+    outputs = var_operand_def(IndexType)
+
+    # streaming stride pattern
+    # there should be one stride pattern for every input/output
+    # the upper bounds of all stride patterns should be equal
+    stride_pattern = prop_def(ArrayAttr[StridePattern])
+
+    body = region_def("single_block")
+
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
+    traits = frozenset((NoTerminator(),))
+
+    def __init__(
+        self,
+        inputs: Sequence[SSAValue],
+        outputs: Sequence[SSAValue],
+        stride_patterns: ArrayAttr[StridePattern] | Sequence[StridePattern],
+        body: Region,
+    ) -> None:
+        if not isinstance(stride_patterns, ArrayAttr):
+            stride_patterns = ArrayAttr(stride_patterns)
+        super().__init__(operands=[inputs, outputs], regions=[body], properties={"stride_patterns": stride_patterns})
+
+
+
+
+SnaxStream = Dialect("snax_stream", [StreamingRegionOp], [StridePattern])

--- a/compiler/dialects/snax_stream.py
+++ b/compiler/dialects/snax_stream.py
@@ -27,6 +27,12 @@ from xdsl.printer import Printer
 class StridePattern(ParametrizedAttribute):
     """
     Attribute representing a strided streaming pattern in SNAX.
+    A stride pattern coincides with the Data Streamers from the SNAX Framework.
+    For detailed information, see: https://github.com/KULeuven-MICAS/snax_cluster/blob/main/hw/chisel/doc/streamer.md
+    The upper bounds and temporal strides define a set of nested for loops
+    where data is accessed sequentially in a structured pattern. Every execution,
+    a number of data elements is acccessed in parallel. The distance between these
+    elements is denoted by the spatial strides.
     """
 
     name = "snax_stream.stride_pattern"
@@ -96,6 +102,11 @@ class StridePattern(ParametrizedAttribute):
 
 @irdl_op_definition
 class StreamingRegionOp(IRDLOperation):
+    """
+    An operation that creates streams from access patterns realized by SNAX Streamers.
+    These streams are accessable only to ops within the body of the operation.
+    """
+
     name = "snax_stream.streaming_region"
 
     # inputs and outputs are pointers to the base address of the data in memory

--- a/compiler/dialects/snax_stream.py
+++ b/compiler/dialects/snax_stream.py
@@ -20,7 +20,7 @@ from xdsl.irdl import (
     var_operand_def,
 )
 from xdsl.parser import AttrParser
-
+from xdsl.printer import Printer
 
 @irdl_attr_definition
 class StridePattern(ParametrizedAttribute):

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -6,6 +6,7 @@ from xdsl.xdsl_opt_main import xDSLOptMain
 
 from compiler.dialects.accfg import ACCFG
 from compiler.dialects.snax import Snax
+from compiler.dialects.snax_stream import SnaxStream
 from compiler.dialects.tsl import TSL
 from compiler.transforms.accfg_config_overlap import AccfgConfigOverlapPass
 from compiler.transforms.accfg_dedup import AccfgDeduplicate
@@ -52,6 +53,7 @@ class SNAXOptMain(xDSLOptMain):
         self.ctx.load_dialect(Snax)
         self.ctx.load_dialect(TSL)
         self.ctx.load_dialect(ACCFG)
+        self.ctx.load_dialect(SnaxStream)
         super().register_pass(DispatchKernels.name, lambda: DispatchKernels)
         super().register_pass(LinalgToLibraryCall.name, lambda: LinalgToLibraryCall)
         super().register_pass(SetMemorySpace.name, lambda: SetMemorySpace)

--- a/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
+++ b/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
@@ -1,5 +1,4 @@
 // RUN: XDSL_ROUNDTRIP
-// RUN: XDSL_GENERIC_ROUNDTRIP
 
 %x, %y, %z = "test.op"() : () -> (index, index, index)
 

--- a/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
+++ b/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
@@ -1,0 +1,29 @@
+// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_GENERIC_ROUNDTRIP
+
+%x, %y, %z = "test.op"() : () -> (index, index, index)
+
+"snax_stream.streaming_region"(%x, %y, %z) <{
+      "stride_pattern" = [
+              #snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [8, 1]>, 
+              #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>, 
+              #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>
+      ], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+^0(%3 : !stream.readable<i64>, %4 : !stream.readable<i64>, %5 : !stream.writable<i64>):
+  %0 = stream.read from %3 : i64
+  %1 = stream.read from %4 : i64
+  %2 = arith.addi %0, %1 : i64
+  stream.write %2 to %5 : i64
+}) : (index, index, index) -> ()
+
+//CHECK:      builtin.module {
+//CHECK-NEXT:   %x, %y, %z = "test.op"() : () -> (index, index, index)
+//CHECK-NEXT:   "snax_stream.streaming_region"(%x, %y, %z) <{"stride_pattern" = [#snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+//CHECK-NEXT:   ^0(%0 : !stream.readable<i64>, %1 : !stream.readable<i64>, %2 : !stream.writable<i64>):
+//CHECK-NEXT:     %3 = stream.read from %0 : i64
+//CHECK-NEXT:     %4 = stream.read from %1 : i64
+//CHECK-NEXT:     %5 = arith.addi %3, %4 : i64
+//CHECK-NEXT:     stream.write %5 to %2 : i64
+//CHECK-NEXT:   }) : (index, index, index) -> ()
+//CHECK-NEXT: }
+


### PR DESCRIPTION
This PR adds the snax_stream dialect.
In many ways, it is a copy of the snitch_stream dialect, with the following changes to adapt it to SNAX Streamers:

- operate on indeces instead of riscv registers
- use a stride pattern with upper bounds, temporal strides, spatial strides