### PR TITLE
add convert-tosa-to-kernel pass

### DIFF
--- a/compiler/dialects/kernel.py
+++ b/compiler/dialects/kernel.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from typing import Annotated
 
 from xdsl.builder import Builder
 from xdsl.dialects import arith, linalg
@@ -7,6 +6,7 @@ from xdsl.dialects.builtin import IntegerType
 from xdsl.ir import BlockArgument, Dialect, Region, SSAValue
 from xdsl.irdl import operand_def
 from xdsl.dialects.builtin import I32, BoolAttr, IntegerType
+from xdsl.dialects.builtin import I8, I32, BoolAttr, IntegerType
 from xdsl.ir import Dialect
 from xdsl.irdl import operand_def, prop_def
 from xdsl.irdl.operations import irdl_op_definition, result_def
@@ -140,9 +140,6 @@ class QMacOp(KernelOp, QuantizedBinaryOp, Parsable):
             linalg.YieldOp(mac)
 
         return equivalent_region
-
-
-I8 = Annotated[IntegerType, IntegerType(8)]
 
 
 @irdl_op_definition

--- a/compiler/dialects/kernel.py
+++ b/compiler/dialects/kernel.py
@@ -1,12 +1,16 @@
 from abc import ABC
+from typing import Annotated
 
 from xdsl.builder import Builder
 from xdsl.dialects import arith, linalg
 from xdsl.dialects.builtin import IntegerType
 from xdsl.ir import BlockArgument, Dialect, Region, SSAValue
 from xdsl.irdl import operand_def
+from xdsl.dialects.builtin import I32, BoolAttr, IntegerType
+from xdsl.ir import Dialect
+from xdsl.irdl import operand_def, prop_def
 from xdsl.irdl.operations import irdl_op_definition, result_def
-from xdsl.parser import IRDLOperation
+from xdsl.parser import IntegerAttr, IRDLOperation
 
 
 class KernelOp(IRDLOperation, ABC):
@@ -138,4 +142,43 @@ class QMacOp(KernelOp, QuantizedBinaryOp, Parsable):
         return equivalent_region
 
 
-Kernel = Dialect("kernel", [MulOp, AddOp, MacOp, QMacOp])
+I8 = Annotated[IntegerType, IntegerType(8)]
+
+
+@irdl_op_definition
+class RescaleOp(KernelOp):
+    """
+    Operation applying rescaling according to the spec in
+    https://gist.github.com/jorendumoulin/83352a1e84501ec4a7b3790461fee2bf
+    """
+
+    name = "kernel.rescale"
+
+    input = operand_def(IntegerType)
+    result = result_def(IntegerType)
+
+    input_zp = prop_def(IntegerAttr[I8])
+    output_zp = prop_def(IntegerAttr[I8])
+    multiplier = prop_def(IntegerAttr[I32])
+    shift = prop_def(IntegerAttr[I8])
+    max_int = prop_def(IntegerAttr[I8])
+    min_int = prop_def(IntegerAttr[I8])
+    double_round = prop_def(BoolAttr)
+
+    assembly_format = (
+        "$input attr-dict `zero_points` `(` $input_zp `,` $output_zp `)`"
+        "`rescale` `(` $multiplier ` ` `>` `>` $shift `)` `clamp` `(` $min_int `,` $max_int `)`"
+        " `double_round` `=` $double_round `:` type($input) `->` type($result)"
+    )
+
+
+Kernel = Dialect(
+    "kernel",
+    [
+        MulOp,
+        AddOp,
+        MacOp,
+        QMacOp,
+        RescaleOp,
+    ],
+)

--- a/compiler/dialects/kernel.py
+++ b/compiler/dialects/kernel.py
@@ -2,12 +2,8 @@ from abc import ABC
 
 from xdsl.builder import Builder
 from xdsl.dialects import arith, linalg
-from xdsl.dialects.builtin import IntegerType
-from xdsl.ir import BlockArgument, Dialect, Region, SSAValue
-from xdsl.irdl import operand_def
-from xdsl.dialects.builtin import I32, BoolAttr, IntegerType
 from xdsl.dialects.builtin import I8, I32, BoolAttr, IntegerType
