### PR TITLE
accelerators: (snax streamers) add streamer flags

### DIFF
--- a/compiler/accelerators/snax_alu.py
+++ b/compiler/accelerators/snax_alu.py
@@ -17,9 +17,9 @@ from compiler.dialects import accfg, snax_stream
 
 default_streamer = StreamerConfiguration(
     [
-        Streamer(StreamerType.Reader, 1, 1),
-        Streamer(StreamerType.Reader, 1, 1),
-        Streamer(StreamerType.Writer, 1, 1),
+        Streamer.from_dim(StreamerType.Reader, 1, 1),
+        Streamer.from_dim(StreamerType.Reader, 1, 1),
+        Streamer.from_dim(StreamerType.Writer, 1, 1),
     ]
 )
 

--- a/compiler/accelerators/snax_gemm.py
+++ b/compiler/accelerators/snax_gemm.py
@@ -21,12 +21,12 @@ default_streamer = StreamerConfiguration(
         Streamer(
             StreamerType.Reader,
             temporal_dims=("n", "n", "n"),
-            spatial_dims=("i", "n", "n"),
+            spatial_dims=("n", "n", "i"),
         ),
         Streamer(
             StreamerType.Writer,
             temporal_dims=("n", "n", "n"),
-            spatial_dims=("n", "n", "i"),
+            spatial_dims=("i", "n", "n"),
         ),
     ]
 )

--- a/compiler/accelerators/snax_gemm.py
+++ b/compiler/accelerators/snax_gemm.py
@@ -13,9 +13,21 @@ from compiler.dialects import accfg, snax_stream
 
 default_streamer = StreamerConfiguration(
     [
-        Streamer(StreamerType.Reader, 3, 2),
-        Streamer(StreamerType.Reader, 3, 2),
-        Streamer(StreamerType.Writer, 3, 2),
+        Streamer(
+            StreamerType.Reader,
+            temporal_dims=("n", "n", "n"),
+            spatial_dims=("n", "i", "n"),
+        ),
+        Streamer(
+            StreamerType.Reader,
+            temporal_dims=("n", "n", "n"),
+            spatial_dims=("i", "n", "n"),
+        ),
+        Streamer(
+            StreamerType.Writer,
+            temporal_dims=("n", "n", "n"),
+            spatial_dims=("n", "n", "i"),
+        ),
     ]
 )
 

--- a/compiler/accelerators/streamers/streamers.py
+++ b/compiler/accelerators/streamers/streamers.py
@@ -35,7 +35,7 @@ class StreamerFlag(StrEnum):
 
     def __bool__(self) -> bool:
         """
-        Overrides the default boolean conversion to ensure that the 'None'
+        Overrides the default boolean conversion to ensure that the 'Normal'
         flag evaluates to False and all other flags evaluate to true
         """
         return self is not StreamerFlag.Normal

--- a/compiler/accelerators/streamers/streamers.py
+++ b/compiler/accelerators/streamers/streamers.py
@@ -16,7 +16,7 @@ class StreamerFlag(StrEnum):
 
     Attributes:
     -----------
-    - None: 'n'
+    - Normal: 'n'
       Indicates that no special flags apply.
     - Irellevant : 'i'
       Indicates a dimension is irrelevant for this operand.
@@ -29,7 +29,7 @@ class StreamerFlag(StrEnum):
       This results in the bound values being for this dimension fixed to 1.
     """
 
-    None_ = "n"
+    Normal = "n"
     Irrelevant = "i"
     Reuse = "r"
 
@@ -38,7 +38,7 @@ class StreamerFlag(StrEnum):
         Overrides the default boolean conversion to ensure that the 'None'
         flag evaluates to False and all other flags evaluate to true
         """
-        return self is not StreamerFlag.None_
+        return self is not StreamerFlag.Normal
 
 
 class Streamer:
