### PR TITLE
Add gemmini Loop WS kernel support through ACCFG

### DIFF
--- a/.github/workflows/build-run-kernel.yml
+++ b/.github/workflows/build-run-kernel.yml
@@ -22,4 +22,4 @@ jobs:
         working-directory: kernels/${{ matrix.kernel }}
     strategy:
       matrix:
-        kernel: [simple_mult, simple_copy, transform_copy, streamer_alu, tiled_add, streamer_matmul]
+        kernel: [simple_mult, simple_copy, transform_copy, streamer_alu, tiled_add, streamer_matmul, gemmini]

--- a/compiler/accelerators/gemmini.py
+++ b/compiler/accelerators/gemmini.py
@@ -1,5 +1,6 @@
 from compiler.accelerators.rocc import RoCCAccelerator
 from compiler.dialects import accfg
+from compiler.util.pack_bitlist import pack_bitlist
 
 
 class GemminiAccelerator(RoCCAccelerator):
@@ -7,14 +8,14 @@ class GemminiAccelerator(RoCCAccelerator):
 
     fields = {
         "k_LOOP_WS_CONFIG_BOUNDS.rs1": 9,
-        "k_LOOP_WS_CONFIG_ADDRS_AB.rs1": 10,
-        "k_LOOP_WS_CONFIG_ADDRS_DC.rs1": 11,
-        "k_LOOP_WS_CONFIG_STRIDES_AB.rs1": 12,
-        "k_LOOP_WS_CONFIG_STRIDES_DC.rs1": 13,
         "k_LOOP_WS_CONFIG_BOUNDS.rs2": 9,
+        "k_LOOP_WS_CONFIG_ADDRS_AB.rs1": 10,
         "k_LOOP_WS_CONFIG_ADDRS_AB.rs2": 10,
+        "k_LOOP_WS_CONFIG_ADDRS_DC.rs1": 11,
         "k_LOOP_WS_CONFIG_ADDRS_DC.rs2": 11,
+        "k_LOOP_WS_CONFIG_STRIDES_AB.rs1": 12,
         "k_LOOP_WS_CONFIG_STRIDES_AB.rs2": 12,
+        "k_LOOP_WS_CONFIG_STRIDES_DC.rs1": 13,
         "k_LOOP_WS_CONFIG_STRIDES_DC.rs2": 13,
     }
 
@@ -42,3 +43,61 @@ class GemminiAccelerator(RoCCAccelerator):
             0x0BAD,  # Gemmini appears to work synchronously,
             # and does not have a separate await instruction
         )
+
+    def _gemmini_loop_ws(self):
+        # Make lists for constructors of accfg ops
+        ops_to_insert = []
+        ops_to_configure = []
+        ops_to_launch = []
+        # Insert hardcoded constants for now
+        constants = [
+            (2, 2, 2),  # pad_K, pad_J, pad_I
+            (2, 2, 2),  # K,J,I
+            (2),  # A,B
+            (2),
+            (2),  # D,C
+            (2),
+            (2),  # A_stride, B_stride
+            (2),
+            (2),  # D_stride, C_stride
+            (2),
+        ]
+        shifts = [
+            (32, 16, 0),  # pad_K, pad_J, pad_I
+            (32, 16, 0),  # K,J,I
+            (0),  # A,B
+            (0),
+            (0),  # D,C
+            (0),
+            (0),  # A_stride, B_stride
+            (0),
+            (0),  # D_stride, C_stride
+            (0),
+        ]
+        # Pack bits together if necessary for configuration ops
+        for shifts, constants in zip(shifts, constants):
+            ops = list(pack_bitlist(values=constants, offsets=shifts, dtype=64))
+            ops_to_insert.append(ops[:-1])
+            ops_to_configure.append(ops[-1])
+
+        # Insert hardcoded constants for now
+        launch_constants = [
+            (0, 0, 0),  # act, low_D, full_C
+            (0, 0),  # A_transpose, B_transpose
+        ]
+        launch_shifts = [
+            (2, 1, 0),
+            (1, 0),
+        ]
+
+        # Pack bits together for launch ops
+        for shifts, constants in zip(launch_shifts, launch_constants):
+            ops = list(pack_bitlist(values=constants, offsets=shifts, dtype=64))
+            ops_to_insert.append(ops[:-1])
+            ops_to_launch.append(ops[-1])
+        return [
+            *ops_to_insert,
+            setup := accfg.SetupOp(ops_to_configure, self.fields, self.name),
+            token := accfg.LaunchOp(ops_to_launch, self.launch_fields, setup),
+            accfg.AwaitOp(token),
+        ]

