### PR TITLE
allow unregistered accelerator ops

### DIFF
--- a/compiler/accelerators/registry.py
+++ b/compiler/accelerators/registry.py
@@ -26,7 +26,7 @@ class AcceleratorRegistry:
 
     def lookup_acc_info(
         self, acc_query: StringAttr, module: ModuleOp
-    ) -> tuple[AcceleratorOp, type[Accelerator]]:
+    ) -> tuple[AcceleratorOp, type[Accelerator] | None]:
         """
         Perform a symbol table lookup for the accelerator op in the IR
         and then get the corresponding the Accelerator interface from
@@ -46,11 +46,11 @@ class AcceleratorRegistry:
 
     def get_acc_info(
         self, acc_op: AcceleratorOp | StringAttr | str
-    ) -> type[Accelerator]:
+    ) -> type[Accelerator] | None:
         """
         Get a reference to an Accelerator interface based on an AcceleratorOp,
         string or StringAttr.
-        If the requested symbol name is not available, throw a RuntimeError
+        If the requested symbol name is not available, return None
         """
         if isinstance(acc_op, str):
             acc_name = acc_op
@@ -61,10 +61,7 @@ class AcceleratorRegistry:
         try:
             acc_info = self.registered_accelerators[acc_name]
         except KeyError:
-            raise RuntimeError(
-                f"'{acc_name}' is not a registered accelerator."
-                f"Registered accelerators: {','.join(self.get_names())}"
-            )
+            return None
         return acc_info
 
     def get_names(self) -> Iterable[str]:

--- a/compiler/transforms/convert_accfg_to_csr.py
+++ b/compiler/transforms/convert_accfg_to_csr.py
@@ -36,6 +36,8 @@ class LowerAccfgBasePattern(RewritePattern, ABC):
         acc_op, acc_info = AcceleratorRegistry().lookup_acc_info(
             accelerator, self.module
         )
+        if not acc_info:
+            raise RuntimeError(f"{accelerator.data} is not a registered Accelerator")
         return acc_op, acc_info
 
     def __hash__(self):

--- a/compiler/transforms/convert_linalg_to_accfg.py
+++ b/compiler/transforms/convert_linalg_to_accfg.py
@@ -49,6 +49,8 @@ class ConvertLinalgToAcceleratorPattern(RewritePattern):
         _, acc_info = acc_reg.lookup_acc_info(
             StringAttr(library_call_name), self.module
         )
+        if not acc_info:
+            raise RuntimeError(f"{library_call_name} is not a registered Accelerator")
         rewriter.replace_matched_op(acc_info().convert_to_acc_ops(op))
 
 


### PR DESCRIPTION
I want to write tests with some arbitrary accelerator ops, but the system won't allow this unless they are registered. However, I don't want to register these dummy accelerator ops.

I therefore suggest we allow unregistered accelerator ops, and only throw runtime errors when we actually apply transformations on accfg ops that are not registered.