### PR TITLE
transform: (stream-snaxify) accelerator attribute hoisting

### DIFF
--- a/compiler/transforms/stream_snaxify.py
+++ b/compiler/transforms/stream_snaxify.py
@@ -43,7 +43,7 @@ class HoistAcceleratorAttribute(RewritePattern):
 
             if accelerator and inner_op.library_call != accelerator:
                 raise RuntimeError(
-                    "multiple different accelerator dispatches found in streaming region op"
+                    "multiple different accelerator dispatches found in a single memref_stream.streaming_region op"
                 )
 
             accelerator = inner_op.library_call.data


### PR DESCRIPTION
When transforming the `memref_stream.streaming_region_op` to `snax_stream`, we must add an accelerator attribute to the `snax_stream` op, which is not included in `memref_stream`. For this, we just look at the generic op in the body and see if it has a library call assigned to it