### PR TITLE
add kernel dialect

### DIFF
--- a/compiler/dialects/kernel.py
+++ b/compiler/dialects/kernel.py
@@ -30,7 +30,9 @@ class QuantizedBinaryOp(BinaryOp):
 @irdl_op_definition
 class MulOp(KernelOp, BinaryOp):
     name = "kernel.mul"
-
+    assembly_format = (
+        "$lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs) `->` type($result)"
+    )
 
 @irdl_op_definition
 class AddOp(KernelOp, BinaryOp):

--- a/compiler/dialects/kernel.py
+++ b/compiler/dialects/kernel.py
@@ -41,20 +41,18 @@ class AddOp(KernelOp, BinaryOp):
 @irdl_op_definition
 class MacOp(KernelOp, BinaryOp):
     name = "kernel.mac"
-    acc = operand_def(IntegerType)
     assembly_format = (
-        "$lhs `,` $rhs `acc``:` $acc attr-dict `:`"
-        "type($lhs) `,` type($rhs) `,` type($acc) `->` type($result)"
+        "$lhs `,` $rhs attr-dict `:`"
+        "type($lhs) `,` type($rhs) `->` type($result)"
     )
 
 
 @irdl_op_definition
 class QMacOp(KernelOp, QuantizedBinaryOp):
     name = "kernel.qmac"
-    acc = operand_def(IntegerType)
     assembly_format = (
-        "$lhs `,` $rhs `acc` `:` $acc `zp_lhs``:` $zp_lhs `zp_rhs``:` $zp_rhs attr-dict `:`"
-        " type($lhs) `,` type($rhs) `,` type($acc) `,` type($zp_lhs) `,` type($zp_rhs) `->` type($result)"
+        "$lhs `,` $rhs `zp_lhs``:` $zp_lhs `zp_rhs``:` $zp_rhs attr-dict `:`"
+        " type($lhs) `,` type($rhs) `,` type($zp_lhs) `,` type($zp_rhs) `->` type($result)"
     )
 
 

--- a/compiler/dialects/kernel.py
+++ b/compiler/dialects/kernel.py
@@ -25,9 +25,6 @@ class QuantizedBinaryOp(BinaryOp):
 @irdl_op_definition
 class MulOp(KernelOp, BinaryOp):
     name = "kernel.mul"
-    assembly_format = (
-        "$lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs) `->` type($result)"
-    )
 
 
 @irdl_op_definition
@@ -42,7 +39,7 @@ class AddOp(KernelOp, BinaryOp):
 class MacOp(KernelOp, BinaryOp):
     name = "kernel.mac"
     assembly_format = (
-        "$lhs `,` $rhs attr-dict `:`" "type($lhs) `,` type($rhs) `->` type($result)"
+        "$lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs) `->` type($result)"
     )
 
 

--- a/compiler/dialects/kernel.py
+++ b/compiler/dialects/kernel.py
@@ -8,6 +8,11 @@ from xdsl.parser import IRDLOperation
 
 
 class KernelOp(IRDLOperation, ABC):
+    """
+    Operation representing different types of kernel operations of a
+    linalg generic body that can be executed by accelerators.
+    """
+
     ...
 
 

--- a/compiler/dialects/kernel.py
+++ b/compiler/dialects/kernel.py
@@ -1,0 +1,61 @@
+from abc import ABC
+
+from xdsl.dialects.builtin import IntegerType
+from xdsl.ir import Dialect
+from xdsl.irdl import operand_def
+from xdsl.irdl.operations import irdl_op_definition, result_def
+from xdsl.parser import IRDLOperation
+
+
+class KernelOp(IRDLOperation, ABC):
+    ...
+
+
+class BinaryOp:
+    lhs = operand_def(IntegerType)
+    rhs = operand_def(IntegerType)
+    result = result_def(IntegerType)
+
+
+class QuantizedBinaryOp(BinaryOp):
+    zp_lhs = operand_def(IntegerType)
+    zp_rhs = operand_def(IntegerType)
+
+
+@irdl_op_definition
+class MulOp(KernelOp, BinaryOp):
+    name = "kernel.mul"
+    assembly_format = (
+        "$lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs) `->` type($result)"
+    )
+
+
+@irdl_op_definition
+class AddOp(KernelOp, BinaryOp):
+    name = "kernel.add"
+    assembly_format = (
+        "$lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs) `->` type($result)"
+    )
+
+
+@irdl_op_definition
+class MacOp(KernelOp, BinaryOp):
+    name = "kernel.mac"
+    acc = operand_def(IntegerType)
+    assembly_format = (
+        "$lhs `,` $rhs `acc``:` $acc attr-dict `:`"
+        "type($lhs) `,` type($rhs) `,` type($acc) `->` type($result)"
+    )
+
+
+@irdl_op_definition
+class QMacOp(KernelOp, QuantizedBinaryOp):
+    name = "kernel.qmac"
+    acc = operand_def(IntegerType)
+    assembly_format = (
+        "$lhs `,` $rhs `acc` `:` $acc `zp_lhs``:` $zp_lhs `zp_rhs``:` $zp_rhs attr-dict `:`"
+        " type($lhs) `,` type($rhs) `,` type($acc) `,` type($zp_lhs) `,` type($zp_rhs) `->` type($result)"
+    )
+
+
+Kernel = Dialect("kernel", [MulOp, AddOp, MacOp, QMacOp])