-from xdsl.ir import Dialect
+from xdsl.ir import BlockArgument, Dialect, Region, SSAValue
 from xdsl.irdl import operand_def, prop_def
 from xdsl.irdl.operations import irdl_op_definition, result_def
 from xdsl.parser import IntegerAttr, IRDLOperation

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -19,6 +19,7 @@ from compiler.transforms.convert_linalg_to_accfg import (
     TraceStatesPass,
 )
 from compiler.transforms.convert_linalg_to_kernel import ConvertLinalgToKernel
+from compiler.transforms.convert_tosa_to_kernel import ConvertTosaToKernelPass
 from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
 from compiler.transforms.guarded_linalg_to_memref_stream import (
@@ -103,6 +104,9 @@ class SNAXOptMain(xDSLOptMain):
         )
         super().register_pass(ScheduleMemrefLinalg.name, lambda: ScheduleMemrefLinalg)
         super().register_pass(ConvertLinalgToKernel.name, lambda: ConvertLinalgToKernel)
+        super().register_pass(
+            ConvertTosaToKernelPass.name, lambda: ConvertTosaToKernelPass
+        )
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/transforms/convert_tosa_to_kernel.py
+++ b/compiler/transforms/convert_tosa_to_kernel.py
@@ -15,6 +15,12 @@ from xdsl.pattern_rewriter import (
 from compiler.dialects import kernel
 
 
+def assert_int8(val):
+    assert isinstance(val, int)
+    assert -128 <= val
+    assert val <= 127
+
+
 class RescaleClampPattern(RewritePattern):
     """
     Transform rescale clamp into a kernel.rescale op
@@ -40,28 +46,22 @@ class RescaleClampPattern(RewritePattern):
 
         # Extract all values:
         input_zp = rescale_op.input_zp.value.data
-        assert -128 <= input_zp
-        assert input_zp <= 127
+        assert_int8(input_zp)
 
         output_zp = rescale_op.output_zp.value.data
-        assert -128 <= output_zp
-        assert output_zp <= 127
+        assert_int8(output_zp)
 
         multiplier = rescale_op.multiplier.data.data[0].data
         assert isinstance(multiplier, int)
 
         shift = rescale_op.shift.data.data[0].data
-        assert isinstance(shift, int)
-        assert -128 <= shift
-        assert shift <= 127
+        assert_int8(shift)
 
         max_int = clamp_op.max_int.value.data
-        assert -128 <= max_int
-        assert max_int <= 127
+        assert_int8(max_int)
 
         min_int = clamp_op.min_int.value.data
-        assert -128 <= min_int
-        assert min_int <= 127
+        assert_int8(min_int)
 
         double_round = rescale_op.double_round.value.data
         assert double_round in (0, 1)

--- a/compiler/transforms/convert_tosa_to_kernel.py
+++ b/compiler/transforms/convert_tosa_to_kernel.py
@@ -1,6 +1,7 @@
 from xdsl.builder import Builder
 from xdsl.context import MLContext
 from xdsl.dialects import builtin, linalg, tosa
+from xdsl.dialects.builtin import IntegerAttr, i1, i8, i32
 from xdsl.ir import BlockArgument
 from xdsl.ir.affine import AffineDimExpr, AffineMap
 from xdsl.passes import ModulePass
@@ -71,15 +72,13 @@ class RescaleClampPattern(RewritePattern):
                 operands=[args[0]],
                 result_types=[args[-1].type],
                 properties={
-                    "input_zp": builtin.IntegerAttr(input_zp, builtin.IntegerType(8)),
-                    "output_zp": builtin.IntegerAttr(output_zp, builtin.IntegerType(8)),
-                    "multiplier": builtin.IntegerAttr(multiplier, builtin.i32),
-                    "shift": builtin.IntegerAttr(shift, builtin.IntegerType(8)),
-                    "max_int": builtin.IntegerAttr(max_int, builtin.IntegerType(8)),
-                    "min_int": builtin.IntegerAttr(min_int, builtin.IntegerType(8)),
-                    "double_round": builtin.IntegerAttr(
-                        double_round, builtin.IntegerType(1)
-                    ),
+                    "input_zp": IntegerAttr(input_zp, i8),
+                    "output_zp": IntegerAttr(output_zp, i8),
+                    "multiplier": IntegerAttr(multiplier, i32),
+                    "shift": IntegerAttr(shift, i8),
+                    "max_int": IntegerAttr(max_int, i8),
+                    "min_int": IntegerAttr(min_int, i8),
+                    "double_round": IntegerAttr(double_round, i1),
                 },
             )
             linalg.YieldOp(kernel_op)

--- a/compiler/transforms/convert_tosa_to_kernel.py
+++ b/compiler/transforms/convert_tosa_to_kernel.py
@@ -1,0 +1,113 @@
+from xdsl.builder import Builder
+from xdsl.context import MLContext
+from xdsl.dialects import builtin, linalg, tosa
+from xdsl.ir import BlockArgument, SSAValue
+from xdsl.ir.affine import AffineDimExpr, AffineMap
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+from compiler.dialects import kernel
+
+
+class RescaleClampPattern(RewritePattern):
+    """
+    Transform rescale clamp into a kernel.rescale op
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, rescale_op: tosa.RescaleOp, rewriter: PatternRewriter):
+
+        # searching for the pattern rescale + clamp
+        if len(rescale_op.output.uses) != 1:
+            return
+        if not isinstance(clamp_op := next(iter(rescale_op.output.uses)).operation, tosa.ClampOp):
+            return
+
+        # should have tensor inputs
+        if not isinstance(inp_type := rescale_op.input.type, builtin.TensorType):
+            return
+        if not isinstance(out_type := clamp_op.output.type, builtin.TensorType):
+            return
+
+        # create linalg body with kernel op with the params of tosa ops
+
+        # Extract all values:
+        input_zp = rescale_op.input_zp.value.data
+        assert -128 <= input_zp
+        assert input_zp <= 127
+
+        output_zp = rescale_op.output_zp.value.data
+        assert -128 <= output_zp
+        assert output_zp <= 127
+
+        multiplier = rescale_op.multiplier.data.data[0].data
+        assert isinstance(multiplier, int)
+
+        shift = rescale_op.shift.data.data[0].data
+        assert isinstance(shift, int)
+        assert -128 <= shift
+        assert shift <= 127
+
+        max_int = clamp_op.max_int.value.data
+        assert -128 <= max_int
+        assert max_int <= 127
+
+        min_int = clamp_op.min_int.value.data
+        assert -128 <= min_int
+        assert min_int <= 127
+
+        double_round = rescale_op.double_round.value.data
+        assert double_round in (0, 1)
+
+
+        @Builder.implicit_region((inp_type.element_type, out_type.element_type))
+        def linalg_body(args: tuple[BlockArgument, ...]) -> None:
+            kernel_op = kernel.RescaleOp(
+                operands=[args[0]],
+                result_types=[args[-1].type],
+                properties={
+                    "input_zp": builtin.IntegerAttr(input_zp, builtin.IntegerType(8)),
+                    "output_zp": builtin.IntegerAttr(output_zp, builtin.IntegerType(8)),
+                    "multiplier": builtin.IntegerAttr(multiplier, builtin.i32),
+                    "shift": builtin.IntegerAttr(shift, builtin.IntegerType(8)),
+                    "max_int": builtin.IntegerAttr(max_int, builtin.IntegerType(8)),
+                    "min_int": builtin.IntegerAttr(min_int, builtin.IntegerType(8)),
+                    "double_round": builtin.IntegerAttr(double_round, builtin.IntegerType(1)),
+                },
+            )
+            linalg.YieldOp(kernel_op)
+
+        # create elementwise linalg op
+        nb_dims = inp_type.get_num_dims()
+
+        new_op = linalg.Generic(
+            inputs=[rescale_op.input],
+            outputs=[rescale_op.input],
+            body=linalg_body,
+            indexing_maps=[
+                builtin.AffineMapAttr(AffineMap(nb_dims, 0, tuple(AffineDimExpr(i) for i in range(nb_dims))))
+                for _ in range(2)
+            ],
+            iterator_types=builtin.ArrayAttr([linalg.IteratorTypeAttr.parallel()] * 2),
+            result_types=(clamp_op.output.type,),
+        )
+
+        # insert new op
+        rewriter.replace_op(clamp_op, new_op)
+        rewriter.erase_matched_op()
+
+
+class ConvertTosaToKernelPass(ModulePass):
+    """
+    Converts tosa dialect ops to kernel ops wrapped in linalg generics.
+    """
+
+    name = "convert-tosa-to-kernel"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(RescaleClampPattern()).rewrite_module(op)