--- a/compiler/accelerators/gemmini.py
+++ b/compiler/accelerators/gemmini.py
@@ -131,19 +131,11 @@ class GemminiAccelerator(RoCCAccelerator):
         pointer_values = []
         stride_values = []
         for operand in a, b, c:
-            if operand == a or operand == b:
-                no_bytes = 1
-            else:  # operand == c:
-                no_bytes = 4
             ops_to_insert.extend(
                 [
                     metadata := memref.ExtractStridedMetaDataOp(operand),
                     pointer := memref.ExtractAlignedPointerAsIndexOp.get(operand),
-                    cst_no_bytes := arith.Constant.from_int_and_width(
-                        no_bytes, IndexType()
-                    ),
-                    divided_offset := arith.Muli(metadata.offset, cst_no_bytes),
-                    offset_ptr := arith.Addi(pointer, divided_offset),
+                    offset_ptr := arith.Addi(pointer, metadata.offset),
                     offset_ptr_i64 := arith.IndexCastOp(offset_ptr, i64),
                     # Only add stride at index 0 for our experiments
                     stride_i64 := arith.IndexCastOp(metadata.strides[0], i64),

--- a/compiler/accelerators/gemmini.py
+++ b/compiler/accelerators/gemmini.py
@@ -1,3 +1,8 @@
+from collections.abc import Sequence
+
+from xdsl.dialects import arith, linalg
+from xdsl.ir import Operation
+
 from compiler.accelerators.rocc import RoCCAccelerator
 from compiler.dialects import accfg
 from compiler.util.pack_bitlist import pack_bitlist
@@ -44,60 +49,100 @@ class GemminiAccelerator(RoCCAccelerator):
             # and does not have a separate await instruction
         )
 
-    def _gemmini_loop_ws(self):
+    def _gemmini_loop_ws(
+        self,
+        pad_K,
+        pad_J,
+        pad_I,
+        K,
+        J,
+        I,
+        A,
+        B,
+        D,
+        C,
+        A_stride,
+        B_stride,
+        D_stride,
+        C_stride,
+    ):
         # Make lists for constructors of accfg ops
         ops_to_insert = []
         ops_to_configure = []
         ops_to_launch = []
         # Insert hardcoded constants for now
         constants = [
-            (2, 2, 2),  # pad_K, pad_J, pad_I
-            (2, 2, 2),  # K,J,I
-            (2),  # A,B
-            (2),
-            (2),  # D,C
-            (2),
-            (2),  # A_stride, B_stride
-            (2),
-            (2),  # D_stride, C_stride
-            (2),
+            [pad_K, pad_J, pad_I],  # pad_K, pad_J, pad_I
+            [K, J, I],  # K,J,I
+            [A],  # A,B
+            [B],
+            [D],  # D,C
+            [C],
+            [A_stride],  # A_stride, B_stride
+            [B_stride],
+            [D_stride],  # D_stride, C_stride
+            [C_stride],
         ]
         shifts = [
-            (32, 16, 0),  # pad_K, pad_J, pad_I
-            (32, 16, 0),  # K,J,I
-            (0),  # A,B
-            (0),
-            (0),  # D,C
-            (0),
-            (0),  # A_stride, B_stride
-            (0),
-            (0),  # D_stride, C_stride
-            (0),
+            [32, 16, 0],  # pad_K, pad_J, pad_I
+            [32, 16, 0],  # K,J,I
+            [0],  # A,B
+            [0],
+            [0],  # D,C
+            [0],
+            [0],  # A_stride, B_stride
+            [0],
+            [0],  # D_stride, C_stride
+            [0],
         ]
         # Pack bits together if necessary for configuration ops
-        for shifts, constants in zip(shifts, constants):
-            ops = list(pack_bitlist(values=constants, offsets=shifts, dtype=64))
-            ops_to_insert.append(ops[:-1])
-            ops_to_configure.append(ops[-1])
+        for shift_vals, constant_vals in zip(shifts, constants):
+            ops = list(pack_bitlist(values=constant_vals, offsets=shift_vals, dtype=64))
+            ops_to_insert.extend(ops)
+            ops_to_configure.extend(ops[-1].results)
 
         # Insert hardcoded constants for now
         launch_constants = [
-            (0, 0, 0),  # act, low_D, full_C
-            (0, 0),  # A_transpose, B_transpose
+            [0, 0, 0],  # act, low_D, full_C
+            [0, 0],  # A_transpose, B_transpose
         ]
         launch_shifts = [
-            (2, 1, 0),
-            (1, 0),
+            [2, 1, 0],
+            [1, 0],
         ]
 
         # Pack bits together for launch ops
-        for shifts, constants in zip(launch_shifts, launch_constants):
-            ops = list(pack_bitlist(values=constants, offsets=shifts, dtype=64))
-            ops_to_insert.append(ops[:-1])
-            ops_to_launch.append(ops[-1])
+        for shift_vals, constant_vals in zip(launch_shifts, launch_constants):
+            ops = list(pack_bitlist(values=constant_vals, offsets=shift_vals, dtype=64))
+            ops_to_insert.extend(ops)
+            ops_to_launch.extend(ops[-1].results)
+
         return [
             *ops_to_insert,
             setup := accfg.SetupOp(ops_to_configure, self.fields, self.name),
             token := accfg.LaunchOp(ops_to_launch, self.launch_fields, setup),
             accfg.AwaitOp(token),
+        ]
+
+    def convert_to_acc_ops(self, op: linalg.Generic) -> Sequence[Operation]:
+        cst_0 = arith.Constant.from_int_and_width(0, 64)
+
+        return [
+            cst_0,
+            *self._gemmini_loop_ws(
+                cst_0,
+                cst_0,
+                cst_0,
+                cst_0,
+                cst_0,
+                cst_0,
+                cst_0,
+                cst_0,
+                cst_0,
+                cst_0,
+                cst_0,
+                cst_0,
+                cst_0,
+                cst_0,
+            ),
         ]

--- a/compiler/accelerators/gemmini.py
+++ b/compiler/accelerators/gemmini.py
@@ -142,7 +142,7 @@ class GemminiAccelerator(RoCCAccelerator):
                     cst_no_bytes := arith.Constant.from_int_and_width(
                         no_bytes, IndexType()
                     ),
-                    divided_offset := arith.DivUI(metadata.offset, cst_no_bytes),
+                    divided_offset := arith.Muli(metadata.offset, cst_no_bytes),
                     offset_ptr := arith.Addi(pointer, divided_offset),
                     offset_ptr_i64 := arith.IndexCastOp(offset_ptr, i64),
                     # Only add stride at index 0 for our experiments

--- a/compiler/accelerators/gemmini.py
+++ b/compiler/accelerators/gemmini.py
@@ -126,7 +126,6 @@ class GemminiAccelerator(RoCCAccelerator):
         ]
 
     def convert_to_acc_ops(self, op: linalg.Generic) -> Sequence[Operation]:
