### PR TITLE
util: (kernel_type) add Kerneltype.ADD kernel

### DIFF
--- a/compiler/util/kernel_type.py
+++ b/compiler/util/kernel_type.py
@@ -30,6 +30,8 @@ class KernelType(Enum):
     linalg generic body.
 
     Attributes:
+        ADD (str): Represents an addition operation.
+            out = a + b
         MUL (str): Represents a multiplication operation.
             out = a * b
         MAC (str): Represents a multiply-accumulate operation.


### PR DESCRIPTION
The snax-alu accelerator implements elementwise addition. To be able to dispatch and detect this, the ADD kernel type is added to the kernel utilities.

This also fixes some weird things I found in the test.
Such as `arith.Constant(IndexType(), 1)`, which is a completely invalid call of the constructor, but does not throw an error as the op is never verified/inserted in ir/ value is requested :)