### PR TITLE
transform: (guarded-linalg-to-memref-stream) init pass

### DIFF
--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -19,6 +19,7 @@ from compiler.transforms.convert_linalg_to_accfg import (
 )
 from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
+from compiler.transforms.guarded_linalg_to_memref_stream import GuardedLinalgToMemrefStreamPass
 from compiler.transforms.insert_accfg_op import InsertAccOp
 from compiler.transforms.insert_sync_barrier import InsertSyncBarrier
 from compiler.transforms.linalg_to_library_call import LinalgToLibraryCall
@@ -31,7 +32,6 @@ from compiler.transforms.snax_copy_to_dma import SNAXCopyToDMA
 from compiler.transforms.snax_lower_mcycle import SNAXLowerMCycle
 from compiler.transforms.snax_to_func import SNAXToFunc
 from compiler.transforms.stream_snaxify import StreamSnaxify
-from compiler.transforms.guarded_linalg_to_memref_stream import GuardedLinalgToMemrefStreamPass
 
 
 class SNAXOptMain(xDSLOptMain):
@@ -85,7 +85,6 @@ class SNAXOptMain(xDSLOptMain):
         )
         super().register_pass(StreamSnaxify.name, lambda: StreamSnaxify)
         super().register_pass(ReuseMemrefAllocs.name, lambda: ReuseMemrefAllocs)
-        super().register_pass(ScheduleMemrefLinalg.name, lambda: ScheduleMemrefLinalg)
         super().register_pass(GuardedLinalgToMemrefStreamPass.name, lambda: GuardedLinalgToMemrefStreamPass)
 
         # arg handling

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -31,6 +31,7 @@ from compiler.transforms.snax_copy_to_dma import SNAXCopyToDMA
 from compiler.transforms.snax_lower_mcycle import SNAXLowerMCycle
 from compiler.transforms.snax_to_func import SNAXToFunc
 from compiler.transforms.stream_snaxify import StreamSnaxify
+from compiler.transforms.guarded_linalg_to_memref_stream import GuardedLinalgToMemrefStreamPass
 
 
 class SNAXOptMain(xDSLOptMain):
@@ -84,6 +85,8 @@ class SNAXOptMain(xDSLOptMain):
         )
         super().register_pass(StreamSnaxify.name, lambda: StreamSnaxify)
         super().register_pass(ReuseMemrefAllocs.name, lambda: ReuseMemrefAllocs)
+        super().register_pass(ScheduleMemrefLinalg.name, lambda: ScheduleMemrefLinalg)
+        super().register_pass(GuardedLinalgToMemrefStreamPass.name, lambda: GuardedLinalgToMemrefStreamPass)
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -19,7 +19,9 @@ from compiler.transforms.convert_linalg_to_accfg import (
 )
 from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
-from compiler.transforms.guarded_linalg_to_memref_stream import GuardedLinalgToMemrefStreamPass
+from compiler.transforms.guarded_linalg_to_memref_stream import (
+    GuardedLinalgToMemrefStreamPass,
+)
 from compiler.transforms.insert_accfg_op import InsertAccOp
 from compiler.transforms.insert_sync_barrier import InsertSyncBarrier
 from compiler.transforms.linalg_to_library_call import LinalgToLibraryCall
@@ -85,7 +87,10 @@ class SNAXOptMain(xDSLOptMain):
         )
         super().register_pass(StreamSnaxify.name, lambda: StreamSnaxify)
         super().register_pass(ReuseMemrefAllocs.name, lambda: ReuseMemrefAllocs)
-        super().register_pass(GuardedLinalgToMemrefStreamPass.name, lambda: GuardedLinalgToMemrefStreamPass)
+        super().register_pass(
+            GuardedLinalgToMemrefStreamPass.name,
+            lambda: GuardedLinalgToMemrefStreamPass,
+        )
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/transforms/guarded_linalg_to_memref_stream.py
+++ b/compiler/transforms/guarded_linalg_to_memref_stream.py
@@ -9,11 +9,13 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
-from xdsl.transforms.convert_linalg_to_memref_stream import ConvertGenericOpPattern, ConvertYieldOpPattern
+from xdsl.transforms.convert_linalg_to_memref_stream import (
+    ConvertGenericOpPattern,
+    ConvertYieldOpPattern,
+)
 
 
 class GuardedGenericOpPattern(RewritePattern):