--- a/tests/filecheck/dialects/kernel/ops.mlir
+++ b/tests/filecheck/dialects/kernel/ops.mlir
@@ -28,6 +28,3 @@
 %5 = "kernel.rescale" (%0) <{"input_zp" = 23 : i8, "output_zp" = -23 : i8, "multiplier" = 12345 : i32, "shift" = 30 : i8, "max_int" = 127 : i8, "min_int" = -128 : i8, "double_round" = true}> : (i32) -> i32
 // CHECK-NEXT:   %5 = kernel.rescale %0 zero_points(23, -23) rescale(12345 >> 30) clamp(-128, 127) double_round = 1 : i32 -> i32
 // CHECK-GENERIC-NEXT    %5 = "kernel.rescale"(%0) <{"input_zp" = 23 : i8, "output_zp" = -23 : i8, "multiplier" = 12345 : i32, "shift" = 30 : i8, "max_int" = 127 : i8, "min_int" = -128 : i8, "double_round" = true}> : (i32) -> i32
-
-// CHECK-NEXT: }
-// CHECK-GENERIC-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/kernel/ops.mlir
+++ b/tests/filecheck/dialects/kernel/ops.mlir
@@ -25,5 +25,9 @@
 // CHECK-GENERIC-NEXT:   %4 = "kernel.qmac"(%0, %0, %0, %0) : (i32, i32, i32, i32) -> i32
 
 