--- a/compiler/dialects/kernel.py
+++ b/compiler/dialects/kernel.py
@@ -42,8 +42,7 @@ class AddOp(KernelOp, BinaryOp):
 class MacOp(KernelOp, BinaryOp):
     name = "kernel.mac"
     assembly_format = (
-        "$lhs `,` $rhs attr-dict `:`"
-        "type($lhs) `,` type($rhs) `->` type($result)"
+        "$lhs `,` $rhs attr-dict `:`" "type($lhs) `,` type($rhs) `->` type($result)"
     )
 
 

--- a/compiler/dialects/kernel.py
+++ b/compiler/dialects/kernel.py
@@ -34,6 +34,7 @@ class MulOp(KernelOp, BinaryOp):
         "$lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs) `->` type($result)"
     )
 
+
 @irdl_op_definition
 class AddOp(KernelOp, BinaryOp):
     name = "kernel.add"

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -5,6 +5,7 @@ from xdsl.context import MLContext
 from xdsl.xdsl_opt_main import xDSLOptMain
 
 from compiler.dialects.accfg import ACCFG
+from compiler.dialects.kernel import Kernel
 from compiler.dialects.snax import Snax
 from compiler.dialects.snax_stream import SnaxStream
 from compiler.dialects.tsl import TSL
@@ -61,6 +62,7 @@ class SNAXOptMain(xDSLOptMain):
 
         self.ctx.load_dialect(Snax)
         self.ctx.load_dialect(TSL)
+        self.ctx.load_dialect(Kernel)
         self.ctx.load_dialect(ACCFG)
         self.ctx.load_dialect(SnaxStream)
         super().register_pass(DispatchKernels.name, lambda: DispatchKernels)

--- a/tests/filecheck/dialects/kernel/ops.mlir
+++ b/tests/filecheck/dialects/kernel/ops.mlir
@@ -6,24 +6,24 @@
 
 %0 = "test.op"() : () -> i32
 // CHECK-NEXT:   %0 = "test.op"() : () -> i32
-// CHECK-NEXT-GENERIC:   %0 = "test.op"() : () -> i32
+// CHECK-GENERIC-NEXT:   %0 = "test.op"() : () -> i32
 
 %1 = "kernel.add" (%0, %0) : (i32, i32) -> i32
 // CHECK-NEXT:   %1 = kernel.add %0, %0 : i32, i32 -> i32
-// CHECK-NEXT-GENERIC:   %1 = "kernel.add"(%0, %0) : (i32, i32) -> i32
+// CHECK-GENERIC-NEXT:   %1 = "kernel.add"(%0, %0) : (i32, i32) -> i32
 
 %2 = "kernel.mul" (%0, %0) : (i32, i32) -> i32
 // CHECK-NEXT:   %2 = kernel.mul %0, %0 : i32, i32 -> i32
-// CHECK-NEXT-GENERIC:   %2 = "kernel.mul"(%0, %0) : (i32, i32) -> i32
+// CHECK-GENERIC-NEXT:   %2 = "kernel.mul"(%0, %0) : (i32, i32) -> i32
 
 %3 = "kernel.mac" (%0, %0, %0) : (i32, i32, i32) -> i32
 // CHECK-NEXT:   %3 = kernel.mac %0, %0 acc : %0 : i32, i32, i32 -> i32
-// CHECK-NEXT-GENERIC:   %3 = "kernel.mac"(%0, %0, %0) : (i32, i32, i32) -> i32
+// CHECK-GENERIC-NEXT:   %3 = "kernel.mac"(%0, %0, %0) : (i32, i32, i32) -> i32
 
 %4 = "kernel.qmac" (%0, %0, %0, %0, %0) : (i32, i32, i32, i32, i32) -> i32
 // CHECK-NEXT:   %4 = kernel.qmac %0, %0 acc : %0 zp_lhs : %0 zp_rhs : %0 : i32, i32, i32, i32, i32 -> i32