-        breakpoint()
         a, b, _, _, c = op.operands  # Don't use zero point adjustments
         ops_to_insert = []
         pointer_values = []

--- a/kernels/gemmini/Makefile
+++ b/kernels/gemmini/Makefile
@@ -13,9 +13,7 @@ CFLAGS += -Wall -Wextra
 SNAXOPTACCFLAGS = -p insert-accfg-op{accelerator=gemmini},convert-linalg-to-accfg,convert-accfg-to-csr
 
 tiled_matmul.mlir: tiled_matmul.transform.mlir
-	# Use quick patch to remove transform module
-	${MLIROPT} --pass-pipeline='builtin.module(transform-interpreter, test-transform-dialect-erase-schedule)' $^ | sed '/^  module @transforms attributes {transform.with_named_sequence} {$$/,/^  }$$/d' > $@
-
+	${MLIROPT} --pass-pipeline='builtin.module(test-transform-dialect-interpreter{bind-first-extra-to-ops=linalg.quantized_matmul}, test-transform-dialect-erase-schedule, linalg-generalize-named-ops)' $^ | sed -E 's/iterator_types =/library_call="gemmini", iterator_types =/gm;t' > $@
 
 %.acc-dialect.snax-opt.mlir: %.preprocfinal.mlir
 	$(SNAXOPT) $(SNAXOPTACCFLAGS) -o $@ $<
