### PR TITLE
util: add canonicalize_affine_map

### DIFF
--- a/compiler/util/canonicalize_affine.py
+++ b/compiler/util/canonicalize_affine.py
@@ -1,0 +1,111 @@
+from xdsl.ir.affine import (
+    AffineBinaryOpExpr,
+    AffineBinaryOpKind,
+    AffineConstantExpr,
+    AffineDimExpr,
+    AffineExpr,
+    AffineMap,
+)
+
+
+def get_dim(expr: AffineExpr) -> int | None:
+    if isinstance(expr, AffineDimExpr):
+        return expr.position
+    if isinstance(expr, AffineBinaryOpExpr):
+        result = get_dim(expr.lhs)
+        if result is not None:
+            return result
+        result = get_dim(expr.rhs)
+        if result is not None:
+            return result
+
+
+def canonicalize_addition(expr: AffineBinaryOpExpr) -> AffineExpr:
+    assert expr.kind is AffineBinaryOpKind.Add
+    if isinstance(expr.lhs, AffineConstantExpr):
+        # lhs is constant
+        if isinstance(expr.rhs, AffineConstantExpr):
+            # both are constants
+            return AffineConstantExpr(expr.lhs.value + expr.rhs.value)
+        else:
+            # move constant to rhs
+            expr = AffineBinaryOpExpr(expr.kind, expr.rhs, expr.lhs)
+    if isinstance(expr.rhs, AffineConstantExpr):
+        # rhs is constant, lhs is not
+        if expr.rhs.value == 0:
+            return expr.lhs
+    # order by minimum dimension first
+    dim_lhs = get_dim(expr.lhs)  # 3
+    dim_rhs = get_dim(expr.rhs)  # 0
+    if dim_rhs is not None:
+        if dim_lhs is None or dim_lhs > dim_rhs:
+            return expr.rhs + expr.lhs
+    return expr
+
+
+def canonicalize_multiplication(expr: AffineBinaryOpExpr) -> AffineExpr:
+    assert expr.kind is AffineBinaryOpKind.Mul
+    if isinstance(expr.lhs, AffineConstantExpr):
+        # lhs is constant
+        if isinstance(expr.rhs, AffineConstantExpr):
+            # both are constants
+            return AffineConstantExpr(expr.lhs.value * expr.rhs.value)
+        else:
+            # move constant to rhs
+            return AffineBinaryOpExpr(expr.kind, expr.rhs, expr.lhs)
+    if isinstance(expr.rhs, AffineConstantExpr):
+        # rhs is constant, lhs is not
+        if expr.rhs.value == 1:
+            return expr.lhs
+    return expr
+
+
+def canonicalize_floordiv(expr: AffineBinaryOpExpr) -> AffineExpr:
+    assert expr.kind is AffineBinaryOpKind.FloorDiv
+    if isinstance(expr.rhs, AffineConstantExpr):
+        # rhs is constant, lhs is not
+        if expr.rhs.value == 1:
+            return expr.lhs
+    return expr
+
+
+def canonicalize_mod(expr: AffineBinaryOpExpr) -> AffineExpr:
+    assert expr.kind is AffineBinaryOpKind.Mod
+    if isinstance(expr.rhs, AffineConstantExpr):
+        # rhs is constant, lhs is not
+        if expr.rhs.value == 1:
+            return AffineConstantExpr(0)
+    return expr
+
+
+def canonicalize_binary_op(expr: AffineBinaryOpExpr) -> AffineExpr:
+    # canonicalize childern
+    expr = AffineBinaryOpExpr(
+        expr.kind, canonicalize_expr(expr.lhs), canonicalize_expr(expr.rhs)
+    )
+    if expr.kind is AffineBinaryOpKind.Add:
+        return canonicalize_addition(expr)
+    if expr.kind is AffineBinaryOpKind.Mul:
+        return canonicalize_multiplication(expr)
+    if expr.kind is AffineBinaryOpKind.FloorDiv:
+        return canonicalize_floordiv(expr)
+    if expr.kind is AffineBinaryOpKind.Mod:
+        return canonicalize_mod(expr)
+    return expr
+
+
+def canonicalize_expr(expr: AffineExpr) -> AffineExpr:
+    if isinstance(expr, AffineBinaryOpExpr):
+        return canonicalize_binary_op(expr)
+
+    return expr
+
+
+# helper function to canonicalize affine maps
+def canonicalize_map(map: AffineMap) -> AffineMap:
+    # canonicalize each result and construct new affine map
+    return AffineMap(
+        map.num_dims,
+        map.num_symbols,
+        tuple(canonicalize_expr(expr) for expr in map.results),
+    )

--- a/tests/util/test_canonicalize_affine.py
+++ b/tests/util/test_canonicalize_affine.py
@@ -1,0 +1,45 @@
+from xdsl.ir.affine import (
+    AffineConstantExpr,
+    AffineDimExpr,
+    AffineMap,
+)
+
+from compiler.util.canonicalize_affine import canonicalize_expr, canonicalize_map
+
+
+def test_canonicalize():
+    c0 = AffineConstantExpr(0)
+    c1 = AffineConstantExpr(1)
+    c2 = AffineConstantExpr(2)
+    c4 = AffineConstantExpr(4)
+
+    d0 = AffineDimExpr(0)
+    d1 = AffineDimExpr(1)
+
+    # additions:
+    # expr + 0
+    assert canonicalize_expr(d0 + c0) == d0
+    # 2 + 2
+    assert canonicalize_expr(c2 + c2) == c4
+    # c1 + expr
+    assert canonicalize_expr(c1 + d0) == d0 + c1
+    # d1 + d0
+    assert canonicalize_expr(d1 + d0) == d0 + d1
+    # (d1 * 4) + (d0 * 4)
+    assert canonicalize_expr(d1 * c4 + d0 * c4) == d0 * c4 + d1 * c4
+
+    # multiplications:
+    assert canonicalize_expr(c4 * d1) == d1 * c4
+
+    # floordiv:
+    # dividing by 1 is useless
+    assert canonicalize_expr(d0 // c1) == d0
+
+    # mod:
+    # mod 1 is zero
+    assert canonicalize_expr(d0 % c1) == c0
+
+    # test map:
+    assert canonicalize_map(AffineMap(2, 0, (c1 * d1, d0 + c0))) == AffineMap(
+        2, 0, (d1, d0)
+    )


### PR DESCRIPTION
The algorithms used in the stream transform passes try to compare different affine maps. To be able to compare them, this utility function tries to implement some canonicalization. It is quite barebones, but it suffices for now. Future work is to implement the full flattening of affine maps in upstream MLIR in xdsl so we can use that, but this is quite some work.