-// CHECK-NEXT-GENERIC:   %4 = "kernel.qmac"(%0, %0, %0, %0, %0) : (i32, i32, i32, i32, i32) -> i32
+// CHECK-GENERIC-NEXT:   %4 = "kernel.qmac"(%0, %0, %0, %0, %0) : (i32, i32, i32, i32, i32) -> i32
 
 
 // CHECK-NEXT: }
-// CHECK-NEXT-GENERIC: }) : () -> ()
+// CHECK-GENERIC-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/kernel/ops.mlir
+++ b/tests/filecheck/dialects/kernel/ops.mlir
@@ -16,13 +16,13 @@
 // CHECK-NEXT:   %2 = kernel.mul %0, %0 : i32, i32 -> i32
 // CHECK-GENERIC-NEXT:   %2 = "kernel.mul"(%0, %0) : (i32, i32) -> i32
 
-%3 = "kernel.mac" (%0, %0, %0) : (i32, i32, i32) -> i32
-// CHECK-NEXT:   %3 = kernel.mac %0, %0 acc : %0 : i32, i32, i32 -> i32
-// CHECK-GENERIC-NEXT:   %3 = "kernel.mac"(%0, %0, %0) : (i32, i32, i32) -> i32
+%3 = "kernel.mac" (%0, %0) : (i32, i32) -> i32
+// CHECK-NEXT:   %3 = kernel.mac %0, %0 : i32, i32 -> i32
+// CHECK-GENERIC-NEXT:   %3 = "kernel.mac"(%0, %0) : (i32, i32) -> i32
 
-%4 = "kernel.qmac" (%0, %0, %0, %0, %0) : (i32, i32, i32, i32, i32) -> i32
-// CHECK-NEXT:   %4 = kernel.qmac %0, %0 acc : %0 zp_lhs : %0 zp_rhs : %0 : i32, i32, i32, i32, i32 -> i32
-// CHECK-GENERIC-NEXT:   %4 = "kernel.qmac"(%0, %0, %0, %0, %0) : (i32, i32, i32, i32, i32) -> i32
+%4 = "kernel.qmac" (%0, %0, %0, %0) : (i32, i32, i32, i32) -> i32
+// CHECK-NEXT:   %4 = kernel.qmac %0, %0 zp_lhs : %0 zp_rhs : %0 : i32, i32, i32, i32 -> i32
+// CHECK-GENERIC-NEXT:   %4 = "kernel.qmac"(%0, %0, %0, %0) : (i32, i32, i32, i32) -> i32
 
 
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/kernel/ops.mlir
+++ b/tests/filecheck/dialects/kernel/ops.mlir
@@ -1,0 +1,29 @@
+// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_GENERIC_ROUNDTRIP
+
+// CHECK: builtin.module {
+// CHECK-GENERIC: "builtin.module"() ({
+
+%0 = "test.op"() : () -> i32
+// CHECK-NEXT:   %0 = "test.op"() : () -> i32
+// CHECK-NEXT-GENERIC:   %0 = "test.op"() : () -> i32
+
+%1 = "kernel.add" (%0, %0) : (i32, i32) -> i32
+// CHECK-NEXT:   %1 = kernel.add %0, %0 : i32, i32 -> i32
+// CHECK-NEXT-GENERIC:   %1 = "kernel.add"(%0, %0) : (i32, i32) -> i32
+
+%2 = "kernel.mul" (%0, %0) : (i32, i32) -> i32
+// CHECK-NEXT:   %2 = kernel.mul %0, %0 : i32, i32 -> i32
+// CHECK-NEXT-GENERIC:   %2 = "kernel.mul"(%0, %0) : (i32, i32) -> i32
+
+%3 = "kernel.mac" (%0, %0, %0) : (i32, i32, i32) -> i32
+// CHECK-NEXT:   %3 = kernel.mac %0, %0 acc : %0 : i32, i32, i32 -> i32
+// CHECK-NEXT-GENERIC:   %3 = "kernel.mac"(%0, %0, %0) : (i32, i32, i32) -> i32
+
+%4 = "kernel.qmac" (%0, %0, %0, %0, %0) : (i32, i32, i32, i32, i32) -> i32
+// CHECK-NEXT:   %4 = kernel.qmac %0, %0 acc : %0 zp_lhs : %0 zp_rhs : %0 : i32, i32, i32, i32, i32 -> i32
+// CHECK-NEXT-GENERIC:   %4 = "kernel.qmac"(%0, %0, %0, %0, %0) : (i32, i32, i32, i32, i32) -> i32
+
+
+// CHECK-NEXT: }
+// CHECK-NEXT-GENERIC: }) : () -> ()


### PR DESCRIPTION
start migrating this logic from `util` and formalize them as ops.
Kernel ops can be used to match accelerator templates