@@ -76,8 +76,8 @@ class Streamer:
         """
         return cls(
             type,
-            (StreamerFlag.None_,) * temporal_dim,
-            (StreamerFlag.None_,) * spatial_dim,
+            (StreamerFlag.Normal,) * temporal_dim,
+            (StreamerFlag.Normal,) * spatial_dim,
         )
 
     @property

--- a/compiler/accelerators/streamers/streamers.py
+++ b/compiler/accelerators/streamers/streamers.py
@@ -1,5 +1,7 @@
 from collections.abc import Sequence
+from typing import Literal
 
+from typing_extensions import deprecated
 from xdsl.utils.str_enum import StrEnum
 
 
@@ -8,19 +10,83 @@ class StreamerType(StrEnum):
     Writer = "w"
 
 
+class StreamerFlag(StrEnum):
+    """
+    Enum that specifies special flags for a streamer dimension.
+
+    Attributes:
+    -----------
+    - None: 'n'
+      Indicates that no special flags apply.
+    - Irellevant : 'i'
+      Indicates a dimension is irrelevant for this operand.
+      In all cases, a zero should be set to the stride of this dimension.
+      For spatial dims, the resulting value is assigned to a "virtual streamer"
+      and will not be programmed.
+    - Reuse : 'r'
+      Only valid for temporal dims. Indicates that the values
+      will be reused temporally and should only be fetched once.
+      This results in the bound values being for this dimension fixed to 1.
+    """
+
+    None_ = "n"
+    Irrelevant = "i"
+    Reuse = "r"
+
+    def __bool__(self) -> bool:
+        """
+        Overrides the default boolean conversion to ensure that the 'None'
+        flag evaluates to False and all other flags evaluate to true
+        """
+        return self is not StreamerFlag.None_
+
+
 class Streamer:
     """
     A representation of a single SNAX Streamer
     """
 
     type: StreamerType
-    temporal_dim: int
-    spatial_dim: int
+    temporal_dims: tuple[StreamerFlag, ...]
+    spatial_dims: tuple[StreamerFlag, ...]
 
-    def __init__(self, type: StreamerType, temporal_dim: int, spatial_dim: int) -> None:
+    def __init__(
+        self,
+        type: StreamerType,
+        temporal_dims: Sequence[StreamerFlag | Literal["n", "i", "r"]],
+        spatial_dims: Sequence[StreamerFlag | Literal["n", "i", "r"]],
+    ) -> None:
         self.type = type
-        self.temporal_dim = temporal_dim
-        self.spatial_dim = spatial_dim
+        temporal_dims = [
+            f if isinstance(f, StreamerFlag) else StreamerFlag(f) for f in temporal_dims
+        ]
+        self.temporal_dims = tuple(temporal_dims)
+        spatial_dims = [
+            f if isinstance(f, StreamerFlag) else StreamerFlag(f) for f in spatial_dims
+        ]
+        self.spatial_dims = tuple(spatial_dims)
+
+    @classmethod
+    def from_dim(
+        cls, type: StreamerType, temporal_dim: int, spatial_dim: int
+    ) -> "Streamer":
+        """
+        Returns a streamer with a specified temporal dim and spatial dim
+        as integers, without any flags set.
+        """
+        return cls(
+            type,
+            (StreamerFlag.None_,) * temporal_dim,
+            (StreamerFlag.None_,) * spatial_dim,
+        )
+
+    @property
+    def temporal_dim(self):
+        return len(self.temporal_dims)
+
+    @property
+    def spatial_dim(self):
+        return len(self.spatial_dims)
 
 
 class StreamerConfiguration:
@@ -42,6 +108,7 @@ class StreamerConfiguration:
         """
         return len(self.streamers)
 
+    @deprecated("Please do not use this function, it is only valid in trivial cases")
     def temporal_dim(self) -> int:
         """
         Return the temporal dimension of the streamers
@@ -50,6 +117,7 @@ class StreamerConfiguration:
         """
         return self.streamers[0].temporal_dim
 
