### PR TITLE
Make state tracing work in scf.parallel and such

### DIFF
--- a/compiler/transforms/convert_linalg_to_accfg.py
+++ b/compiler/transforms/convert_linalg_to_accfg.py
@@ -264,7 +264,9 @@ def _weave_states_in_region(
                         if isinstance(result.type, accfg.StateType):
                             # update the state to reflect this
                             state[result.type.accelerator.data] = result
-
+                # any other op that contains ops:
+                elif op.regions:
+                    _weave_states_in_region(op, dict(), rewriter)
                 # Check if the op has effects on accfg state
                 elif has_accfg_effects(op):
                     state.clear()

--- a/tests/filecheck/transforms/accfg-trace-states.mlir
+++ b/tests/filecheck/transforms/accfg-trace-states.mlir
@@ -304,3 +304,34 @@ func.func @loop_with_multiple_input_states() {
 // CHECK-NEXT:    }
 // CHECK-NEXT:    func.return
 // CHECK-NEXT:  }
+
+
+func.func @random_parent_op() {
+    "test.op"() ({
+        %A, %B, %O, %nr_iters = "test.op"() : () -> (i32, i32, i32, i32)
+
+        %s1 = accfg.setup "snax_hwpe_mult" to (
+            "A" = %A : i32, "B" = %B : i32, "O" = %O : i32, "nr_iters" = %nr_iters : i32
+        ) : !accfg.state<"snax_hwpe_mult">
+
+        %s2 = accfg.setup "snax_hwpe_mult" to (
+            "A" = %A : i32, "B" = %B : i32, "O" = %O : i32, "nr_iters" = %nr_iters : i32
+        ) : !accfg.state<"snax_hwpe_mult">
+
+        "test.termop"() : () -> ()
+    }) : () -> ()
+
+    return
+}
+
+// check that states have been connected inside the test op:
+// CHECK-NEXT:  func.func @random_parent_op() {
+// CHECK-NEXT:    "test.op"() ({
+// CHECK-NEXT:      %A, %B, %O, %nr_iters = "test.op"() : () -> (i32, i32, i32, i32)
+// CHECK-NEXT:      %s1 = accfg.setup "snax_hwpe_mult" to ("A" = %A : i32, "B" = %B : i32, "O" = %O : i32, "nr_iters" = %nr_iters : i32) : !accfg.state<"snax_hwpe_mult">
+// CHECK-NEXT:      %s2 = accfg.setup "snax_hwpe_mult" from %s1 to ("A" = %A : i32, "B" = %B : i32, "O" = %O : i32, "nr_iters" = %nr_iters : i32) : !accfg.state<"snax_hwpe_mult">
+//                                                     ^^^^^^^^ perfect!
+// CHECK-NEXT:      "test.termop"() : () -> ()
+// CHECK-NEXT:    }) : () -> ()
+// CHECK-NEXT:    func.return
+// CHECK-NEXT:  }


### PR DESCRIPTION
 if there is an op that's not specifically handled, we just recurse in the body of that op, without carrying state in or out