@@ -32,6 +30,7 @@ tiled_matmul.mlir: tiled_matmul.transform.mlir
 %.x: %.ll
 	${CC} -x ir $< -c -O3 -o $@ -Wno-override-module --target=riscv64-unknown-elf -mcpu=generic-rv64 -march=rv64gc
 
+allrun: all
 
 all: $(TESTS)
 

--- a/kernels/gemmini/Makefile
+++ b/kernels/gemmini/Makefile
@@ -10,7 +10,7 @@ CFLAGS += -Wall -Wextra
 
 
 # Override snax-opt rules to avoid linalg-to-library-call pass
-SNAXOPTACCFLAGS = -p insert-accfg-op{accelerator=gemmini},convert-linalg-to-accfg #,convert-accfg-to-csr
+SNAXOPTACCFLAGS = -p insert-accfg-op{accelerator=gemmini},convert-linalg-to-accfg,convert-accfg-to-csr
 
 tiled_matmul.mlir: tiled_matmul.transform.mlir
 	# Use quick patch to remove transform module
@@ -18,26 +18,26 @@ tiled_matmul.mlir: tiled_matmul.transform.mlir
 
 
 %.acc-dialect.snax-opt.mlir: %.preprocfinal.mlir
-	echo lol
 	$(SNAXOPT) $(SNAXOPTACCFLAGS) -o $@ $<
 
-data.c data.h:
-	$(PYTHON) gendata.py
+%.postproc.mlir: %.snax-opt.mlir
+	cat $< | sed 's/arith.maximumf/arith.maxf/g' | sed 's/arith.minimumf/arith.minf/g' > $@
 
-%.x: %.o main.o data.o
-	$(LD) $(LDFLAGS) $^ -o $@
+%.ll.mlir: %.postproc.mlir
+	${MLIROPT} --test-lower-to-llvm -o $@ $<
 
-sim_%: %
-	rm -fr ./logs/
-	$(VLTSIM) $<
+%.ll: %.postproc.mlir
+	${MLIRTRANSLATE} --mlir-to-llvmir -o $@ $<
 
-RUN = $(addprefix run_, $(TESTS))
-$(RUN): run_%: sim_%
-	mv logs $(subst sim_,,$<).logs
+%.x: %.ll
+	cat $< | ${CC} -x ir - -c -O3 -o $@ -Wno-override-module --target=riscv64-unknown-elf -mcpu=generic-rv64 -march=rv64gc
+
 
 all: $(TESTS)
 
-allrun: $(RUN)
+dump: $(TESTS)
+	${OBJDUMP} -d $<
+
 
 clean:
 	rm -fr *.ll12 *.x *.o *.logs/ logs/ data.h data.c