+%5 = "kernel.rescale" (%0) <{"input_zp" = 23 : i8, "output_zp" = -23 : i8, "multiplier" = 12345 : i32, "shift" = 30 : i8, "max_int" = 127 : i8, "min_int" = -128 : i8, "double_round" = true}> : (i32) -> i32
+// CHECK-NEXT:   %5 = kernel.rescale %0 zero_points(23, -23) rescale(12345 >> 30) clamp(-128, 127) double_round = 1 : i32 -> i32
+// CHECK-GENERIC-NEXT    %5 = "kernel.rescale"(%0) <{"input_zp" = 23 : i8, "output_zp" = -23 : i8, "multiplier" = 12345 : i32, "shift" = 30 : i8, "max_int" = 127 : i8, "min_int" = -128 : i8, "double_round" = true}> : (i32) -> i32
+
 // CHECK-NEXT: }
 // CHECK-GENERIC-NEXT: }) : () -> ()

--- a/tests/filecheck/transforms/convert-tosa-to-kernel.mlir
+++ b/tests/filecheck/transforms/convert-tosa-to-kernel.mlir
@@ -1,0 +1,14 @@
+// RUN: ./compiler/snax-opt -p convert-tosa-to-kernel %s | filecheck %s
+
+%0 = "test.op"() : () -> tensor<?x8xi32>
+%1 = tosa.rescale %0 {"double_round" = true, "input_zp" = 0 : i32, "multiplier" = array<i32: 1085889731>, "output_zp" = -128 : i32, "per_channel" = false, "scale32" = true, "shift" = array<i32: 37>} : (tensor<?x8xi32>) -> tensor<?x8xi8>
+%2 = tosa.clamp %1 {"max_fp" = 0.000000e+00 : f32, "max_int" = 127 : i64, "min_fp" = 0.000000e+00 : f32, "min_int" = -128 : i64} : (tensor<?x8xi8>) -> tensor<?x8xi8>
+
+// CHECK: builtin.module {
+// CHECK-NEXT:   %0 = "test.op"() : () -> tensor<?x8xi32>
+// CHECK-NEXT:   %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0 : tensor<?x8xi32>) outs(%0 : tensor<?x8xi32>) {
+// CHECK-NEXT:   ^0(%2 : i32, %3 : i8):
+// CHECK-NEXT:     %4 = kernel.rescale %2 zero_points(0, -128) rescale(1085889731 >> 37) clamp(-128, 127) double_round = 1 : i32 -> i8
+// CHECK-NEXT:     linalg.yield %4 : i8
+// CHECK-NEXT:   } -> tensor<?x8xi8>
+// CHECK-NEXT: }


### PR DESCRIPTION
This PR specifies the convert-tosa-to-kernel pass, useful for the new rescaling op. In linalg.generic format, this op is humongous and very inconvenient to try and parse, so this pass just allows for a lowering straight from tosa