+    @deprecated("Please do not use this function, it is only valid in trivial cases")
     def spatial_dim(self) -> int:
         """
         Return the spatial dimension of the streamers

--- a/compiler/transforms/stream_snaxify.py
+++ b/compiler/transforms/stream_snaxify.py
@@ -130,12 +130,6 @@ class MemrefStreamToSnaxPattern(RewritePattern):
 
             spat_dim = streamer_config.data.spatial_dim()
 
-            # extremely dirty fix:
-            # FIXME: this only works because gemm is the only one with
-            # two spat_dims. This must be fixed with some "virtual" spatial dim
-            if spat_dim == 2:
-                spat_dim = 3
-
             temporal_strides = []
             spatial_strides = []
             upper_bounds = []
@@ -153,9 +147,6 @@ class MemrefStreamToSnaxPattern(RewritePattern):
                     temporal_strides.append(stride[0])
                     # have to set upper bounds for spatial strides
                     upper_bounds.append(op.patterns.data[operand].ub.data[i].value)
-
-            # delete all zeros from spatial strides
-            spatial_strides = [x for x in spatial_strides if x]
 
             # create the stride pattern for this operand
             snax_stride_pattern = snax_stream.StridePattern(

--- a/tests/filecheck/dialects/snax/snax_ops.mlir
+++ b/tests/filecheck/dialects/snax/snax_ops.mlir
@@ -16,6 +16,6 @@
 // CHECK-NEXT:   %3 = "snax.alloc"(%2, %2, %2) <{"memory_space" = "L3", "alignment" = 64 : i32}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
 
 // Test streamer config attribute:
-"test.op"() {"streamer_config" = #snax.streamer_config<r[1, 2], r[3, 4], w[5, 6]> } : () -> ()
-// CHECK-NEXT: #snax.streamer_config<r[1, 2], r[3, 4], w[5, 6]>
+"test.op"() {"streamer_config" = #snax.streamer_config<r[temp=n-n-n, spat=n-n-n], r[temp=n-r-i, spat=i-n-r], w[temp=i-i-i, spat=n-n]> } : () -> ()
+// CHECK-NEXT: #snax.streamer_config<r[temp=n-n-n, spat=n-n-n], r[temp=n-r-i, spat=i-n-r], w[temp=i-i-i, spat=n-n]>
 

--- a/tests/filecheck/dialects/snax_stream/snax_stream_invalid.mlir
+++ b/tests/filecheck/dialects/snax_stream/snax_stream_invalid.mlir
@@ -31,7 +31,7 @@
     name = @accelerator_with_streamers,
     fields = {}, launch_fields = {}, barrier = 0
 }> {
-    "streamer_config" = #snax.streamer_config< r[2,2], r[2,2], w[2,2]>
+    "streamer_config" = #snax.streamer_config< r[temp=n-n, spat=n-n], r[temp=n-n, spat=n-n], w[temp=n-n, spat=n-n]>
 } : () -> ()
 
 "snax_stream.streaming_region"() <{
@@ -49,7 +49,7 @@
     name = @accelerator_with_streamers,
     fields = {}, launch_fields = {}, barrier = 0
 }> {
-    "streamer_config" = #snax.streamer_config< r[2,2], r[2,2], w[2,2]>
+    "streamer_config" = #snax.streamer_config< r[temp=n-n, spat=n-n], r[temp=n-n, spat=n-n], w[temp=n-n, spat=n-n]>
 } : () -> ()
 
 "snax_stream.streaming_region"() <{
@@ -70,7 +70,7 @@
     name = @accelerator_with_streamers,
     fields = {}, launch_fields = {}, barrier = 0
 }> {
-    "streamer_config" = #snax.streamer_config< r[2,2], r[2,2], w[2,2]>
+    "streamer_config" = #snax.streamer_config< r[temp=n-n, spat=n-n], r[temp=n-n, spat=n-n], w[temp=n-n, spat=n-n]>
 } : () -> ()
 
 "snax_stream.streaming_region"() <{

--- a/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
+++ b/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
@@ -4,7 +4,7 @@
     name = @accelerator_with_streamers,
     fields = {}, launch_fields = {}, barrier = 0
 }> {
-    "streamer_config" = #snax.streamer_config< r[2,2], r[2,2], w[2,2]>
+    "streamer_config" = #snax.streamer_config< r[temp=n-n, spat=n-n], r[temp=n-n, spat=n-n], w[temp=n-n, spat=n-n]>
 } : () -> ()
 
 %x, %y, %z = "test.op"() : () -> (index, index, index)
@@ -24,7 +24,7 @@
 }) : (index, index, index) -> ()
 
 //CHECK:      builtin.module {
-//CHECK-NEXT:   "accfg.accelerator"() <{"name" = @accelerator_with_streamers, "fields" = {}, "launch_fields" = {}, "barrier" = 0 : i64}> {"streamer_config" = #snax.streamer_config<r[2, 2], r[2, 2], w[2, 2]>} : () -> ()
+//CHECK-NEXT:   "accfg.accelerator"() <{"name" = @accelerator_with_streamers, "fields" = {}, "launch_fields" = {}, "barrier" = 0 : i64}> {"streamer_config" = #snax.streamer_config<r[temp=n-n, spat=n-n], r[temp=n-n, spat=n-n], w[temp=n-n, spat=n-n]>} : () -> ()
 //CHECK-NEXT:   %x, %y, %z = "test.op"() : () -> (index, index, index)
 //CHECK-NEXT:   "snax_stream.streaming_region"(%x, %y, %z) <{"stride_patterns" = [#snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>], "operandSegmentSizes" = array<i32: 2, 1>, "accelerator" = "accelerator_with_streamers"}> ({
 //CHECK-NEXT:   ^0(%0 : !stream.readable<i64>, %1 : !stream.readable<i64>, %2 : !stream.writable<i64>):


### PR DESCRIPTION
This PR extends the streamer configuration attributes so that each streamer dimension can have a flag assigned to it.
This allows us to express the irrelevance of certain dimensions or possible reuse within the accelerator, such that we can program the streamers correctly.

Additionally, this pr also deprecates and starts moving away from the global `spatial_dim` and `temporal_dim` functions. These are only valid when the temporal/spatial dim is equal for every operand, which is only the case for very simple examples.