### PR TITLE
add stream-snaxify pass

### DIFF
--- a/compiler/accelerators/snax.py
+++ b/compiler/accelerators/snax.py
@@ -112,7 +112,7 @@ class SNAXStreamer(ABC):
         result: Sequence[tuple[Sequence[Operation], SSAValue]] = []
 
         # loop bound registers
-        loop_bounds: Sequence[IntAttr] = op.stride_pattern.data[0].upper_bounds.data
+        loop_bounds: Sequence[IntAttr] = op.stride_patterns.data[0].upper_bounds.data
         result.extend(
             [
                 (
@@ -127,7 +127,7 @@ class SNAXStreamer(ABC):
         for dim in range(self.streamer_config.data.temporal_dim()):
             for streamer in range(self.streamer_config.data.size()):
                 cst = arith.Constant.from_int_and_width(
-                    op.stride_pattern.data[streamer].temporal_strides.data[dim], i32
+                    op.stride_patterns.data[streamer].temporal_strides.data[dim], i32
                 )
                 result.append(([cst], cst.result))
 
@@ -135,7 +135,7 @@ class SNAXStreamer(ABC):
         for dim in range(self.streamer_config.data.spatial_dim()):
             for streamer in range(self.streamer_config.data.size()):
                 cst = arith.Constant.from_int_and_width(
-                    op.stride_pattern.data[streamer].spatial_strides.data[dim], i32
+                    op.stride_patterns.data[streamer].spatial_strides.data[dim], i32
                 )
                 result.append(([cst], cst.result))
 

--- a/compiler/accelerators/snax_alu.py
+++ b/compiler/accelerators/snax_alu.py
@@ -127,7 +127,7 @@ class SNAXAluAccelerator(SNAXAccelerator, SNAXPollingBarrier, SNAXStreamer):
     ) -> Sequence[tuple[Sequence[Operation], SSAValue]]:
         c0 = arith.Constant.from_int_and_width(0, 32)
         loop_bound = arith.Constant.from_int_and_width(
-            op.stride_pattern.data[0].upper_bounds.data[0], 32
+            op.stride_patterns.data[0].upper_bounds.data[0], 32
         )
 
         return [

--- a/compiler/dialects/snax_stream.py
+++ b/compiler/dialects/snax_stream.py
@@ -151,7 +151,7 @@ class StreamingRegionOp(IRDLOperation):
     ) -> None:
         if not isinstance(stride_patterns, ArrayAttr):
             stride_patterns = ArrayAttr(stride_patterns)
-        if not isinstance(accelerator, StringAttr):
+        if isinstance(accelerator, str):
             accelerator = StringAttr(accelerator)
         super().__init__(
             operands=[inputs, outputs],

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -28,6 +28,7 @@ from compiler.transforms.set_memory_space import SetMemorySpace
 from compiler.transforms.snax_copy_to_dma import SNAXCopyToDMA
 from compiler.transforms.snax_lower_mcycle import SNAXLowerMCycle
 from compiler.transforms.snax_to_func import SNAXToFunc
+from compiler.transforms.stream_snaxify import StreamSnaxify
 
 
 class SNAXOptMain(xDSLOptMain):
@@ -78,6 +79,7 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(
             AccfgConfigOverlapPass.name, lambda: AccfgConfigOverlapPass
         )
+        super().register_pass(StreamSnaxify.name, lambda: StreamSnaxify)
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/transforms/stream_snaxify.py
+++ b/compiler/transforms/stream_snaxify.py
@@ -1,0 +1,167 @@
+from dataclasses import dataclass
+
+from xdsl.dialects import builtin, memref, memref_stream
+from xdsl.dialects.builtin import ModuleOp, StringAttr
+from xdsl.ir import MLContext, Region
+from xdsl.ir.affine import AffineDimExpr, AffineMap
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.traits import SymbolTable
+
+from compiler.dialects import snax_stream
+from compiler.dialects.accfg import AcceleratorOp
+from compiler.dialects.snax import StreamerConfigurationAttr
+
+
+@dataclass
+class MemrefStreamToSnaxPattern(RewritePattern):
+    """
+    This pattern converts memref_stream streaming
+    region ops into snax_stream streaming region ops.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: memref_stream.StreamingRegionOp, rewriter: PatternRewriter):
+        """
+        Current restrictions:
+            - only allow default memref layouts
+        """
+
+        # only memref stream ops dispatched to an accelerator:
+        if "accelerator" not in op.attributes:
+            return
+
+        accelerator_str = op.attributes["accelerator"]
+        assert isinstance(accelerator_str, StringAttr)
+
+        shaped_operands = [*op.inputs, *op.outputs]
+
+        # make sure there are as much shaped operands as access patterns
+        assert len(shaped_operands) == len(op.patterns)
+
+        # make sure the operands are memrefs with default layout
+        for memref_operand in shaped_operands:
+            if not isinstance(memref_operand.type, builtin.MemRefType):
+                return
+            if not isinstance(memref_operand.type.layout, builtin.NoneAttr):
+                return
+
+        # construct the strided patterns for SNAX Streamers
+
+        # get the affine mapping from data to memory:
+        data_mem_maps = [AffineMap.identity(1) for _ in shaped_operands]
+
+        # combine the maps access -> data and data -> memory to access -> memory
+        access_mem_maps = [
+            data_mem_map.compose(memref_stride_pattern.index_map.data)
+            for data_mem_map, memref_stride_pattern in zip(data_mem_maps, op.patterns.data)
+        ]
+
+        # now we have a mapping from access to memory, this can be used to program the streamers
+        # first, find the streamer config
+        module_op = op
+        while module_op and not isinstance(module_op, ModuleOp):
+            module_op = module_op.parent_op()
+        if not module_op:
+            raise RuntimeError("Module Op not found")
+
+        trait = module_op.get_trait(SymbolTable)
+        assert trait is not None
+        acc_op = trait.lookup_symbol(module_op, accelerator_str)
+
+        if not isinstance(acc_op, AcceleratorOp):
+            raise RuntimeError("AcceleratorOp not found!")
+
+        streamer_config = acc_op.attributes["streamer_config"]
+        if not isinstance(streamer_config, StreamerConfigurationAttr):
+            raise RuntimeError("Streamer interface not found for given accelerator op")
+
+        # small function to generate a list of n zeros with the i-th element 1
+        def generate_one_list(n: int, i: int):
+            return [1 if j == i else 0 for j in range(n)]
+
+
+        snax_stride_patterns = []
+        for access_mem_map, memref_stride_pattern in zip(access_mem_maps, op.patterns.data):
+            # find accelerator in attribute, look up accelerator op in the ir.
+            # get the streamer access patterns from the interface attribute of the accfg op
+            # map the access pattern to stride pattern spatial first, then temporal
+
+            temporal_strides = []
+            spatial_strides = []
+            upper_bounds = []
+            access_mem_map_dim = access_mem_map.num_dims
+
+            # do not consider symbols yet
+            if access_mem_map.num_symbols != 0:
+                raise RuntimeError("Access patterns with symbols are not supported yet.")
+
+            # first, fill up the spatial strides
+            for i in reversed(
+                range(
+                    streamer_config.data.temporal_dim(),
+                    streamer_config.data.temporal_dim() + streamer_config.data.spatial_dim(),
+                )
+            ):
+                stride = access_mem_map.eval(generate_one_list(access_mem_map_dim, i), ())
+                spatial_strides.append(stride[0])
+
+            # then, fill up the temporal strides
+            for i in range(streamer_config.data.temporal_dim()):
+                stride = access_mem_map.eval(generate_one_list(access_mem_map_dim, i), ())
+                temporal_strides.append(stride[0])
+                upper_bounds.append(memref_stride_pattern.ub.data[i].data)
+
+            # create the stride pattern
+            snax_stride_pattern = snax_stream.StridePattern(
+                upper_bounds=upper_bounds,
+                temporal_strides=temporal_strides,
+                spatial_strides=spatial_strides,
+            )
+            snax_stride_patterns.append(snax_stride_pattern)
+
+
+        # get base addresses of the streaming region ops
+        # TODO: generalize and fix for offsets
+
+        new_inputs = [
+            memref.ExtractAlignedPointerAsIndexOp.get(input)
+            for input in op.inputs
+        ]
+
+        new_outputs = [
+            memref.ExtractAlignedPointerAsIndexOp.get(output)
+            for output in op.outputs
+        ]
+
+        # now create snax_streaming region op
+        new_op = snax_stream.StreamingRegionOp(
+            inputs=new_inputs,
+            outputs=new_outputs,
+            stride_patterns=snax_stride_patterns,
+            accelerator=accelerator_str,
+            body=rewriter.move_region_contents_to_new_regions(op.body),
+        )
+
+        rewriter.replace_matched_op([*new_inputs, *new_outputs, new_op], new_op.results)
+
+
+@dataclass(frozen=True)
+class StreamSnaxify(ModulePass):
+    """
+    A pass to convert memref_stream operations to snax stream. This
+    boils down to combining the data access patterns of a memref_stream
+    op (operation -> data), with a certain data layout (data -> memory)
+    and realizing this by a snax_stream access pattern
+    (operation -> memory), which is then realized by the Streamers.
+    """
+
+    name = "stream-snaxify"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(MemrefStreamToSnaxPattern()).rewrite_module(op)

--- a/kernels/streamer_alu/Makefile
+++ b/kernels/streamer_alu/Makefile
@@ -12,13 +12,7 @@ TESTS += streamer_add_stream.x
 CFLAGS += -std=gnu11
 CFLAGS += -Wall -Wextra
 
-SNAXOPTFLAGS = -p dispatch-kernels,set-memory-space,set-memory-layout,realize-memref-casts,insert-sync-barrier,dispatch-regions,insert-accfg-op{accelerator=snax_alu},convert-linalg-to-accfg,convert-accfg-to-csr,snax-copy-to-dma,memref-to-snax,snax-to-func,clear-memory-space
-
-
-# override for streamer_add_stream.x, without insert-accfg-op (this is only temporary)
-SNAXOPTFLAGS2 = -p dispatch-kernels,set-memory-space,set-memory-layout,realize-memref-casts,insert-sync-barrier,dispatch-regions,convert-linalg-to-accfg,convert-accfg-to-csr,snax-copy-to-dma,memref-to-snax,snax-to-func,clear-memory-space
-streamer_add_stream.snax-opt.mlir: streamer_add_stream.preprocfinal.mlir
-	$(SNAXOPT) $(SNAXOPTFLAGS2) -o $@ $<
+SNAXOPTFLAGS = -p dispatch-kernels,set-memory-space,set-memory-layout,realize-memref-casts,insert-sync-barrier,dispatch-regions,insert-accfg-op{accelerator=snax_alu},stream-snaxify,convert-linalg-to-accfg,convert-accfg-to-csr,snax-copy-to-dma,memref-to-snax,snax-to-func,clear-memory-space
 
 
 data.c data.h:

--- a/kernels/streamer_alu/streamer_add_stream.preprocfinal.mlir
+++ b/kernels/streamer_alu/streamer_add_stream.preprocfinal.mlir
@@ -19,18 +19,14 @@ func.func public @streamer_add(%arg0 : memref<?xi64, "L3">, %arg1 : memref<?xi64
   "snax.cluster_sync_op"() : () -> ()
   "scf.if"(%0) ({
 
-    %x = "memref.extract_aligned_pointer_as_index" (%4) : (memref<?xi64, "L1">) -> (index)
-    %y = "memref.extract_aligned_pointer_as_index" (%7) : (memref<?xi64, "L1">) -> (index)
-    %z = "memref.extract_aligned_pointer_as_index" (%10) : (memref<?xi64, "L1">) -> (index)
-
-    "snax_stream.streaming_region"(%x, %y, %z) <{
-          "stride_pattern" = [
-                  #snax_stream.stride_pattern<ub = [4], ts = [32], ss = [8]>, 
-                  #snax_stream.stride_pattern<ub = [4], ts = [32], ss = [8]>, 
-                  #snax_stream.stride_pattern<ub = [4], ts = [32], ss = [8]>
-          ], "operandSegmentSizes" = array<i32: 2, 1>,
-          "accelerator" = "snax_alu"}> ({
-    ^0(%103 : !stream.readable<i64>, %104 : !stream.readable<i64>, %105 : !stream.writable<i64>):
+    memref_stream.streaming_region {
+      patterns = [
+          #memref_stream.stride_pattern<ub = [4, 4], index_map = (d0, d1) -> (4 * d0 + d1)>,
+          #memref_stream.stride_pattern<ub = [4, 4], index_map = (d0, d1) -> (4 * d0 + d1)>,
+          #memref_stream.stride_pattern<ub = [4, 4], index_map = (d0, d1) -> (4 * d0 + d1)>
+      ]
+    } ins(%4, %7 : memref<?xi64, "L1">, memref<?xi64, "L1">) outs(%10 : memref<?xi64, "L1">) attrs = {accelerator="snax_alu"} {
+    ^bb0(%103: !stream.readable<i64>, %104: !stream.readable<i64>, %105: !stream.writable<i64>):
 
       // body of this streaming region does not really matter, as it is not 
       // yet considered by the transformation passes
@@ -40,8 +36,7 @@ func.func public @streamer_add(%arg0 : memref<?xi64, "L3">, %arg1 : memref<?xi64
       %102 = arith.addi %100, %101 : i64
       stream.write %102 to %105 : i64
 
-    }) : (index, index, index) -> ()
-
+    }
 
     scf.yield
   }, {
@@ -54,27 +49,6 @@ func.func public @streamer_add(%arg0 : memref<?xi64, "L3">, %arg1 : memref<?xi64
   }) : (i1) -> ()
   func.return
 }
-
-"accfg.accelerator"() <{"name" = @snax_alu, 
-  "fields" = {
-    "loop_bound_0" = 960 : i32, 
-    "a_tstride_0" = 961 : i32, 
-    "b_tstride_0" = 962 : i32, 
-    "c_tstride_0" = 963 : i32, 
-    "a_sstride_0" = 964 : i32, 
-    "b_sstride_0" = 965 : i32, 
-    "c_sstride_0" = 966 : i32, 
-    "a_ptr" = 967 : i32, 
-    "b_ptr" = 968 : i32, 
-    "c_ptr" = 969 : i32, 
-    "alu_mode" = 972 : i32, 
-    "loop_bound_alu" = 973 : i32}, 
-  "launch_fields" = {
-    "launch_streamer" = 970 : i32, 
-    "launch_alu" = 974 : i32}, 
-  "barrier" = 975 : i32}> {
-    "streamer_config" = #snax.streamer_config<r[1, 1], r[1, 1], r[1, 1]>
-} : () -> ()
 
 func.func private @snax_is_compute_core() -> i1
 func.func private @snax_is_dm_core() -> i1

--- a/tests/filecheck/dialects/snax_stream/snax_stream_invalid.mlir
+++ b/tests/filecheck/dialects/snax_stream/snax_stream_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: XDSL_VERIFY_DIAG
 
 "snax_stream.streaming_region"() <{
-  "stride_pattern" = [],
+  "stride_patterns" = [],
   "operandSegmentSizes" = array<i32: 0, 0>,
   "accelerator" = "accelerator_with_streamers"}> ({
 ^0():
@@ -17,7 +17,7 @@
 }> {} : () -> ()
 
 "snax_stream.streaming_region"() <{
-  "stride_pattern" = [],
+  "stride_patterns" = [],
   "operandSegmentSizes" = array<i32: 0, 0>,
   "accelerator" = "accelerator_without_streamers"}> ({
 ^0():
@@ -35,7 +35,7 @@
 } : () -> ()
 
 "snax_stream.streaming_region"() <{
-  "stride_pattern" = [],
+  "stride_patterns" = [],
   "operandSegmentSizes" = array<i32: 0, 0>,
   "accelerator" = "accelerator_with_streamers"}> ({
 ^0():
@@ -53,7 +53,7 @@
 } : () -> ()
 
 "snax_stream.streaming_region"() <{
-  "stride_pattern" = [
+  "stride_patterns" = [
               #snax_stream.stride_pattern<ub = [16, 8, 3], ts = [13, 7, 5], ss = [8, 1]>,
               #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>,
               #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>
@@ -74,7 +74,7 @@
 } : () -> ()
 
 "snax_stream.streaming_region"() <{
-  "stride_pattern" = [
+  "stride_patterns" = [
               #snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [9, 8, 1]>,
               #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>,
               #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>

--- a/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
+++ b/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
@@ -10,7 +10,7 @@
 %x, %y, %z = "test.op"() : () -> (index, index, index)
 
 "snax_stream.streaming_region"(%x, %y, %z) <{
-      "stride_pattern" = [
+      "stride_patterns" = [
               #snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [8, 1]>, 
               #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>, 
               #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>

--- a/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
+++ b/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
@@ -26,7 +26,7 @@
 //CHECK:      builtin.module {
 //CHECK-NEXT:   "accfg.accelerator"() <{"name" = @accelerator_with_streamers, "fields" = {}, "launch_fields" = {}, "barrier" = 0 : i64}> {"streamer_config" = #snax.streamer_config<r[2, 2], r[2, 2], w[2, 2]>} : () -> ()
 //CHECK-NEXT:   %x, %y, %z = "test.op"() : () -> (index, index, index)
-//CHECK-NEXT:   "snax_stream.streaming_region"(%x, %y, %z) <{"stride_pattern" = [#snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>], "operandSegmentSizes" = array<i32: 2, 1>, "accelerator" = "accelerator_with_streamers"}> ({
+//CHECK-NEXT:   "snax_stream.streaming_region"(%x, %y, %z) <{"stride_patterns" = [#snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>], "operandSegmentSizes" = array<i32: 2, 1>, "accelerator" = "accelerator_with_streamers"}> ({
 //CHECK-NEXT:   ^0(%0 : !stream.readable<i64>, %1 : !stream.readable<i64>, %2 : !stream.writable<i64>):
 //CHECK-NEXT:     %3 = stream.read from %0 : i64
 //CHECK-NEXT:     %4 = stream.read from %1 : i64

--- a/tests/filecheck/transforms/stream-snaxify.mlir
+++ b/tests/filecheck/transforms/stream-snaxify.mlir
@@ -1,0 +1,22 @@
+// RUN: ./compiler/snax-opt --split-input-file %s -p insert-accfg-op{accelerator=snax_alu},stream-snaxify | filecheck %s
+
+%A, %B, %C = "test.op"() : () -> (memref<16xi64>, memref<16xi64>, memref<16xi64>)
+
+memref_stream.streaming_region {
+    patterns = [
+        #memref_stream.stride_pattern<ub = [4, 4], index_map = (d0, d1) -> (4 * d0 + d1)>,
+        #memref_stream.stride_pattern<ub = [4, 4], index_map = (d0, d1) -> (4 * d0 + d1)>,
+        #memref_stream.stride_pattern<ub = [4, 4], index_map = (d0, d1) -> (4 * d0 + d1)>
+    ]
+} ins(%A, %B : memref<16xi64>, memref<16xi64>) outs(%C : memref<16xi64>) attrs = {accelerator="snax_alu"} {
+^bb0(%a: !stream.readable<i64>, %b: !stream.readable<i64>, %c: !stream.writable<i64>):
+    "test.op"(%a, %b, %c) : (!stream.readable<i64>, !stream.readable<i64>, !stream.writable<i64>) -> ()
+}
+
+//CHECK:        %0 = "memref.extract_aligned_pointer_as_index"(%A) : (memref<16xi64>) -> index
+//CHECK-NEXT:   %1 = "memref.extract_aligned_pointer_as_index"(%B) : (memref<16xi64>) -> index
+//CHECK-NEXT:   %2 = "memref.extract_aligned_pointer_as_index"(%C) : (memref<16xi64>) -> index
+//CHECK-NEXT:   "snax_stream.streaming_region"(%0, %1, %2) <{"stride_patterns" = [#snax_stream.stride_pattern<ub = [4], ts = [4], ss = [1]>, #snax_stream.stride_pattern<ub = [4], ts = [4], ss = [1]>, #snax_stream.stride_pattern<ub = [4], ts = [4], ss = [1]>], "accelerator" = "snax_alu", "operandSegmentSizes" = array<i32: 2, 1>}> ({
+//CHECK-NEXT:   ^0(%a : !stream.readable<i64>, %b : !stream.readable<i64>, %c : !stream.writable<i64>):
+//CHECK-NEXT:     "test.op"(%a, %b, %c) : (!stream.readable<i64>, !stream.readable<i64>, !stream.writable<i64>) -> ()
+//CHECK-NEXT:   }) : (index, index, index) -> ()

--- a/tests/filecheck/transforms/stream-snaxify.mlir
+++ b/tests/filecheck/transforms/stream-snaxify.mlir
@@ -16,7 +16,7 @@ memref_stream.streaming_region {
 //CHECK:        %0 = "memref.extract_aligned_pointer_as_index"(%A) : (memref<16xi64>) -> index
 //CHECK-NEXT:   %1 = "memref.extract_aligned_pointer_as_index"(%B) : (memref<16xi64>) -> index
 //CHECK-NEXT:   %2 = "memref.extract_aligned_pointer_as_index"(%C) : (memref<16xi64>) -> index
-//CHECK-NEXT:   "snax_stream.streaming_region"(%0, %1, %2) <{"stride_patterns" = [#snax_stream.stride_pattern<ub = [4], ts = [4], ss = [1]>, #snax_stream.stride_pattern<ub = [4], ts = [4], ss = [1]>, #snax_stream.stride_pattern<ub = [4], ts = [4], ss = [1]>], "accelerator" = "snax_alu", "operandSegmentSizes" = array<i32: 2, 1>}> ({
+//CHECK-NEXT:   "snax_stream.streaming_region"(%0, %1, %2) <{"stride_patterns" = [#snax_stream.stride_pattern<ub = [4], ts = [32], ss = [8]>, #snax_stream.stride_pattern<ub = [4], ts = [32], ss = [8]>, #snax_stream.stride_pattern<ub = [4], ts = [32], ss = [8]>], "accelerator" = "snax_alu", "operandSegmentSizes" = array<i32: 2, 1>}> ({
 //CHECK-NEXT:   ^0(%a : !stream.readable<i64>, %b : !stream.readable<i64>, %c : !stream.writable<i64>):
 //CHECK-NEXT:     "test.op"(%a, %b, %c) : (!stream.readable<i64>, !stream.readable<i64>, !stream.writable<i64>) -> ()
 //CHECK-NEXT:   }) : (index, index, index) -> ()


### PR DESCRIPTION
This pass converts a `memref.streaming_region_op` into a `snax_stream.streaming_region_op`. 
This is somewhat similar to the pass `convert_memref_stream_to_snitch_stream` in xdsl. I am refactoring some stuff over there to share some more code.

It also updates the lowering for the `snax_alu` accelerator to start from `memref_stream`.