--- a/kernels/gemmini/Makefile
+++ b/kernels/gemmini/Makefile
@@ -1,0 +1,43 @@
+.DEFAULT_GOAL := all
+
+include ../../runtime/Makefile.rules
+
+TESTS =
+TESTS += tiled_matmul.acc-dialect.x
+
+CFLAGS += -std=gnu11
+CFLAGS += -Wall -Wextra
+
+
+# Override snax-opt rules to avoid linalg-to-library-call pass
+SNAXOPTACCFLAGS = -p insert-accfg-op{accelerator=gemmini},convert-linalg-to-accfg #,convert-accfg-to-csr
+
+tiled_matmul.mlir: tiled_matmul.transform.mlir
+	# Use quick patch to remove transform module
+	${MLIROPT} --pass-pipeline='builtin.module(transform-interpreter, test-transform-dialect-erase-schedule)' $^ | sed '/^  module @transforms attributes {transform.with_named_sequence} {$$/,/^  }$$/d' > $@
+
+
+%.acc-dialect.snax-opt.mlir: %.preprocfinal.mlir
+	echo lol
+	$(SNAXOPT) $(SNAXOPTACCFLAGS) -o $@ $<
+
+data.c data.h:
+	$(PYTHON) gendata.py
+
+%.x: %.o main.o data.o
+	$(LD) $(LDFLAGS) $^ -o $@
+
+sim_%: %
+	rm -fr ./logs/
+	$(VLTSIM) $<
+
+RUN = $(addprefix run_, $(TESTS))
+$(RUN): run_%: sim_%
+	mv logs $(subst sim_,,$<).logs
+
+all: $(TESTS)
+
+allrun: $(RUN)
+
+clean:
+	rm -fr *.ll12 *.x *.o *.logs/ logs/ data.h data.c

--- a/kernels/gemmini/Makefile
+++ b/kernels/gemmini/Makefile
@@ -30,7 +30,7 @@ tiled_matmul.mlir: tiled_matmul.transform.mlir
 	${MLIRTRANSLATE} --mlir-to-llvmir -o $@ $<
 
 %.x: %.ll
-	cat $< | ${CC} -x ir - -c -O3 -o $@ -Wno-override-module --target=riscv64-unknown-elf -mcpu=generic-rv64 -march=rv64gc
+	${CC} -x ir $< -c -O3 -o $@ -Wno-override-module --target=riscv64-unknown-elf -mcpu=generic-rv64 -march=rv64gc
 
 
 all: $(TESTS)

--- a/kernels/gemmini/tiled_matmul.transform.mlir
+++ b/kernels/gemmini/tiled_matmul.transform.mlir
@@ -1,0 +1,27 @@
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> ()>
+#map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
+module {
+  func.func @gemmini_matmul(%arg0: memref<128x128xi8>, %arg1: memref<128x128xi8>, %arg2: memref<128x128xi32>, %arg3: memref<128x128xi32>) {
+    %c0_i32 = arith.constant 0 : i32
+    linalg.generic {indexing_maps = [#map, #map1, #map2, #map2, #map3], iterator_types = ["parallel", "parallel", "reduction"], first, library_call="gemmini"} ins(%arg0, %arg1, %c0_i32, %c0_i32 : memref<128x128xi8>, memref<128x128xi8>, i32, i32) outs(%arg2 : memref<128x128xi32>) {
+    ^bb0(%in: i8, %in_0: i8, %in_1: i32, %in_2: i32, %out: i32):
+      %0 = arith.extsi %in : i8 to i32
+      %1 = arith.subi %0, %in_1 : i32
+      %2 = arith.extsi %in_0 : i8 to i32
+      %3 = arith.subi %2, %in_2 : i32
+      %4 = arith.muli %1, %3 : i32
+      %5 = arith.addi %out, %4 : i32
+      linalg.yield %5 : i32
+    }
+    return
+  }
+  module @transforms attributes {transform.with_named_sequence} {
+    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+      %0 = transform.structured.match attributes {first} in %arg0 : (!transform.any_op) -> !transform.any_op
+      %tiled_linalg_op, %loops:3 = transform.structured.tile_using_for %0 [80, 96, 128] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+      transform.yield 
+    }
+  }
+}

