### PR TITLE
Add test-add-mcycle-around-loop pass

### DIFF
--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -35,6 +35,7 @@ from compiler.transforms.snax_copy_to_dma import SNAXCopyToDMA
 from compiler.transforms.snax_lower_mcycle import SNAXLowerMCycle
 from compiler.transforms.snax_to_func import SNAXToFunc
 from compiler.transforms.stream_snaxify import StreamSnaxify
+from compiler.transforms.test_add_mcycle_around_loop import AddMcycleAroundLoopPass
 from compiler.transforms.test_remove_memref_copy import RemoveMemrefCopyPass
 
 
@@ -90,6 +91,9 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(StreamSnaxify.name, lambda: StreamSnaxify)
         super().register_pass(ReuseMemrefAllocs.name, lambda: ReuseMemrefAllocs)
         super().register_pass(RemoveMemrefCopyPass.name, lambda: RemoveMemrefCopyPass)
+        super().register_pass(
+            AddMcycleAroundLoopPass.name, lambda: AddMcycleAroundLoopPass
+        )
         super().register_pass(
             GuardedLinalgToMemrefStreamPass.name,
             lambda: GuardedLinalgToMemrefStreamPass,

--- a/compiler/transforms/test_add_mcycle_around_loop.py
+++ b/compiler/transforms/test_add_mcycle_around_loop.py
@@ -1,0 +1,39 @@
+from xdsl.context import MLContext
+from xdsl.dialects import builtin, func, scf
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.rewriter import InsertPoint
+
+from compiler.dialects import snax
+
+
+class InsertMcycleForLoop(RewritePattern):
+    """
+    Pattern that looks for top-level scf.for ops and inserts a SNAX mcycle op before and after the top-level for loop.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: func.FuncOp, rewriter: PatternRewriter):
+        for opy in op.body.block.ops:
+            if isinstance(opy, scf.For):
+                rewriter.insert_op(snax.MCycleOp(), InsertPoint.before(opy))
+                rewriter.insert_op(snax.MCycleOp(), InsertPoint.after(opy))
+
+
+class AddMcycleAroundLoopPass(ModulePass):
+
+    """
+    Pass to insert an mcycle op before and after all top-level loops inside a function
+    """
+
+    name = "test-add-mcycle-around-loop"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(
+            InsertMcycleForLoop(), apply_recursively=False
+        ).rewrite_module(op)

--- a/tests/filecheck/transforms/test-add-mcycle-around-loop.mlir
+++ b/tests/filecheck/transforms/test-add-mcycle-around-loop.mlir
@@ -1,0 +1,63 @@
+// RUN: snax-opt --split-input-file -p test-add-mcycle-around-loop %s | filecheck %s
+
+builtin.module {
+  func.func @add_mcycles_to_me() {
+    %t = "test.op"() : () -> index
+    scf.for %arg3 = %t to %t step %t {
+      scf.for %arg4 = %t to %t step %t {
+        "test.op"() : () -> ()
+      }
+    }
+    func.return
+  }
+}
+
+// CHECK: builtin.module {
+// CHECK-NEXT:   func.func @add_mcycles_to_me() {
+// CHECK-NEXT:     %t = "test.op"() : () -> index
+// CHECK-NEXT:     "snax.mcycle"() : () -> ()
+// CHECK-NEXT:     scf.for %arg3 = %t to %t step %t {
+// CHECK-NEXT:       scf.for %arg4 = %t to %t step %t {
+// CHECK-NEXT:         "test.op"() : () -> ()
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     "snax.mcycle"() : () -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// -----
+
+builtin.module {
+  func.func @add_mcycles_to_me_twice() {
+    %t = "test.op"() : () -> index
+    scf.for %arg3 = %t to %t step %t {
+      scf.for %arg4 = %t to %t step %t {
+        "test.op"() : () -> ()
+      }
+    }
+    scf.for %arg1 = %t to %t step %t {
+      "test.op"() : () -> ()
+    }
+    func.return
+  }
+}
+
+// CHECK: builtin.module {
+// CHECK-NEXT:   func.func @add_mcycles_to_me_twice() {
+// CHECK-NEXT:     %t = "test.op"() : () -> index
+// CHECK-NEXT:     "snax.mcycle"() : () -> ()
+// CHECK-NEXT:     scf.for %arg3 = %t to %t step %t {
+// CHECK-NEXT:       scf.for %arg4 = %t to %t step %t {
+// CHECK-NEXT:         "test.op"() : () -> ()
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     "snax.mcycle"() : () -> ()
+// CHECK-NEXT:     "snax.mcycle"() : () -> ()
+// CHECK-NEXT:     scf.for %arg1 = %t to %t step %t {
+// CHECK-NEXT:       "test.op"() : () -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:     "snax.mcycle"() : () -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }


### PR DESCRIPTION
This pass adds two snax-mcycle ops, one right before, and one right after all top-level scf for loops inside a function.
This pass is to be used for measurement purposes only.