-
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: linalg.Generic, rewriter: PatternRewriter) -> None:
         """
@@ -25,10 +27,9 @@ class GuardedGenericOpPattern(RewritePattern):
         if not op.library_call:
             return
 
-        if op.library_call.data.endswith('_stream'):
-            op.library_call = StringAttr(op.library_call.data[:-len('_stream')])
+        if op.library_call.data.endswith("_stream"):
+            op.library_call = StringAttr(op.library_call.data[: -len("_stream")])
             ConvertGenericOpPattern().match_and_rewrite(op, rewriter)
-
 
 
 class GuardedLinalgToMemrefStreamPass(ModulePass):
@@ -36,6 +37,8 @@ class GuardedLinalgToMemrefStreamPass(ModulePass):
 
     def apply(self, ctx: MLContext, op: ModuleOp) -> None:
         PatternRewriteWalker(
-            GreedyRewritePatternApplier([GuardedGenericOpPattern(), ConvertYieldOpPattern()]),
+            GreedyRewritePatternApplier(
+                [GuardedGenericOpPattern(), ConvertYieldOpPattern()]
+            ),
             apply_recursively=False,
         ).rewrite_module(op)

--- a/compiler/transforms/guarded_linalg_to_memref_stream.py
+++ b/compiler/transforms/guarded_linalg_to_memref_stream.py
@@ -22,6 +22,8 @@ class GuardedGenericOpPattern(RewritePattern):
         This pattern is a guarded version of the pattern in upstream xDSL.
         This is required because we can't (or don't want to) lower all
         generic calls through the stream dialects.
+        It only matches on linalg.generics that have a library call with
+        a `_stream` suffix. This pass removes that suffix.
         """
 
         if not op.library_call:

--- a/compiler/transforms/guarded_linalg_to_memref_stream.py
+++ b/compiler/transforms/guarded_linalg_to_memref_stream.py
@@ -1,0 +1,41 @@
+from xdsl.context import MLContext
+from xdsl.dialects import linalg
+from xdsl.dialects.builtin import ModuleOp, StringAttr
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.transforms.convert_linalg_to_memref_stream import ConvertGenericOpPattern, ConvertYieldOpPattern
+
+
+class GuardedGenericOpPattern(RewritePattern):
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: linalg.Generic, rewriter: PatternRewriter) -> None:
+        """
+        This pattern is a guarded version of the pattern in upstream xDSL.
+        This is required because we can't (or don't want to) lower all
+        generic calls through the stream dialects.
+        """
+
+        if not op.library_call:
+            return
+
+        if op.library_call.data.endswith('_stream'):
+            op.library_call = StringAttr(op.library_call.data[:-len('_stream')])
+            ConvertGenericOpPattern().match_and_rewrite(op, rewriter)
+
+
+
+class GuardedLinalgToMemrefStreamPass(ModulePass):
+    name = "guarded-linalg-to-memref-stream"
+
+    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier([GuardedGenericOpPattern(), ConvertYieldOpPattern()]),
+            apply_recursively=False,
+        ).rewrite_module(op)

--- a/tests/filecheck/transforms/guarded-linalg-to-memref-stream.mlir
+++ b/tests/filecheck/transforms/guarded-linalg-to-memref-stream.mlir
@@ -1,0 +1,23 @@
+// RUN: ./compiler/snax-opt --split-input-file %s -p guarded-linalg-to-memref-stream | filecheck %s
+
+%0, %1, %2 = "test.op"() : () -> (memref<16xi64>, memref<16xi64>, memref<16xi64>)
+linalg.generic {library_call="snax_alu", indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%0, %1 : memref<16xi64>, memref<16xi64>) outs(%2 : memref<16xi64>) {
+^bb0(%in: i64, %in_0: i64, %out: i64):
+  %3 = arith.addi %in, %in_0 : i64
+  linalg.yield %3 : i64
+}
+
+// CHECK: linalg.generic
+// CHECK: library_call = "snax_alu"
+
+// -----
+
+%0, %1, %2 = "test.op"() : () -> (memref<16xi64>, memref<16xi64>, memref<16xi64>)
+linalg.generic {library_call="snax_alu_stream", indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%0, %1 : memref<16xi64>, memref<16xi64>) outs(%2 : memref<16xi64>) {
+^bb0(%in: i64, %in_0: i64, %out: i64):
+  %3 = arith.addi %in, %in_0 : i64
+  linalg.yield %3 : i64
+}
+
+// CHECK: memref_stream.generic
+// CHECK: library_call = "snax_alu"


### PR DESCRIPTION
Upstream xdsl converts all linalg.generic calls to memref.generic calls. We don't always want this. This pass adds an extra guard to only convert linalg.generic which are dispatched to an accelerator, appended with the _stream suffix. It then removes the suffix after the conversion is done.