### PR TITLE
Add snax streamer interface

### DIFF
--- a/compiler/accelerators/snax.py
+++ b/compiler/accelerators/snax.py
@@ -17,9 +17,7 @@ class SNAXAccelerator(Accelerator, ABC):
     """
 
     @staticmethod
-    def lower_acc_launch(
-        launch_op: accfg.LaunchOp, acc_op: accfg.AcceleratorOp
-    ) -> Sequence[Operation]:
+    def lower_acc_launch(launch_op: accfg.LaunchOp, acc_op: accfg.AcceleratorOp) -> Sequence[Operation]:
         field_to_csr = dict(acc_op.launch_field_items())
         ops: Sequence[Operation] = []
         for field, val in launch_op.iter_params():
@@ -51,9 +49,7 @@ class SNAXAccelerator(Accelerator, ABC):
         return ops
 
     @staticmethod
-    def lower_acc_setup(
-        setup_op: accfg.SetupOp, acc_op: accfg.AcceleratorOp
-    ) -> Sequence[Operation]:
+    def lower_acc_setup(setup_op: accfg.SetupOp, acc_op: accfg.AcceleratorOp) -> Sequence[Operation]:
         field_to_csr = dict(acc_op.field_items())
         ops: Sequence[Operation] = []
         for field, val in setup_op.iter_params():
@@ -100,18 +96,14 @@ class SNAXPollingBarrier(Accelerator, ABC):
         # kernels/tiled_mult/tiled.preprocfinal.mlir only works
         # when at least 4 nops are introduced, due to hardware handshake issues.
         # this is will likely not be fixed in the future.
-        nops = [
-            llvm.InlineAsmOp("nop", "", [], [], has_side_effects=True) for _ in range(4)
-        ]
+        nops = [llvm.InlineAsmOp("nop", "", [], [], has_side_effects=True) for _ in range(4)]
         return [
             While(
                 [],
                 [],
                 [
                     barrier := arith.Constant(acc_op.barrier),
-                    zero := arith.Constant(
-                        builtin.IntegerAttr.from_int_and_width(0, 32)
-                    ),
+                    zero := arith.Constant(builtin.IntegerAttr.from_int_and_width(0, 32)),
                     status := llvm.InlineAsmOp(
                         "csrr $0, $1",
                         # I = any 12 bit immediate
@@ -170,9 +162,7 @@ class SNAXPollingBarrier2(Accelerator, ABC):
                 [],
                 [
                     barrier := arith.Constant(acc_op.barrier),
-                    one := arith.Constant(
-                        builtin.IntegerAttr.from_int_and_width(1, 32)
-                    ),
+                    one := arith.Constant(builtin.IntegerAttr.from_int_and_width(1, 32)),
                     status := llvm.InlineAsmOp(
                         "csrr $0, $1",
                         # I = any 12 bit immediate

--- a/compiler/accelerators/snax.py
+++ b/compiler/accelerators/snax.py
@@ -1,13 +1,16 @@
-from abc import ABC
+import string
+from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
 from xdsl.dialects import arith, builtin, llvm
-from xdsl.dialects.builtin import i32
+from xdsl.dialects.builtin import IntAttr, i32
 from xdsl.dialects.scf import Condition, While, Yield
 from xdsl.ir import Operation
+from xdsl.parser import SSAValue
 
 from compiler.accelerators.accelerator import Accelerator
-from compiler.dialects import accfg
+from compiler.accelerators.streamers import StreamerConfiguration
+from compiler.dialects import accfg, snax_stream
 
 
 class SNAXAccelerator(Accelerator, ABC):
@@ -66,6 +69,22 @@ class SNAXAccelerator(Accelerator, ABC):
                 ]
             )
         return ops
+
+
+class SNAXStreamer(Accelerator, ABC):
+    """
+    Abstract base class for SNAX Accelerators with Streamer interfaces.
+    """
+
+    streamer_config: StreamerConfiguration
+    streamer_names: Sequence[str]
+
+    def __init__(self, streamer_config: StreamerConfiguration) -> None:
+        self.streamer_config = streamer_config
+
+        # set streamer names as a, b, c, d, ...
+        self.streamer_names = list(string.ascii_lowercase[: self.streamer_config.size()])
+
 
 
 class SNAXPollingBarrier(Accelerator, ABC):

--- a/compiler/accelerators/streamers/__init__.py
+++ b/compiler/accelerators/streamers/__init__.py
@@ -1,0 +1,1 @@
+from .streamers import *

--- a/compiler/accelerators/streamers/streamers.py
+++ b/compiler/accelerators/streamers/streamers.py
@@ -1,0 +1,60 @@
+from collections.abc import Sequence
+
+from xdsl.utils.str_enum import StrEnum
+
+
+class StreamerType(StrEnum):
+    Reader = 'r'
+    Writer = 'w'
+
+
+class Streamer:
+    """
+    A representation of a single SNAX Streamer
+    """
+
+    type : StreamerType
+    temporal_dim : int
+    spatial_dim : int
+
+    def __init__(self, type: StreamerType, temporal_dim: int, spatial_dim: int) -> None:
+        self.type = type
+        self.temporal_dim = temporal_dim
+        self.spatial_dim = spatial_dim
+
+
+class StreamerConfiguration:
+    """
+    A representation for a SNAX Streamer Configuration.
+    The configuration consists of one of more Streamer objects,
+    one for each operand of the accelerator.
+    """
+
+    streamers: Sequence[Streamer]
+
+    def __init__(self, streamers: Sequence[Streamer]):
+        assert len(streamers)
+        self.streamers = streamers
+
+    def size(self) -> int:
+        """
+        Return the number of streamers in the configuration
+        """
+        return len(self.streamers)
+
+    def temporal_dim(self) -> int:
+        """
+        Return the temporal dimension of the streamers
+        For now, assume all temporal dimensions are equal,
+        so just take the first
+        """
+        return self.streamers[0].temporal_dim
+
+    def spatial_dim(self) -> int:
+        """
+        Return the spatial dimension of the streamers
+        For now, assume all spatial dimensions are equal,
+        so just take the first
+        """
+        return self.streamers[0].spatial_dim
+

--- a/compiler/accelerators/streamers/streamers.py
+++ b/compiler/accelerators/streamers/streamers.py
@@ -4,8 +4,8 @@ from xdsl.utils.str_enum import StrEnum
 
 
 class StreamerType(StrEnum):
-    Reader = 'r'
-    Writer = 'w'
+    Reader = "r"
+    Writer = "w"
 
 
 class Streamer:
@@ -13,9 +13,9 @@ class Streamer:
     A representation of a single SNAX Streamer
     """
 
