### PR TITLE
dialects: (tsl) implement get_affine_map

### DIFF
--- a/compiler/dialects/tsl.py
+++ b/compiler/dialects/tsl.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from math import prod
 
 from xdsl.dialects.arith import Constant, DivUI, Muli
@@ -52,8 +51,10 @@ class TiledStridedLayoutAttr(MemrefLayoutAttr, Data[TiledStridedLayout]):
             for depth in range(max_depth):
                 strides = self.data.tstrides[dim].strides
                 mod = prod([stride.bound for stride in strides[depth:] if stride.bound])
-                fdiv = prod([stride.bound for stride in strides[depth + 1:] if stride.bound])
-                assert (step := self.data.get_stride(dim,depth).step)
+                fdiv = prod(
+                    [stride.bound for stride in strides[depth + 1 :] if stride.bound]
+                )
+                assert (step := self.data.get_stride(dim, depth).step)
                 if depth > 0:
                     result += step * ((AffineDimExpr(dim) % mod) // fdiv)
                 else:

--- a/compiler/dialects/tsl.py
+++ b/compiler/dialects/tsl.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from math import prod
 
 from xdsl.dialects.arith import Constant, DivUI, Muli
@@ -11,7 +12,7 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.dialects.memref import Dim, ExtractStridedMetaDataOp
 from xdsl.ir import Data, Dialect, Operation, SSAValue
-from xdsl.ir.affine import AffineMap
+from xdsl.ir.affine import AffineConstantExpr, AffineDimExpr, AffineMap
 from xdsl.irdl import (
     irdl_attr_definition,
 )
@@ -38,7 +39,26 @@ class TiledStridedLayoutAttr(MemrefLayoutAttr, Data[TiledStridedLayout]):
         printer.print_string(f"<{self.data}>")
 
     def get_affine_map(self) -> AffineMap:
-        raise NotImplementedError("Still to do!")
+        if self.data.is_dynamic():
+            raise NotImplementedError("Dynamic case is not implemented yet!")
+
+        # TODO: the affine map should result in element offset, not byte offset
+        # i will probably transition the tsl definition to element offset
+        # as well, to make everything more convenien
+
+        result = AffineConstantExpr(0)
+        for dim in range(self.data.dimension()):
+            max_depth = self.data.tstrides[dim].depth()
+            for depth in range(max_depth):
+                strides = self.data.tstrides[dim].strides
+                mod = prod([stride.bound for stride in strides[depth:] if stride.bound])
+                fdiv = prod([stride.bound for stride in strides[depth + 1:] if stride.bound])
+                assert (step := self.data.get_stride(dim,depth).step)
+                if depth > 0:
+                    result += step * ((AffineDimExpr(dim) % mod) // fdiv)
+                else:
+                    result += step * (AffineDimExpr(dim) // fdiv)
+        return AffineMap(self.data.dimension(), 0, (result,))
 
     def get_bound_ops(
         self, memref_op_or_shapes: SSAValue | Operation | list[Operation]

--- a/compiler/dialects/tsl.py
+++ b/compiler/dialects/tsl.py
@@ -43,7 +43,7 @@ class TiledStridedLayoutAttr(MemrefLayoutAttr, Data[TiledStridedLayout]):
 
         # TODO: the affine map should result in element offset, not byte offset
         # i will probably transition the tsl definition to element offset
-        # as well, to make everything more convenien
+        # as well, to make everything more convenient
 
         result = AffineConstantExpr(0)
         for dim in range(self.data.dimension()):

--- a/compiler/ir/tsl/README.md
+++ b/compiler/ir/tsl/README.md
@@ -46,3 +46,25 @@ For example, if dealing with a 64x64 matrix, the layout would be adjusted accord
 `#tsl.tsl<[16, 4] -> (32, 4), [16, 4] -> (?, 1)>`
 
 Here, the missing stride is calculated as 32x16=512. This adjustment ensures that the dynamic shapes remain consistent with the fixed tile sizes and strides while accommodating the overall matrix dimensions.
+
+## Conversion to an affine map
+
+The TSL Layout attribute can be translated to an affine map, in the following manner:
+
+
+For a TSL with bounds
+
+$$
+    \left[b_{0,M}, ..., b_{0,1}, b_{0, 0}\right], \left[b_{1,K}, ..., b_{1,1}, b_{1, 0}\right], ...
+    $$
+
+and tiled strides for every dim $d$:
+
+$$
+    \left[b_{d,M}, ..., b_{d,1}, b_{d, 0}\right] \rightarrow \left(s_{d,M}, ..., s_{d,1}, s_{d, 0}\right)
+$$
+
+The affine map for a tsl of dim $N$ and depth $M$ is given by:
+
+$$(i_0, i_1, ..., i_n) \rightarrow
+\sum_{n=0}^{N-1}\sum_{m=0}^{M-1} s_{n,m} \cdot \left\lfloor\left( i_n \bmod \prod_{k=0}^{m}b_{n,k} \right) \div \prod_{k=0}^{m-1}b_{n,k}\right\rfloor$$

--- a/tests/dialects/test_tsl.py
+++ b/tests/dialects/test_tsl.py
@@ -37,7 +37,6 @@ def test_tsl_attr_get_affine(example_tsl_attr):
     tsl = example_tsl_attr
     breakpoint()
     map = canonicalize_map(tsl.get_affine_map())
-    # turns out it is very difficult to check the equality of affine maps :(
     assert map == AffineMap.from_callable(
         lambda d0, d1: (
             (((((d0 // 4) * 32) + ((d0 % 4) * 4)) + ((d1 // 4) * 16)) + (d1 % 4)),

--- a/tests/dialects/test_tsl.py
+++ b/tests/dialects/test_tsl.py
@@ -39,5 +39,7 @@ def test_tsl_attr_get_affine(example_tsl_attr):
     map = canonicalize_map(tsl.get_affine_map())
     # turns out it is very difficult to check the equality of affine maps :(
     assert map == AffineMap.from_callable(
-        lambda d0, d1: ((((((d0 // 4) * 32) + ((d0 % 4) * 4)) + ((d1 // 4) * 16)) + (d1 % 4)),)
+        lambda d0, d1: (
+            (((((d0 // 4) * 32) + ((d0 % 4) * 4)) + ((d1 // 4) * 16)) + (d1 % 4)),
+        )
     )

--- a/tests/dialects/test_tsl.py
+++ b/tests/dialects/test_tsl.py
@@ -35,7 +35,6 @@ def test_tsl_attr_constructor(example_tsl_attr):
 
 def test_tsl_attr_get_affine(example_tsl_attr):
     tsl = example_tsl_attr
-    breakpoint()
     map = canonicalize_map(tsl.get_affine_map())
     assert map == AffineMap.from_callable(
         lambda d0, d1: (

--- a/tests/dialects/test_tsl.py
+++ b/tests/dialects/test_tsl.py
@@ -1,9 +1,11 @@
 import pytest
+from xdsl.ir.affine import AffineMap
 
 from compiler.dialects.tsl import TiledStridedLayoutAttr
 from compiler.ir.tsl.stride import Stride
 from compiler.ir.tsl.tiled_stride import TiledStride
 from compiler.ir.tsl.tiled_strided_layout import TiledStridedLayout
+from compiler.util.canonicalize_affine import canonicalize_map
 
 
 @pytest.fixture()
@@ -29,3 +31,13 @@ def test_tsl_attr_constructor(example_tsl_attr):
     tsl = example_tsl_attr
     assert isinstance(tsl, TiledStridedLayoutAttr)
     assert isinstance(tsl.data, TiledStridedLayout)
+
+
+def test_tsl_attr_get_affine(example_tsl_attr):
+    tsl = example_tsl_attr
+    breakpoint()
+    map = canonicalize_map(tsl.get_affine_map())
+    # turns out it is very difficult to check the equality of affine maps :(
+    assert map == AffineMap.from_callable(
+        lambda d0, d1: ((((((d0 // 4) * 32) + ((d0 % 4) * 4)) + ((d1 // 4) * 16)) + (d1 % 4)),)
+    )


### PR DESCRIPTION
 To be able to stream-snaxify, we must have an affine mapping from data to memory. This implements this for TSL layouts, such that these are supported as well as NoneAttr and StridedLayoutAttr.

One caveat is that the definition of `get_affine` is to return the element offset. TSL returns the byte offset. In hindsight, I will probably refactor tsl layouts to use element offset instead at a later stage, once the dust settles.

For a TSL with bounds

$$
    \left[b_{0,M}, ..., b_{0,1}, b_{0, 0}\right], \left[b_{1,K}, ..., b_{1,1}, b_{1, 0}\right], ...
    $$

and tiled strides for every dim $d$:

$$
    \left[b_{d,M}, ..., b_{d,1}, b_{d, 0}\right] \rightarrow \left(s_{d,M}, ..., s_{d,1}, s_{d, 0}\right)
$$

The affine map is given by:

$$(i_0, i_1, ..., i_n) \rightarrow
\sum_{n=0}^{N-1}\sum_{m=0}^{M-1} s_{n,m} \cdot \left\lfloor\left( i_n \bmod \prod_{k=0}^{m}b_{n,k} \right) \div \prod_{k=0}^{m-1}b_{n,k}\right\rfloor$$