### PR TITLE
transforms: (set-memory-layout) make tsls more static

### DIFF
--- a/compiler/ir/tsl/tiled_strided_layout.py
+++ b/compiler/ir/tsl/tiled_strided_layout.py
@@ -162,7 +162,9 @@ class TiledStridedLayout:
             next_stride = next(
                 (
                     (dim, depth, stride_self)
-                    for dim, depth, stride_self in self_strides
+                    for dim, depth, stride_self in sorted(
+                        self_strides, key=lambda x: x[2].bound is None
+                    )
                     if stride_self.step == current_stride
                 ),
                 None,

--- a/compiler/ir/tsl/tiled_strided_layout.py
+++ b/compiler/ir/tsl/tiled_strided_layout.py
@@ -162,6 +162,9 @@ class TiledStridedLayout:
             next_stride = next(
                 (
                     (dim, depth, stride_self)
+                    # must order such that in the case of strides with
+                    # equal steps = current_stride, the one with fixed
+                    # bound None is not chosen
                     for dim, depth, stride_self in sorted(
                         self_strides, key=lambda x: x[2].bound is None
                     )

--- a/compiler/transforms/set_memory_layout.py
+++ b/compiler/transforms/set_memory_layout.py
@@ -37,7 +37,7 @@ class AddMemoryLayout(RewritePattern):
         # check for library call
         if library_call == "snax_gemm" or library_call == "snax_gemm_stream":
             # the layout should be as static as the memref is. no more, no less
-            # get i, j, k
+            # get m, n, k
 
             shaped_operands: list[MemRefType] = [
                 op.type

--- a/tests/filecheck/transforms/set-memory-layout.mlir
+++ b/tests/filecheck/transforms/set-memory-layout.mlir
@@ -19,25 +19,7 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: "builtin.module"() ({
-// CHECK-NEXT:   "func.func"() <{"sym_name" = "mnist", "function_type" = (memref<?x128xi8, 1 : i32>, memref<128x128xi8, 1 : i32>, memref<?x128xi32, 1 : i32>) -> memref<?x128xi32, 1 : i32>}> ({
-// CHECK-NEXT:   ^0(%arg0 : memref<?x128xi8, 1 : i32>, %arg1 : memref<128x128xi8, 1 : i32>, %arg2 : memref<?x128xi32, 1 : i32>):
-// CHECK-NEXT:     %0 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
-// CHECK-NEXT:     %1 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
-// CHECK-NEXT:     %2 = "snax.layout_cast"(%arg0) : (memref<?x128xi8, 1 : i32>) -> memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, 1 : i32>
-// CHECK-NEXT:     %3 = "snax.layout_cast"(%arg1) : (memref<128x128xi8, 1 : i32>) -> memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8)>, 1 : i32>
-// CHECK-NEXT:     %4 = "snax.layout_cast"(%arg2) : (memref<?x128xi32, 1 : i32>) -> memref<?x128xi32, #tsl.tsl<[?, 8] -> (?, 32), [?, 8] -> (256, 4)>, 1 : i32>
-// CHECK-NEXT:     "linalg.generic"(%2, %3, %0, %1, %4) <{"indexing_maps" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>], "iterator_types" = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>], "library_call" = "snax_gemm", "operandSegmentSizes" = array<i32: 4, 1>}> ({
-// CHECK-NEXT:     ^1(%arg3 : i8, %arg4 : i8, %arg5 : i32, %arg6 : i32, %arg7 : i32):
-// CHECK-NEXT:       %5 = "arith.extsi"(%arg3) : (i8) -> i32
-// CHECK-NEXT:       %6 = "arith.subi"(%5, %arg5) : (i32, i32) -> i32
-// CHECK-NEXT:       %7 = "arith.extsi"(%arg4) : (i8) -> i32
-// CHECK-NEXT:       %8 = "arith.subi"(%7, %arg6) : (i32, i32) -> i32
-// CHECK-NEXT:       %9 = "arith.muli"(%6, %8) : (i32, i32) -> i32
-// CHECK-NEXT:       %10 = "arith.addi"(%arg7, %9) : (i32, i32) -> i32
-// CHECK-NEXT:       "linalg.yield"(%10) : (i32) -> ()
-// CHECK-NEXT:     }) : (memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, 1 : i32>, memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8)>, 1 : i32>, i32, i32, memref<?x128xi32, #tsl.tsl<[?, 8] -> (?, 32), [?, 8] -> (256, 4)>, 1 : i32>) -> ()
-// CHECK-NEXT:     "func.return"(%arg2) : (memref<?x128xi32, 1 : i32>) -> ()
-// CHECK-NEXT:   }) : () -> ()
-// CHECK-NEXT: }) : () -> ()
 
+//CHECK:       %2 = "snax.layout_cast"(%arg0) : (memref<?x128xi8, 1 : i32>) -> memref<?x128xi8, #tsl.tsl<[?, 8] -> (4096, 8), [16, 8] -> (256, 1)>, 1 : i32>
+//CHECK-NEXT:  %3 = "snax.layout_cast"(%arg1) : (memref<128x128xi8, 1 : i32>) -> memref<128x128xi8, #tsl.tsl<[16, 8] -> (256, 1), [16, 8] -> (4096, 8)>, 1 : i32>
+//CHECK-NEXT:  %4 = "snax.layout_cast"(%arg2) : (memref<?x128xi32, 1 : i32>) -> memref<?x128xi32, #tsl.tsl<[?, 8] -> (4096, 32), [16, 8] -> (256, 4)>, 1 : i32>


### PR DESCRIPTION
The tsl's were given dynamic strides and bounds, even for static problem sizes.
The assumption that everything downstream easily handles dynamic layouts is not always as convenient :)
This makes sure the layout attribute is exactly as statically determined as the memref it is assigned to.