--- a/kernels/gemmini/tiled_matmul.transform.mlir
+++ b/kernels/gemmini/tiled_matmul.transform.mlir
@@ -1,27 +1,15 @@
-#map = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
-#map2 = affine_map<(d0, d1, d2) -> ()>
-#map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
-module {
-  func.func @gemmini_matmul(%arg0: memref<128x128xi8>, %arg1: memref<128x128xi8>, %arg2: memref<128x128xi32>, %arg3: memref<128x128xi32>) {
-    %c0_i32 = arith.constant 0 : i32
-    linalg.generic {indexing_maps = [#map, #map1, #map2, #map2, #map3], iterator_types = ["parallel", "parallel", "reduction"], first, library_call="gemmini"} ins(%arg0, %arg1, %c0_i32, %c0_i32 : memref<128x128xi8>, memref<128x128xi8>, i32, i32) outs(%arg2 : memref<128x128xi32>) {
-    ^bb0(%in: i8, %in_0: i8, %in_1: i32, %in_2: i32, %out: i32):
-      %0 = arith.extsi %in : i8 to i32
-      %1 = arith.subi %0, %in_1 : i32
-      %2 = arith.extsi %in_0 : i8 to i32
-      %3 = arith.subi %2, %in_2 : i32
-      %4 = arith.muli %1, %3 : i32
-      %5 = arith.addi %out, %4 : i32
-      linalg.yield %5 : i32
-    }
-    return
-  }
-  module @transforms attributes {transform.with_named_sequence} {
-    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-      %0 = transform.structured.match attributes {first} in %arg0 : (!transform.any_op) -> !transform.any_op
-      %tiled_linalg_op, %loops:3 = transform.structured.tile_using_for %0 [80, 96, 128] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
-      transform.yield 
-    }
-  }
+func.func @tiled_matmul(%arg0: memref<128x128xi8>, %arg1: memref<128x128xi8>, %arg2: memref<128x128xi32>) {
+   %c0_i32 = arith.constant 0 : i32
+   linalg.quantized_matmul ins(%arg0, %arg1, %c0_i32, %c0_i32 : memref<128x128xi8>, memref<128x128xi8>, i32, i32) outs(%arg2 : memref<128x128xi32>)
+   return
+}
+
+
+transform.sequence failures(propagate) {
+^bb0(%arg0: !transform.any_op,
+     %arg1: !transform.op<"linalg.quantized_matmul">):
+  // The actual tiling transformation takes tile sizes as attributes.
+   %loop1, %loop2, %loop3, %tiled = transform.structured.tile %arg1 [80, 96, 128]
+    : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+  transform.yield
 }

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -9,6 +9,7 @@ CC            = $(SNITCH_LLVM_PATH)/clang$(LLVM_VERSION_POSTFIX)
 LD            = $(SNITCH_LLVM_PATH)/clang$(LLVM_VERSION_POSTFIX)
 AR            = $(SNITCH_LLVM_PATH)/llvm-ar$(LLVM_VERSION_POSTFIX)
 RANLIB        = $(SNITCH_LLVM_PATH)/llvm-ranlib$(LLVM_VERSION_POSTFIX)
+OBJDUMP       = $(SNITCH_LLVM_PATH)/llvm-objdump$(LLVM_VERSION_POSTFIX)
 DASM          = spike-dasm
 GENTRACE      = /opt/gen_trace.py
 MLIROPT       = mlir-opt-17

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -92,7 +92,7 @@ MLIRPREPROC2FLAGS += --empty-tensor-to-alloc-tensor
 
 MLIRPREPROC3FLAGS += --test-linalg-transform-patterns="test-generalize-pad-tensor"
 MLIRPREPROC3FLAGS += --linalg-generalize-named-ops
-MLIRPREPROC3FLAGS += --empty-tensor-to-alloc-tensor --one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"
+MLIRPREPROC3FLAGS += --empty-tensor-to-alloc-tensor --one-shot-bufferize="bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map"
 MLIRPREPROC3FLAGS += --mlir-print-op-generic
 MLIRPREPROC3FLAGS += --mlir-print-local-scope
 

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -93,7 +93,7 @@ MLIRPREPROC2FLAGS += --empty-tensor-to-alloc-tensor
 
 MLIRPREPROC3FLAGS += --test-linalg-transform-patterns="test-generalize-pad-tensor"
 MLIRPREPROC3FLAGS += --linalg-generalize-named-ops
-MLIRPREPROC3FLAGS += --empty-tensor-to-alloc-tensor --one-shot-bufferize="bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map allow-return-allocs-from-loops"
+MLIRPREPROC3FLAGS += --empty-tensor-to-alloc-tensor --one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"
 MLIRPREPROC3FLAGS += --mlir-print-op-generic
 MLIRPREPROC3FLAGS += --mlir-print-local-scope
 

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -93,7 +93,7 @@ MLIRPREPROC2FLAGS += --empty-tensor-to-alloc-tensor
 
 MLIRPREPROC3FLAGS += --test-linalg-transform-patterns="test-generalize-pad-tensor"
 MLIRPREPROC3FLAGS += --linalg-generalize-named-ops
-MLIRPREPROC3FLAGS += --empty-tensor-to-alloc-tensor --one-shot-bufferize="bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map"
+MLIRPREPROC3FLAGS += --empty-tensor-to-alloc-tensor --one-shot-bufferize="bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map allow-return-allocs-from-loops"
 MLIRPREPROC3FLAGS += --mlir-print-op-generic
 MLIRPREPROC3FLAGS += --mlir-print-local-scope
 

--- a/tests/filecheck/transforms/rocc-dedup.mlir
+++ b/tests/filecheck/transforms/rocc-dedup.mlir
@@ -22,7 +22,7 @@ builtin.module {
 
 
   func.func public @test() {
-    %t = arith.constant 32 : i32
+    %t = arith.constant 32 : i64
     %9 = "accfg.setup"(%t,%t,%t,%t,%t,%t,%t,%t,%t) <{"accelerator" = "gemmini", "operandSegmentSizes" = array<i32: 9, 0>, 
     "param_names" = [ "k_LOOP_WS_CONFIG_BOUNDS.rs1",
         "k_LOOP_WS_CONFIG_ADDRS_AB.rs1",
@@ -33,16 +33,16 @@ builtin.module {
         "k_LOOP_WS_CONFIG_ADDRS_AB.rs2",
         "k_LOOP_WS_CONFIG_ADDRS_DC.rs2",
         "k_LOOP_WS_CONFIG_STRIDES_DC.rs2"
-        ]}> : (i32, i32, i32, i32, i32, i32, i32, i32, i32) -> !accfg.state<"gemmini">
+        ]}> : (i64, i64, i64, i64, i64, i64, i64, i64, i64) -> !accfg.state<"gemmini">
 
 
     %10 = "accfg.launch"(%t,%t,%9) <{
     "param_names" = ["k_LOOP_WS.rs1", "k_LOOP_WS.rs2"],
-    "accelerator" = "gemmini"}> : (i32, i32, !accfg.state<"gemmini">) -> !accfg.token<"gemmini">
+    "accelerator" = "gemmini"}> : (i64, i64, !accfg.state<"gemmini">) -> !accfg.token<"gemmini">
     "accfg.await"(%10) : (!accfg.token<"gemmini">) -> ()
 
     // An arbitrary new value
-    %n = arith.constant 31 : i32
+    %n = arith.constant 31 : i64
     %11 = "accfg.setup"(%n,%n,%n,%n,%n,%9) <{"accelerator" = "gemmini", "operandSegmentSizes" = array<i32: 5, 1>, 
         "param_names" = [ "k_LOOP_WS_CONFIG_BOUNDS.rs1", // rs1 set, but rs2 not
         "k_LOOP_WS_CONFIG_ADDRS_AB.rs1",  // Both rs1 and rs2 set
@@ -50,10 +50,10 @@ builtin.module {
         "k_LOOP_WS_CONFIG_ADDRS_DC.rs2",  // rs2 set, but rs1 not
         "k_LOOP_WS_CONFIG_STRIDES_AB.rs2"   // rs2 set, but was never set before in this chain because of deduplication hoisting
         // strides are not set, so can be reused from the previous one.
-        ]}> : (i32, i32, i32, i32, i32, !accfg.state<"gemmini">) -> !accfg.state<"gemmini">
+        ]}> : (i64, i64, i64, i64, i64, !accfg.state<"gemmini">) -> !accfg.state<"gemmini">
     %12 = "accfg.launch"(%t,%t,%11) <{
     "param_names" = ["k_LOOP_WS.rs1", "k_LOOP_WS.rs2"],
-    "accelerator" = "gemmini"}> : (i32, i32, !accfg.state<"gemmini">) -> !accfg.token<"gemmini">
+    "accelerator" = "gemmini"}> : (i64, i64, !accfg.state<"gemmini">) -> !accfg.token<"gemmini">
       "accfg.await"(%12) : (!accfg.token<"gemmini">) -> ()
     func.return
   }
