### PR TITLE
transform: schedule-memref-linalg pass

### DIFF
--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -28,6 +28,7 @@ from compiler.transforms.linalg_to_library_call import LinalgToLibraryCall
 from compiler.transforms.memref_to_snax import MemrefToSNAX
 from compiler.transforms.realize_memref_casts import RealizeMemrefCastsPass
 from compiler.transforms.reuse_memref_allocs import ReuseMemrefAllocs
+from compiler.transforms.schedule_memref_linalg import ScheduleMemrefLinalg
 from compiler.transforms.set_memory_layout import SetMemoryLayout
 from compiler.transforms.set_memory_space import SetMemorySpace
 from compiler.transforms.snax_copy_to_dma import SNAXCopyToDMA
@@ -91,6 +92,7 @@ class SNAXOptMain(xDSLOptMain):
             GuardedLinalgToMemrefStreamPass.name,
             lambda: GuardedLinalgToMemrefStreamPass,
         )
+        super().register_pass(ScheduleMemrefLinalg.name, lambda: ScheduleMemrefLinalg)
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/transforms/schedule_memref_linalg.py
+++ b/compiler/transforms/schedule_memref_linalg.py
@@ -114,6 +114,7 @@ class ScheduleMemrefLinalgRewriter(RewritePattern):
     Takes a memref_stream.generic op as input and wraps it in a memref_stream streaming region op
     to determine the access patterns, the operation is scheduled to an accelerator template.
     """
+
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref_stream.GenericOp, rewriter: PatternRewriter):
         if any(isinstance(operand.type, stream.StreamType) for operand in op.operands):

--- a/compiler/transforms/schedule_memref_linalg.py
+++ b/compiler/transforms/schedule_memref_linalg.py
@@ -1,0 +1,269 @@
+from xdsl.context import MLContext
+from xdsl.dialects import builtin, memref_stream, stream
+from xdsl.ir import Block, Region
+from xdsl.ir.affine import AffineConstantExpr, AffineDimExpr, AffineExpr, AffineMap
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import PatternRewriter, PatternRewriteWalker, RewritePattern, op_type_rewrite_pattern
+from xdsl.rewriter import InsertPoint
+
+from compiler.util.canonicalize_affine import canonicalize_map
+
+
+def disable_dims(map: AffineMap, dim: int) -> AffineMap:
+    """
+    Returns an affine map with the first `dim` dimensions set to 0
+
+    For example:
+        (d0, d1, d2) -> d0 + d1 + d2
+    For `dim` = 1, will return:
+        (d1, d2) -> d1 + d2
+    For `dim` = 2, will return:
+        (d2) -> d2
+    """
+    return canonicalize_map(
+        map.replace_dims_and_symbols(
+            [AffineConstantExpr(0) for _ in range(dim)] + [AffineDimExpr(i) for i in range(map.num_dims - dim)],
+            [],
+            map.num_dims - dim,
+            0,
+        )
+    )
+
+
+def rotate_dims(map: AffineMap, dim: int) -> AffineMap:
+    """
+    Returns an affine map with the first `dim` dimensions rotated
+
+    For example:
+        (d0, d1, d2) -> 1 * d0 + 2 * d1 + 3 * d2
+    For `dim` = 3, will return:
+        (d0, d1, d2) -> 3 * d0 + 1 * d1 + 2 * d2
+    For `dim` = 2, will return:
+        (d0, d1, d2) -> 2 * d0 + 1 * d1 + 3 * d2
+    """
+    new_dims = [AffineDimExpr(i) for i in range(dim)]
+    # rotate dims by popping first and appending
+    new_dims.append(new_dims.pop(0))
+    # keep remaining dims
+    new_dims = new_dims + [AffineDimExpr(i) for i in range(dim, map.num_dims)]
+    return canonicalize_map(map.replace_dims_and_symbols(new_dims, [], len(new_dims), 0))
+
+
+def rotate_bounds(bounds: list[int | None], dim: int) -> list[int | None]:
+    """
+    Returns the bounds after rotating dims, as in rotate_dims
+    """
+    bounds = bounds.copy()
+    bounds.insert(0, bounds.pop(dim -1))
+    return bounds
+
+
+def split_dim(map: AffineMap, dim: int, template_bound: int) -> AffineMap:
+    """
+    Returns the bounds and a new affine map with the `dim` dimension split up into two
+    This translates to creating two for loops with adjuste bounds from one for loop
+
+
+    For example:
+        (d0, d1, d2) -> d0 + d1 + d2
+    For `dim` = 1, `template_bound` = 2:
+        (d0, d1, d2, d3) -> d0 + 2 * d1 + d2 + d3
+    """
+    # 1 extra dimension
+    # create result map (d0, d1, ... dn)
+    new_results: list[AffineExpr] = [AffineDimExpr(i) for i in range(map.num_dims + 1)]
+    # pop the result at dim
+    dim_sum = new_results.pop(dim)
+    # add it to dim multiplied by original bound // max_bound
+    new_results[dim] = new_results[dim] + dim_sum * template_bound
+    transform_map = AffineMap(map.num_dims + 1, 0, tuple(new_results))
+
+    result = canonicalize_map(map.compose(transform_map))
+
+    return result
+
+
+def split_bounds(bounds: list[int | None], dim: int, template_bound: int) -> list[int | None]:
+    """
+    Returns the bounds after applying `split_dim` in similar fashion.
+
+    For example:
+        [2, 8, 2]
+    For `dim` = 1, `template_bound` = 2:
+        [2, 4, 2, 2]
+    """
+    bounds = bounds.copy()
+    bound = bounds[dim]
+    bounds[dim] = template_bound
+    bounds.insert(dim, bound // template_bound if bound else None)
+    return bounds
+
+
+class ScheduleMemrefLinalgRewriter(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: memref_stream.GenericOp, rewriter: PatternRewriter):
+        if any(isinstance(operand.type, stream.StreamType) for operand in op.operands):
+            # Already streamified
+            return
+
+        if not (isinstance(op.library_call, builtin.StringAttr) and op.library_call.data in ("snax_alu", "snax_gemm")):
+            raise NotImplementedError("panic!")
+
+        # only handle snax_alu for now
+        if op.library_call.data == "snax_alu":
+            template = [AffineMap.from_callable(lambda x, y: (4 * x + y,))] * 3
+            template_bounds = (None, 4)
+        elif op.library_call.data == "snax_gemm":
+            M, N, K, m, n, k = (AffineDimExpr(i) for i in range(6))
+            template = [
+                AffineMap(6, 0, (M * 8 + m, K * 8 + k)),
+                AffineMap(6, 0, (K * 8 + k, N * 8 + n)),
+                AffineMap(6, 0, (M * 8 + m, N * 8 + n)),
+            ]
+            template_bounds = (None, None, None, 8, 8, 8)
+        else:
+            raise RuntimeError("panic!")
+
+        # only take patterns of memref operands
+        schedule = [
+            imap.data for imap, op in zip(op.indexing_maps.data, op.operands) if isinstance(op.type, builtin.MemRefType)
+        ]
+
+        schedule_bounds: list[int | None] = [bound.value.data for bound in op.bounds.data]
+
+        for i in range(template[0].num_dims):
+            # i = 0: look at the last dimension
+            template_dim = template[0].num_dims - i - 1
+            schedule_dim = schedule[0].num_dims - i - 1
+            # i = 1: look at the second to last dimension
+            match = False
+
+            for it in range(schedule_dim + 1):
+                # keep rotating the remaining dimensions until we have a match
+
+                template_check = tuple(disable_dims(map, template_dim) for map in template)
+                schedule_check = tuple(disable_dims(map, schedule_dim) for map in schedule)
+
+                # print(f"i = {i}, template_dim = {template_dim}, schedule_dim = {schedule_dim}, attempt = {it}")
+
+                # for j in range(3):
+                #     print(f"schedule-{j}: {str(schedule[j])}")
+
+                # print(f"schedule-bounds: {schedule_bounds}")
+
+                # for j in range(3):
+                #     print(f"template-check-{j}: {str(template_check[j])}")
+
+                # for j in range(3):
+                #     print(f"schedule-check-{j}: {str(schedule_check[j])}")
+
+                # print(f"template_check == schedule_check: {template_check == schedule_check}")
+
+                # breakpoint()
+
+                if template_check == schedule_check:
+                    match = True
+                    break
+
+                # else rotate the for loops
+                schedule = tuple(rotate_dims(map, schedule_dim + 1) for map in schedule)
+                schedule_bounds = rotate_bounds(schedule_bounds, schedule_dim + 1)
+
+            if not match:
+                raise RuntimeError("failed to match template and schedule")
+
+            # now, check bounds and design potential transoformation map
+            if not (template_bound := template_bounds[template_dim]):
+                # nothing to worry about, continue to next dim
+                continue
+
+            schedule_bound = op.bounds.data[schedule_dim].value.data
+
+            if schedule_bound < template_bound:
+                # need to apply padding
+                raise NotImplementedError("padding not supported")
+            elif schedule_bound == template_bound:
+                # perfect!
+                # (i think?)
+                raise NotImplementedError("need to check behaviour in this case")
+            elif schedule_bound > template_bound:
+                # need to split up the schedule
+                assert schedule_bound % template_bound == 0
+                schedule = [split_dim(schedule_map, schedule_dim, template_bound) for schedule_map in schedule]
+                schedule_bounds = split_bounds(schedule_bounds, schedule_dim, template_bound)
+
+
+        # if we get here, we're lucky, because nothing broke yet :-)
+        # we have now successfully determined a schedule for the operator
+        # this is implemented with a memref streaming region
+        # the original op stays the same
+        # the indexing maps of that one are now pretty meaningless, but should
+        # not be looked at in following passes i think
+        #
+
+        input_streams = [
+            stream.ReadableStreamType(input.type.element_type)
+            for input in op.inputs
+            if isinstance(input.type, builtin.MemRefType)
+        ]
+
+        output_streams = [
+            stream.WritableStreamType(output.type.element_type)
+            for output in op.outputs
+            if isinstance(output.type, builtin.MemRefType)
+        ]
+
+        bounds_attr = builtin.ArrayAttr(
+            [builtin.IntegerAttr(val if val else -1, builtin.IndexType()) for val in schedule_bounds]
+        )
+        input_stride_patterns: list[memref_stream.StridePattern] = [
+            memref_stream.StridePattern(bounds_attr, builtin.AffineMapAttr(map)) for map in schedule
+        ]
+
+        streaming_region_op = memref_stream.StreamingRegionOp(
+            inputs=[input for input in op.inputs if isinstance(input.type, builtin.MemRefType)],
+            outputs=[output for output in op.outputs if isinstance(output.type, builtin.MemRefType)],
+            patterns=builtin.ArrayAttr(input_stride_patterns),
+            body=Region(Block(arg_types=input_streams + output_streams)),
+        )
+
+        streaming_args = list(streaming_region_op.body.block.args)
+        new_inputs = [
+            streaming_args.pop(0) if isinstance(input.type, builtin.MemRefType) else input for input in op.inputs
+        ]
+        new_outputs = [
+            streaming_args.pop(0) if isinstance(output.type, builtin.MemRefType) else output for output in op.outputs
+        ]
+
+
+        new_generic_op = memref_stream.GenericOp(
+            inputs=new_inputs,
+            outputs=new_outputs,
+            inits=op.inits,
+            body=rewriter.move_region_contents_to_new_regions(op.body),
+            indexing_maps=op.indexing_maps,
+            iterator_types=op.iterator_types,
+            bounds=op.bounds,
+            init_indices=op.init_indices,
+            doc=op.doc,
+            library_call=op.library_call,
+        )
+
+        rewriter.replace_matched_op(streaming_region_op)
+        rewriter.insert_op(new_generic_op, InsertPoint.at_end(streaming_region_op.body.block))
+
+
+class ScheduleMemrefLinalg(ModulePass):
+    """
+    A pass to schedule a memref stream according
+    to an accelerator definition. The result is
+    wraped in a memref streaming region op that
+    contains the resulting schedule. The linalg
+    operation itself remains unchanged. As it is
+    schedule agnostic.
+    """
+
+    name = "schedule-memref-linalg"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp):
+        PatternRewriteWalker(ScheduleMemrefLinalgRewriter(), apply_recursively=False).rewrite_module(op)

--- a/tests/filecheck/transforms/schedule-memref-linalg.mlir
+++ b/tests/filecheck/transforms/schedule-memref-linalg.mlir
@@ -1,0 +1,21 @@
+// RUN: ./compiler/snax-opt --split-input-file %s -p schedule-memref-linalg | filecheck %s
+
+builtin.module {
+  func.func public @streamer_add(%arg0 : memref<16xi64>, %arg1 : memref<16xi64>, %arg2 : memref<16xi64>) {
+    memref_stream.generic {
+      bounds = [16],
+      indexing_maps = [
+        affine_map<(d0) -> (d0)>,
+        affine_map<(d0) -> (d0)>,
+        affine_map<(d0) -> (d0)>
+      ],
+      iterator_types = ["parallel"],
+      library_call = "snax_alu"
+    } ins(%arg0, %arg1 : memref<16xi64>, memref<16xi64>) outs(%arg2 : memref<16xi64>) {
+    ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
+      %0 = arith.addi %arg3, %arg4 : i64
+      memref_stream.yield %0 : i64
+    }
+    func.return
+  }
+}

--- a/tests/filecheck/transforms/schedule-memref-linalg.mlir
+++ b/tests/filecheck/transforms/schedule-memref-linalg.mlir
@@ -25,3 +25,39 @@ builtin.module {
 //CHECK-NEXT:   #memref_stream.stride_pattern<ub = [4, 4], index_map = (d0, d1) -> (((d0 * 4) + d1))>,
 //CHECK-NEXT:   #memref_stream.stride_pattern<ub = [4, 4], index_map = (d0, d1) -> (((d0 * 4) + d1))>
 //CHECK-NEXT: ]
+
+// -----
+
+builtin.module {
+  func.func @streamer_matmul(%arg0 : memref<16x16xi8>, %arg1 : memref<16x16xi8, strided<[1, 16]>>, %arg2 : memref<16x16xi32>) {
+    %0 = arith.constant 0 : i32
+    memref_stream.generic {
+      bounds = [16, 16, 16],
+      indexing_maps = [
+        affine_map<(d0, d1, d2) -> (d0, d2)>,
+        affine_map<(d0, d1, d2) -> (d2, d1)>,
+        affine_map<(d0, d1, d2) -> ()>,
+        affine_map<(d0, d1, d2) -> ()>,
+        affine_map<(d0, d1, d2) -> (d0, d1)>
+      ],
+      iterator_types = ["parallel", "parallel", "reduction"],
+      library_call = "snax_gemm"
+    } ins(%arg0, %arg1, %0, %0 : memref<16x16xi8>, memref<16x16xi8, strided<[1, 16]>>, i32, i32) outs(%arg2 : memref<16x16xi32>) {
+    ^0(%arg3 : i8, %arg4 : i8, %arg5 : i32, %arg6 : i32, %arg7 : i32):
+      %1 = arith.extsi %arg3 : i8 to i32
+      %2 = arith.subi %1, %arg5 : i32
+      %3 = arith.extsi %arg4 : i8 to i32
+      %4 = arith.subi %3, %arg6 : i32
+      %5 = arith.muli %2, %4 : i32
+      %6 = arith.addi %arg7, %5 : i32
+      memref_stream.yield %6 : i32
+    }
+    func.return
+  }
+}
+
+//CHECK:      patterns = [
+//CHECK-NEXT:   #memref_stream.stride_pattern<ub = [2, 2, 2, 8, 8, 8], index_map = (d0, d1, d2, d3, d4, d5) -> (((d0 * 8) + d3), ((d2 * 8) + d5))>,
+//CHECK-NEXT:   #memref_stream.stride_pattern<ub = [2, 2, 2, 8, 8, 8], index_map = (d0, d1, d2, d3, d4, d5) -> (((d2 * 8) + d5), ((d1 * 8) + d4))>,
+//CHECK-NEXT:   #memref_stream.stride_pattern<ub = [2, 2, 2, 8, 8, 8], index_map = (d0, d1, d2, d3, d4, d5) -> (((d0 * 8) + d3), ((d1 * 8) + d4))>
+//CHECK-NEXT: ]

--- a/tests/filecheck/transforms/schedule-memref-linalg.mlir
+++ b/tests/filecheck/transforms/schedule-memref-linalg.mlir
@@ -19,3 +19,9 @@ builtin.module {
     func.return
   }
 }
+
+\\ CHECK:      indexing_maps = [
+\\ CHECK-NEXT:   affine_map<(d0, d1) -> (((d0 * 4) + d1))>,
+\\ CHECK-NEXT:   affine_map<(d0, d1) -> (((d0 * 4) + d1))>,
+\\ CHECK-NEXT:   affine_map<(d0, d1) -> (((d0 * 4) + d1))>
+\\ CHECK-NEXT: ],

--- a/tests/filecheck/transforms/schedule-memref-linalg.mlir
+++ b/tests/filecheck/transforms/schedule-memref-linalg.mlir
@@ -20,8 +20,8 @@ builtin.module {
   }
 }
 
-\\ CHECK:      indexing_maps = [
-\\ CHECK-NEXT:   affine_map<(d0, d1) -> (((d0 * 4) + d1))>,
-\\ CHECK-NEXT:   affine_map<(d0, d1) -> (((d0 * 4) + d1))>,
-\\ CHECK-NEXT:   affine_map<(d0, d1) -> (((d0 * 4) + d1))>
-\\ CHECK-NEXT: ],
+// CHECK:      indexing_maps = [
+// CHECK-NEXT:   affine_map<(d0, d1) -> (((d0 * 4) + d1))>,
+// CHECK-NEXT:   affine_map<(d0, d1) -> (((d0 * 4) + d1))>,
+// CHECK-NEXT:   affine_map<(d0, d1) -> (((d0 * 4) + d1))>
+// CHECK-NEXT: ],

--- a/tests/filecheck/transforms/schedule-memref-linalg.mlir
+++ b/tests/filecheck/transforms/schedule-memref-linalg.mlir
@@ -20,8 +20,8 @@ builtin.module {
   }
 }
 
-// CHECK:      indexing_maps = [
-// CHECK-NEXT:   affine_map<(d0, d1) -> (((d0 * 4) + d1))>,
-// CHECK-NEXT:   affine_map<(d0, d1) -> (((d0 * 4) + d1))>,
-// CHECK-NEXT:   affine_map<(d0, d1) -> (((d0 * 4) + d1))>
-// CHECK-NEXT: ],
+//CHECK:      patterns = [
+//CHECK-NEXT:   #memref_stream.stride_pattern<ub = [4, 4], index_map = (d0, d1) -> (((d0 * 4) + d1))>,
+//CHECK-NEXT:   #memref_stream.stride_pattern<ub = [4, 4], index_map = (d0, d1) -> (((d0 * 4) + d1))>,
+//CHECK-NEXT:   #memref_stream.stride_pattern<ub = [4, 4], index_map = (d0, d1) -> (((d0 * 4) + d1))>
+//CHECK-NEXT: ]


### PR DESCRIPTION
This PR adds the first version of the schedule-memref-linalg pass.
This pass matches and transforms an operation on an accelerator template.

At this stage, this is quite barebones, and only functional for easy examples (elementwise operation on elementwise snax-alu accelerator/ gemm operation on gemm accelerator).

This document is an effort to explain its workings at the current stage.
[schedule-memref-linalg.pdf](https://github.com/user-attachments/files/16744943/schedule-memref-linalg.pdf)

Many improvements to this algorithm will come very shortly :)