-    type : StreamerType
-    temporal_dim : int
-    spatial_dim : int
+    type: StreamerType
+    temporal_dim: int
+    spatial_dim: int
 
     def __init__(self, type: StreamerType, temporal_dim: int, spatial_dim: int) -> None:
         self.type = type
@@ -57,4 +57,3 @@ class StreamerConfiguration:
         so just take the first
         """
         return self.streamers[0].spatial_dim
-

--- a/compiler/dialects/snax.py
+++ b/compiler/dialects/snax.py
@@ -80,17 +80,11 @@ class LayoutCast(IRDLOperation):
         source = cast(MemRefType[Attribute], self.source.type)
         dest = cast(MemRefType[Attribute], self.dest.type)
         if source.get_shape() != dest.get_shape():
-            raise VerifyException(
-                "Expected source and destination to have the same shape."
-            )
+            raise VerifyException("Expected source and destination to have the same shape.")
         if source.get_element_type() != dest.get_element_type():
-            raise VerifyException(
-                "Expected source and destination to have the same element type."
-            )
+            raise VerifyException("Expected source and destination to have the same element type.")
         if source.memory_space != dest.memory_space:
-            raise VerifyException(
-                "Expected source and destination to have the same memory space."
-            )
+            raise VerifyException("Expected source and destination to have the same memory space.")
 
 
 @irdl_op_definition

--- a/compiler/dialects/snax.py
+++ b/compiler/dialects/snax.py
@@ -87,11 +87,17 @@ class LayoutCast(IRDLOperation):
         source = cast(MemRefType[Attribute], self.source.type)
         dest = cast(MemRefType[Attribute], self.dest.type)
         if source.get_shape() != dest.get_shape():
-            raise VerifyException("Expected source and destination to have the same shape.")
+            raise VerifyException(
+                "Expected source and destination to have the same shape."
+            )
         if source.get_element_type() != dest.get_element_type():
-            raise VerifyException("Expected source and destination to have the same element type.")
+            raise VerifyException(
+                "Expected source and destination to have the same element type."
+            )
         if source.memory_space != dest.memory_space:
-            raise VerifyException("Expected source and destination to have the same memory space.")
+            raise VerifyException(
+                "Expected source and destination to have the same memory space."
+            )
 
 
 @irdl_op_definition
@@ -161,7 +167,9 @@ class StreamerConfigurationAttr(Data[StreamerConfiguration]):
                 streamer_type: StreamerType = parser.parse_str_enum(StreamerType)
 
                 # Determine temporal and spatial dimensions
-                dimensions = parser.parse_comma_separated_list(parser.Delimiter.SQUARE, parser.parse_integer)
+                dimensions = parser.parse_comma_separated_list(
+                    parser.Delimiter.SQUARE, parser.parse_integer
+                )
                 assert len(dimensions) == 2
                 streamers.append(Streamer(streamer_type, *dimensions))
 
@@ -183,4 +191,6 @@ class StreamerConfigurationAttr(Data[StreamerConfiguration]):
         printer.print_string(f"<{', '.join(streamer_strings)}>")
 
 
-Snax = Dialect("snax", [ClusterSyncOp, MCycleOp, LayoutCast, Alloc], [StreamerConfigurationAttr])
+Snax = Dialect(
+    "snax", [ClusterSyncOp, MCycleOp, LayoutCast, Alloc], [StreamerConfigurationAttr]
+)

--- a/compiler/dialects/snax_stream.py
+++ b/compiler/dialects/snax_stream.py
@@ -62,9 +62,13 @@ class StridePattern(ParametrizedAttribute):
             printer.print_string("ub = [")
             printer.print_list(self.upper_bounds, lambda attr: printer.print(attr.data))
             printer.print_string("], ts = [")
-            printer.print_list(self.temporal_strides, lambda attr: printer.print(attr.data))
+            printer.print_list(
+                self.temporal_strides, lambda attr: printer.print(attr.data)
+            )
             printer.print_string("], ss = [")
-            printer.print_list(self.spatial_strides, lambda attr: printer.print(attr.data))
+            printer.print_list(
+                self.spatial_strides, lambda attr: printer.print(attr.data)
+            )
             printer.print_string("]")
 
     @classmethod
@@ -73,19 +77,28 @@ class StridePattern(ParametrizedAttribute):
             parser.parse_identifier("ub")
             parser.parse_punctuation("=")
             ub = ArrayAttr(
-                IntAttr(i) for i in parser.parse_comma_separated_list(parser.Delimiter.SQUARE, parser.parse_integer)
+                IntAttr(i)
+                for i in parser.parse_comma_separated_list(
+                    parser.Delimiter.SQUARE, parser.parse_integer
+                )
             )
             parser.parse_punctuation(",")
             parser.parse_identifier("ts")
             parser.parse_punctuation("=")
             ts = ArrayAttr(
-                IntAttr(i) for i in parser.parse_comma_separated_list(parser.Delimiter.SQUARE, parser.parse_integer)
+                IntAttr(i)
+                for i in parser.parse_comma_separated_list(
+                    parser.Delimiter.SQUARE, parser.parse_integer
+                )
             )
             parser.parse_punctuation(",")
             parser.parse_identifier("ss")
             parser.parse_punctuation("=")
             ss = ArrayAttr(
-                IntAttr(i) for i in parser.parse_comma_separated_list(parser.Delimiter.SQUARE, parser.parse_integer)
+                IntAttr(i)
+                for i in parser.parse_comma_separated_list(
+                    parser.Delimiter.SQUARE, parser.parse_integer
+                )
             )
             return (ub, ts, ss)
 
@@ -144,28 +157,41 @@ class StreamingRegionOp(IRDLOperation):
             module_op = module_op.parent_op()
         if not module_op:
             raise VerifyException("ModuleOp not found!")
-        accelerator_op, _ = AcceleratorRegistry().lookup_acc_info(self.accelerator, module_op)
+        accelerator_op, _ = AcceleratorRegistry().lookup_acc_info(
+            self.accelerator, module_op
+        )
 
         if not accelerator_op:
             raise VerifyException("AcceleratorOp for streaming_region not found!")
 
         streamer_interface = accelerator_op.get_attr_or_prop("streamer_config")
 
-        if not streamer_interface or not isinstance(streamer_interface, StreamerConfigurationAttr):
-            raise VerifyException("Specified accelerator does not implement the streamer interface")
+        if not streamer_interface or not isinstance(
+            streamer_interface, StreamerConfigurationAttr
+        ):
+            raise VerifyException(
+                "Specified accelerator does not implement the streamer interface"
+            )
 
         streamer_config: StreamerConfiguration = streamer_interface.data
 
         if len(self.stride_pattern) != streamer_config.size():
-            raise VerifyException("Number of streamers does not equal number of stride patterns")
+            raise VerifyException(
+                "Number of streamers does not equal number of stride patterns"
+            )
 
-        for stride_pattern, streamer in zip(self.stride_pattern, streamer_config.streamers):
-
+        for stride_pattern, streamer in zip(
+            self.stride_pattern, streamer_config.streamers
+        ):
             if len(stride_pattern.temporal_strides) > streamer.temporal_dim:
-                raise VerifyException("Temporal stride pattern exceeds streamer dimensionality")
+                raise VerifyException(
+                    "Temporal stride pattern exceeds streamer dimensionality"
+                )
 
             if len(stride_pattern.spatial_strides) > streamer.spatial_dim:
-                raise VerifyException("Spatial stride pattern exceeds streamer dimensionality")
+                raise VerifyException(
+                    "Spatial stride pattern exceeds streamer dimensionality"
+                )
 
 
 SnaxStream = Dialect("snax_stream", [StreamingRegionOp], [StridePattern])

--- a/compiler/dialects/snax_stream.py
+++ b/compiler/dialects/snax_stream.py
@@ -24,7 +24,7 @@ from xdsl.parser import AttrParser
 from xdsl.printer import Printer
 from xdsl.traits import SymbolTable
 
-from compiler.accelerators.streamers.streamers import StreamerConfiguration
+from compiler.accelerators.streamers import StreamerConfiguration
 from compiler.dialects.accfg import AcceleratorOp
 from compiler.dialects.snax import StreamerConfigurationAttr
 
@@ -174,7 +174,7 @@ class StreamingRegionOp(IRDLOperation):
             streamer_interface, StreamerConfigurationAttr
         ):
             raise VerifyException(
-                "Specified accelerator does not implement the streamer interface"
+                "Specified accelerator does not contain a StreamerConfigurationAttr"
             )
 
         streamer_config: StreamerConfiguration = streamer_interface.data

--- a/compiler/dialects/snax_stream.py
+++ b/compiler/dialects/snax_stream.py
@@ -60,6 +60,11 @@ class StridePattern(ParametrizedAttribute):
             parameters.append(arg)
         super().__init__(parameters)
 
+    def verify(self):
+
+        if len(self.upper_bounds) != len(self.temporal_strides):
+            raise VerifyException("Number of upper bounds should be equal to number of strides")
+
     def print_parameters(self, printer: Printer) -> None:
         with printer.in_angle_brackets():
             printer.print_string("ub = [")
@@ -121,7 +126,6 @@ class StreamingRegionOp(IRDLOperation):
 
     # streaming stride pattern
     # there should be one stride pattern for every input/output
-    # the upper bounds of all stride patterns should be equal
     stride_pattern = prop_def(ArrayAttr[StridePattern])
 
     accelerator = prop_def(StringAttr)

--- a/compiler/dialects/snax_stream.py
+++ b/compiler/dialects/snax_stream.py
@@ -61,9 +61,10 @@ class StridePattern(ParametrizedAttribute):
         super().__init__(parameters)
 
     def verify(self):
-
         if len(self.upper_bounds) != len(self.temporal_strides):
-            raise VerifyException("Number of upper bounds should be equal to number of strides")
+            raise VerifyException(
+                "Number of upper bounds should be equal to number of strides"
+            )
 
     def print_parameters(self, printer: Printer) -> None:
         with printer.in_angle_brackets():
@@ -155,7 +156,6 @@ class StreamingRegionOp(IRDLOperation):
         )
 
     def verify_(self):
-
         module_op = self
         while module_op and not isinstance(module_op, ModuleOp):
             module_op = module_op.parent_op()

--- a/compiler/dialects/snax_stream.py
+++ b/compiler/dialects/snax_stream.py
@@ -59,13 +59,9 @@ class StridePattern(ParametrizedAttribute):
             printer.print_string("ub = [")
             printer.print_list(self.upper_bounds, lambda attr: printer.print(attr.data))
             printer.print_string("], ts = [")
-            printer.print_list(
-                self.temporal_strides, lambda attr: printer.print(attr.data)
-            )
+            printer.print_list(self.temporal_strides, lambda attr: printer.print(attr.data))
             printer.print_string("], ss = [")
-            printer.print_list(
-                self.spatial_strides, lambda attr: printer.print(attr.data)
-            )
+            printer.print_list(self.spatial_strides, lambda attr: printer.print(attr.data))
             printer.print_string("]")
 
     @classmethod
@@ -74,28 +70,19 @@ class StridePattern(ParametrizedAttribute):
             parser.parse_identifier("ub")
             parser.parse_punctuation("=")
             ub = ArrayAttr(
-                IntAttr(i)
-                for i in parser.parse_comma_separated_list(
-                    parser.Delimiter.SQUARE, parser.parse_integer
-                )
+                IntAttr(i) for i in parser.parse_comma_separated_list(parser.Delimiter.SQUARE, parser.parse_integer)
             )
             parser.parse_punctuation(",")
             parser.parse_identifier("ts")
             parser.parse_punctuation("=")
             ts = ArrayAttr(
-                IntAttr(i)
-                for i in parser.parse_comma_separated_list(
-                    parser.Delimiter.SQUARE, parser.parse_integer
-                )
+                IntAttr(i) for i in parser.parse_comma_separated_list(parser.Delimiter.SQUARE, parser.parse_integer)
             )
             parser.parse_punctuation(",")
             parser.parse_identifier("ss")
             parser.parse_punctuation("=")
             ss = ArrayAttr(
-                IntAttr(i)
-                for i in parser.parse_comma_separated_list(
-                    parser.Delimiter.SQUARE, parser.parse_integer
-                )
+                IntAttr(i) for i in parser.parse_comma_separated_list(parser.Delimiter.SQUARE, parser.parse_integer)
             )
             return (ub, ts, ss)
 

--- a/tests/filecheck/dialects/snax/snax_ops.mlir
+++ b/tests/filecheck/dialects/snax/snax_ops.mlir
@@ -1,19 +1,21 @@
 // RUN: XDSL_ROUNDTRIP
 // RUN: XDSL_SINGLETRIP
 
-"builtin.module"() ({
-  %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, "L1">
-  %1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, "L1">) -> memref<8x8xi32, strided<[1, 16]>, "L1">
-  "snax.mcycle"() : () -> ()
-  %2 = "test.op"() : () -> index
-  %3 = "snax.alloc"(%2, %2, %2) <{"memory_space" = "L3", "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
-}) : () -> ()
+%0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, "L1">
+// CHECK:   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, "L1">
 
-
-// CHECK-NEXT: builtin.module {
-// CHECK-NEXT:   %0 = "test.op"() : () -> memref<8x8xi32, strided<[1, 8]>, "L1">
+%1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, "L1">) -> memref<8x8xi32, strided<[1, 16]>, "L1">
 // CHECK-NEXT:   %1 = "snax.layout_cast"(%0) : (memref<8x8xi32, strided<[1, 8]>, "L1">) -> memref<8x8xi32, strided<[1, 16]>, "L1">
+
+"snax.mcycle"() : () -> ()
 // CHECK-NEXT:   "snax.mcycle"() : () -> ()
+
+%2 = "test.op"() : () -> index
+%3 = "snax.alloc"(%2, %2, %2) <{"memory_space" = "L3", "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 // CHECK-NEXT:   %2 = "test.op"() : () -> index
 // CHECK-NEXT:   %3 = "snax.alloc"(%2, %2, %2) <{"memory_space" = "L3", "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
-// CHECK-NEXT: }
+
+// Test streamer config attribute:
+"test.op"() {"streamer_config" = #snax.streamer_config<r[1, 2], r[3, 4], w[5, 6]> } : () -> ()
+// CHECK-NEXT: #snax.streamer_config<r[1, 2], r[3, 4], w[5, 6]>
+

--- a/tests/filecheck/dialects/snax_stream/snax_stream_invalid.mlir
+++ b/tests/filecheck/dialects/snax_stream/snax_stream_invalid.mlir
@@ -1,0 +1,91 @@
+// RUN: XDSL_VERIFY_DIAG
+
+"snax_stream.streaming_region"() <{
+  "stride_pattern" = [],
+  "operandSegmentSizes" = array<i32: 0, 0>,
+  "accelerator" = "accelerator_with_streamers"}> ({
+^0():
+}) : () -> ()
+
+// CHECK: Operation does not verify: AcceleratorOp not found!
+
+// -----
+
+"accfg.accelerator"() <{
+    name = @accelerator_without_streamers,
+    fields = {}, launch_fields = {}, barrier = 0
+}> {} : () -> ()
+
+"snax_stream.streaming_region"() <{
+  "stride_pattern" = [],
+  "operandSegmentSizes" = array<i32: 0, 0>,
+  "accelerator" = "accelerator_without_streamers"}> ({
+^0():
+}) : () -> ()
+
+// CHECK: Operation does not verify: Specified accelerator does not implement the streamer interface
+
+// -----
+
+"accfg.accelerator"() <{
+    name = @accelerator_with_streamers,
+    fields = {}, launch_fields = {}, barrier = 0
+}> {
+    "streamer_config" = #snax.streamer_config< r[2,2], r[2,2], w[2,2]>
+} : () -> ()
+
+"snax_stream.streaming_region"() <{
+  "stride_pattern" = [],
+  "operandSegmentSizes" = array<i32: 0, 0>,
+  "accelerator" = "accelerator_with_streamers"}> ({
+^0():
+}) : () -> ()
+
+// CHECK: Operation does not verify: Number of streamers does not equal number of stride patterns
+
+// -----
+
+"accfg.accelerator"() <{
+    name = @accelerator_with_streamers,
+    fields = {}, launch_fields = {}, barrier = 0
+}> {
+    "streamer_config" = #snax.streamer_config< r[2,2], r[2,2], w[2,2]>
+} : () -> ()
+
+"snax_stream.streaming_region"() <{
+  "stride_pattern" = [
+              #snax_stream.stride_pattern<ub = [16, 8, 3], ts = [13, 7, 5], ss = [8, 1]>,
+              #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>,
+              #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>
+  ], "operandSegmentSizes" = array<i32: 2, 1>,
+  "accelerator" = "accelerator_with_streamers"}> ({
+^0():
+}) : () -> ()
+
+// CHECK: Operation does not verify: Temporal stride pattern exceeds streamer dimensionality
+
+// -----
+
+"accfg.accelerator"() <{
+    name = @accelerator_with_streamers,
+    fields = {}, launch_fields = {}, barrier = 0
+}> {
+    "streamer_config" = #snax.streamer_config< r[2,2], r[2,2], w[2,2]>
+} : () -> ()
+
+"snax_stream.streaming_region"() <{
+  "stride_pattern" = [
+              #snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [9, 8, 1]>,
+              #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>,
+              #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>
+  ], "operandSegmentSizes" = array<i32: 2, 1>,
+  "accelerator" = "accelerator_with_streamers"}> ({
+^0():
+}) : () -> ()
+
+// CHECK: Operation does not verify: Spatial stride pattern exceeds streamer dimensionality
+
+
+
+
+

--- a/tests/filecheck/dialects/snax_stream/snax_stream_invalid.mlir
+++ b/tests/filecheck/dialects/snax_stream/snax_stream_invalid.mlir
@@ -23,7 +23,7 @@
 ^0():
 }) : () -> ()
 
-// CHECK: Operation does not verify: Specified accelerator does not implement the streamer interface
+// CHECK: Operation does not verify: Specified accelerator does not contain a StreamerConfigurationAttr
 
 // -----
 

--- a/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
+++ b/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
@@ -1,5 +1,12 @@
 // RUN: XDSL_ROUNDTRIP
 
+"accfg.accelerator"() <{
+    name = @accelerator_with_streamers,
+    fields = {}, launch_fields = {}, barrier = 0
+}> {
+    "streamer_config" = #snax.streamer_config< r[2,2], r[2,2], w[2,2]>
+} : () -> ()
+
 %x, %y, %z = "test.op"() : () -> (index, index, index)
 
 "snax_stream.streaming_region"(%x, %y, %z) <{
@@ -18,7 +25,7 @@
 
 //CHECK:      builtin.module {
 //CHECK-NEXT:   %x, %y, %z = "test.op"() : () -> (index, index, index)
-//CHECK-NEXT:   "snax_stream.streaming_region"(%x, %y, %z) <{"stride_pattern" = [#snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>], "operandSegmentSizes" = array<i32: 2, 1>, "accelerator" = "accelerator_with_streamers"}> ({
+//CHECK-NEXT:   "snax_stream.streaming_region"(%x, %y, %z) <{"stride_pattern" = [#snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>], "operandSegmentSizes" = array<i32: 2, 1>, }> ({
 //CHECK-NEXT:   ^0(%0 : !stream.readable<i64>, %1 : !stream.readable<i64>, %2 : !stream.writable<i64>):
 //CHECK-NEXT:     %3 = stream.read from %0 : i64
 //CHECK-NEXT:     %4 = stream.read from %1 : i64

--- a/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
+++ b/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
@@ -7,7 +7,8 @@
               #snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [8, 1]>, 
               #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>, 
               #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>
-      ], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+      ], "operandSegmentSizes" = array<i32: 2, 1>,
+      "accelerator" = "accelerator_with_streamers"}> ({
 ^0(%3 : !stream.readable<i64>, %4 : !stream.readable<i64>, %5 : !stream.writable<i64>):
   %0 = stream.read from %3 : i64
   %1 = stream.read from %4 : i64
@@ -17,7 +18,7 @@
 
 //CHECK:      builtin.module {
 //CHECK-NEXT:   %x, %y, %z = "test.op"() : () -> (index, index, index)
-//CHECK-NEXT:   "snax_stream.streaming_region"(%x, %y, %z) <{"stride_pattern" = [#snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+//CHECK-NEXT:   "snax_stream.streaming_region"(%x, %y, %z) <{"stride_pattern" = [#snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>], "operandSegmentSizes" = array<i32: 2, 1>, "accelerator" = "accelerator_with_streamers"}> ({
 //CHECK-NEXT:   ^0(%0 : !stream.readable<i64>, %1 : !stream.readable<i64>, %2 : !stream.writable<i64>):
 //CHECK-NEXT:     %3 = stream.read from %0 : i64
 //CHECK-NEXT:     %4 = stream.read from %1 : i64

--- a/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
+++ b/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
@@ -24,8 +24,9 @@
 }) : (index, index, index) -> ()
 
 //CHECK:      builtin.module {
+//CHECK-NEXT:   "accfg.accelerator"() <{"name" = @accelerator_with_streamers, "fields" = {}, "launch_fields" = {}, "barrier" = 0 : i64}> {"streamer_config" = #snax.streamer_config<r[2, 2], r[2, 2], w[2, 2]>} : () -> ()
 //CHECK-NEXT:   %x, %y, %z = "test.op"() : () -> (index, index, index)
-//CHECK-NEXT:   "snax_stream.streaming_region"(%x, %y, %z) <{"stride_pattern" = [#snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>], "operandSegmentSizes" = array<i32: 2, 1>, }> ({
+//CHECK-NEXT:   "snax_stream.streaming_region"(%x, %y, %z) <{"stride_pattern" = [#snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>], "operandSegmentSizes" = array<i32: 2, 1>, "accelerator" = "accelerator_with_streamers"}> ({
 //CHECK-NEXT:   ^0(%0 : !stream.readable<i64>, %1 : !stream.readable<i64>, %2 : !stream.writable<i64>):
 //CHECK-NEXT:     %3 = stream.read from %0 : i64
 //CHECK-NEXT:     %4 = stream.read from %1 : i64


### PR DESCRIPTION
note: stacked on #175 

This PR includes the following:

- A representation of the Streamers in `accelerators/streamers/streamer.py`
- An attribute which holds as data a StreamerConfiguration: `StreamerConfigurationAttr`
- This attribute can be passed along with an `accfg.AcceleratorOp`.
- The `snax_stream.streaming_region_op` now comes with a verifier that does the following:
  - The region must be linked to an accelerator
  - The accelerator must implement a streamer interface, through the streamer configuration attribute
  - All of the dimensions of the stride pattern must mach the streamer interface implementation
- It also includes a `SNAXStreamer` base class, which can be inherited by other accelerators, this class will then handle anything streamer-related automatically, based on the supplied StreamerConfiguration. (This is implemented in future PRs, see #177 for a sneak peak) 