@@ -61,20 +61,20 @@ builtin.module {
 
 // CHECK: builtin.module {
 // CHECK-NEXT:   func.func public @test() {
-// CHECK-NEXT:     %t = arith.constant 32 : i32
+// CHECK-NEXT:     %t = arith.constant 32 : i64
 // CHECK-NEXT:     %0 = arith.constant 0 : i64
-// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 9 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
-// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 10 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
-// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 11 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
-// CHECK-NEXT:     "llvm.inline_asm"(%t, %0) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 12 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i64) -> ()
-// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 13 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
-// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 8 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
-// CHECK-NEXT:     %n = arith.constant 31 : i32
-// CHECK-NEXT:     "llvm.inline_asm"(%n, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 9 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
-// CHECK-NEXT:     "llvm.inline_asm"(%n, %n) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 10 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
-// CHECK-NEXT:     "llvm.inline_asm"(%t, %n) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 11 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
-// CHECK-NEXT:     "llvm.inline_asm"(%t, %n) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 12 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
-// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 8 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i32, i32) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 9 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i64) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 10 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i64) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 11 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i64) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %0) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 12 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i64) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 13 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i64) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 8 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i64) -> ()
+// CHECK-NEXT:     %n = arith.constant 31 : i64
+// CHECK-NEXT:     "llvm.inline_asm"(%n, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 9 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i64) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%n, %n) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 10 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i64) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %n) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 11 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i64) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %n) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 12 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i64) -> ()
+// CHECK-NEXT:     "llvm.inline_asm"(%t, %t) <{"asm_string" = ".insn r CUSTOM_3, 0x3, 8 ,x0, $0, $1", "constraints" = "r, r", "asm_dialect" = 0 : i64}> {"has_side_effects"} : (i64, i64) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }


### PR DESCRIPTION
This PR implements the following:
* A conversion from linalg generic to Gemmini's weight-stationary kernel
* A "temporary fix" to allow deduplicated RoCC code to be converted to CSRs.
Right now there is no way to create pairs if one of the pairs is deduplicated. 
The `create_pairs` function will try to catch the previous state to create a pair again, but this is not possible if only half of the pair is set in said previous state.
As a first fix, this test assumes all settings are set in pairs, and a constant default is appended to the very first setup op in the state chain (the one without an in_state). This makes sure that a default value is set to rs1 if rs2 is set - but not rs1 - and vice versa.  A more thorough fix for this actually might reset all values at first? Any suggestions welcome.
- [x] add test for this ^^