### PR TITLE
add debugging dialect and pass

### DIFF
--- a/compiler/dialects/test/debug.py
+++ b/compiler/dialects/test/debug.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from xdsl.dialects.builtin import (
+    MemRefType,
+    StringAttr,
+)
+from xdsl.ir import Attribute, Dialect, SSAValue
+from xdsl.irdl import (
+    IRDLOperation,
+    irdl_op_definition,
+    operand_def,
+    prop_def,
+)
+
+
+@irdl_op_definition
+class DebugOp(IRDLOperation):
+    """
+    Run a debug statement, passing operands to a C function
+    to allow inspection of the memref operands.
+    """
+
+    name = "debug.debug"
+
+    op_a = operand_def(MemRefType[Attribute])
+    op_b = operand_def(MemRefType[Attribute])
+    op_c = operand_def(MemRefType[Attribute])
+
+    # what linalg kernel am i debugging?
+    debug_type = prop_def(StringAttr)
+
+    # am i debuggin before or after the op?
+    when = prop_def(StringAttr)
+
+    # at what memory level is the data i am inspecting?
+    level = prop_def(StringAttr)
+
+    def __init__(
+        self,
+        op_a: SSAValue,
+        op_b: SSAValue,
+        op_c: SSAValue,
+        debug_type: str,
+        when: str,
+        level: str = "L1",
+    ):
+        super().__init__(
+            operands=[op_a, op_b, op_c],
+            result_types=[],
+            properties={
+                "debug_type": StringAttr(debug_type),
+                "when": StringAttr(when),
+                "level": StringAttr(level),
+            },
+        )
+
+
+Debug = Dialect("debug", [DebugOp])

--- a/compiler/dialects/test/debug.py
+++ b/compiler/dialects/test/debug.py
@@ -14,13 +14,13 @@ from xdsl.irdl import (
 
 
 @irdl_op_definition
-class DebugOp(IRDLOperation):
+class DebugLinalgOp(IRDLOperation):
     """
     Run a debug statement, passing operands to a C function
     to allow inspection of the memref operands.
     """
 
-    name = "debug.debug"
+    name = "debug.linalg"
 
     op_a = operand_def(MemRefType[Attribute])
     op_b = operand_def(MemRefType[Attribute])
@@ -55,4 +55,4 @@ class DebugOp(IRDLOperation):
         )
 
 
-Debug = Dialect("debug", [DebugOp])
+Debug = Dialect("debug", [DebugLinalgOp])

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -8,6 +8,7 @@ from compiler.dialects.accfg import ACCFG
 from compiler.dialects.kernel import Kernel
 from compiler.dialects.snax import Snax
 from compiler.dialects.snax_stream import SnaxStream
+from compiler.dialects.test.debug import Debug
 from compiler.dialects.tsl import TSL
 from compiler.transforms.accfg_config_overlap import AccfgConfigOverlapPass
 from compiler.transforms.accfg_dedup import AccfgDeduplicate
@@ -38,6 +39,8 @@ from compiler.transforms.snax_copy_to_dma import SNAXCopyToDMA
 from compiler.transforms.snax_lower_mcycle import SNAXLowerMCycle
 from compiler.transforms.snax_to_func import SNAXToFunc
 from compiler.transforms.stream_snaxify import StreamSnaxify
+from compiler.transforms.test.debug_to_func import DebugToFuncPass
+from compiler.transforms.test.insert_debugs import InsertDebugPass
 from compiler.transforms.test_add_mcycle_around_loop import AddMcycleAroundLoopPass
 from compiler.transforms.test_remove_memref_copy import RemoveMemrefCopyPass
 
@@ -67,6 +70,7 @@ class SNAXOptMain(xDSLOptMain):
         self.ctx.load_dialect(Kernel)
         self.ctx.load_dialect(ACCFG)
         self.ctx.load_dialect(SnaxStream)
+        self.ctx.load_dialect(Debug)
         super().register_pass(DispatchKernels.name, lambda: DispatchKernels)
         super().register_pass(LinalgToLibraryCall.name, lambda: LinalgToLibraryCall)
         super().register_pass(SetMemorySpace.name, lambda: SetMemorySpace)
@@ -107,6 +111,8 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(
             ConvertTosaToKernelPass.name, lambda: ConvertTosaToKernelPass
         )
+        super().register_pass(InsertDebugPass.name, lambda: InsertDebugPass)
+        super().register_pass(DebugToFuncPass.name, lambda: DebugToFuncPass)
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/transforms/test/debug_to_func.py
+++ b/compiler/transforms/test/debug_to_func.py
@@ -1,6 +1,6 @@
 from xdsl.context import MLContext
 from xdsl.dialects import arith, builtin, func, memref
-from xdsl.irdl.operations import Operation
+from xdsl.irdl import Operation
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     PatternRewriter,
@@ -17,7 +17,7 @@ class DebugToFunc(RewritePattern):
     """Insert debugging function calls"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: debug.DebugOp, rewriter: PatternRewriter):
+    def match_and_rewrite(self, op: debug.DebugLinalgOp, rewriter: PatternRewriter):
         ptr_a = memref.ExtractAlignedPointerAsIndexOp.get(op.op_a)
         ptr_b = memref.ExtractAlignedPointerAsIndexOp.get(op.op_b)
         ptr_c = memref.ExtractAlignedPointerAsIndexOp.get(op.op_c)

--- a/compiler/transforms/test/debug_to_func.py
+++ b/compiler/transforms/test/debug_to_func.py
@@ -65,7 +65,7 @@ class DebugToFunc(RewritePattern):
 
 
 class DebugToFuncPass(ModulePass):
-    name = "debug-to-func"
+    name = "test-debug-to-func"
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         PatternRewriteWalker(DebugToFunc()).rewrite_module(op)

--- a/compiler/transforms/test/debug_to_func.py
+++ b/compiler/transforms/test/debug_to_func.py
@@ -46,13 +46,13 @@ class DebugToFunc(RewritePattern):
         ops_to_insert.append(when)
 
         func_call = func.Call(
-            f"snax_debug_{op.debug_type.data}", [ptr_a, ptr_b, ptr_c, when], []
+            f"debug_{op.debug_type.data}", [ptr_a, ptr_b, ptr_c, when], []
         )
         ops_to_insert.append(func_call)
         rewriter.replace_matched_op(ops_to_insert)
 
         func_decl = func.FuncOp.external(
-            f"snax_debug_{op.debug_type.data}",
+            f"debug_{op.debug_type.data}",
             [builtin.i32, builtin.i32, builtin.i32, builtin.i32],
             [],
         )

--- a/compiler/transforms/test/debug_to_func.py
+++ b/compiler/transforms/test/debug_to_func.py
@@ -1,0 +1,71 @@
+from xdsl.context import MLContext
+from xdsl.dialects import arith, builtin, func, memref
+from xdsl.irdl.operations import Operation
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.traits import SymbolTable
+
+from compiler.dialects.test import debug
+
+
+class DebugToFunc(RewritePattern):
+    """Insert debugging function calls"""
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: debug.DebugOp, rewriter: PatternRewriter):
+        ptr_a = memref.ExtractAlignedPointerAsIndexOp.get(op.op_a)
+        ptr_b = memref.ExtractAlignedPointerAsIndexOp.get(op.op_b)
+        ptr_c = memref.ExtractAlignedPointerAsIndexOp.get(op.op_c)
+
+        ops_to_insert: list[Operation] = [ptr_a, ptr_b, ptr_c]
+
+        ptr_a = arith.IndexCastOp(ptr_a, builtin.i32)
+        ptr_b = arith.IndexCastOp(ptr_b, builtin.i32)
+        ptr_c = arith.IndexCastOp(ptr_c, builtin.i32)
+
+        ops_to_insert.extend([ptr_a, ptr_b, ptr_c])
+
+        match (op.when.data, op.level.data):
+            case "before", "L3":
+                whenparam = 0
+            case "before", "L1":
+                whenparam = 1
+            case "after", "L1":
+                whenparam = 2
+            case "after", "L3":
+                whenparam = 3
+            case _:
+                whenparam = 5
+
+        when = arith.Constant.from_int_and_width(whenparam, 32)
+        ops_to_insert.append(when)
+
+        func_call = func.Call(
+            f"snax_debug_{op.debug_type.data}", [ptr_a, ptr_b, ptr_c, when], []
+        )
+        ops_to_insert.append(func_call)
+        rewriter.replace_matched_op(ops_to_insert)
+
+        func_decl = func.FuncOp.external(
+            f"snax_debug_{op.debug_type.data}",
+            [builtin.i32, builtin.i32, builtin.i32, builtin.i32],
+            [],
+        )
+        module_op = func_call
+        while not isinstance(module_op, builtin.ModuleOp):
+            x = module_op.parent_op()
+            assert x is not None
+            module_op = x
+        SymbolTable.insert_or_update(module_op, func_decl)
+
+
+class DebugToFuncPass(ModulePass):
+    name = "debug-to-func"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(DebugToFunc()).rewrite_module(op)

--- a/compiler/transforms/test/insert_debugs.py
+++ b/compiler/transforms/test/insert_debugs.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+
+from xdsl.context import MLContext
+from xdsl.dialects import builtin, linalg
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.rewriter import InsertPoint
+
+from compiler.dialects.test import debug
+
+
+@dataclass(frozen=True)
+class InsertDebugStatements(RewritePattern):
+    """
+    Insert debugs :)
+    Do this before and after every linalg generic operation.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: linalg.Generic, rewriter: PatternRewriter):
+        kernel_type = op.body.block.first_op
+        assert kernel_type
+        kernel_name = kernel_type.name
+
+        memreftype = op.inputs[0].type
+        if not isinstance(memreftype, builtin.MemRefType):
+            return
+
+        if isinstance(memreftype.memory_space, builtin.StringAttr):
+            level = memreftype.memory_space.data
+        else:
+            level = "none"
+
+        debug_before = debug.DebugOp(
+            op.inputs[0], op.inputs[-1], op.outputs[0], kernel_name, "before", level
+        )
+        debug_after = debug.DebugOp(
+            op.inputs[0], op.inputs[-1], op.outputs[0], kernel_name, "after", level
+        )
+        rewriter.insert_op(debug_before, InsertPoint.before(op))
+        rewriter.insert_op(debug_after, InsertPoint.after(op))
+
+
+class InsertDebugPass(ModulePass):
+    name = "insert-debugs"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(
+            InsertDebugStatements(), apply_recursively=False
+        ).rewrite_module(op)

--- a/compiler/transforms/test/insert_debugs.py
+++ b/compiler/transforms/test/insert_debugs.py
@@ -35,7 +35,8 @@ class InsertDebugStatements(RewritePattern):
         if isinstance(memreftype.memory_space, builtin.StringAttr):
             level = memreftype.memory_space.data
         else:
-            level = "none"
+            # defaulting to L3
+            level = "L3"
 
         debug_before = debug.DebugLinalgOp(
             op.inputs[0], op.inputs[-1], op.outputs[0], kernel_name, "before", level

--- a/compiler/transforms/test/insert_debugs.py
+++ b/compiler/transforms/test/insert_debugs.py
@@ -37,10 +37,10 @@ class InsertDebugStatements(RewritePattern):
         else:
             level = "none"
 
-        debug_before = debug.DebugOp(
+        debug_before = debug.DebugLinalgOp(
             op.inputs[0], op.inputs[-1], op.outputs[0], kernel_name, "before", level
         )
-        debug_after = debug.DebugOp(
+        debug_after = debug.DebugLinalgOp(
             op.inputs[0], op.inputs[-1], op.outputs[0], kernel_name, "after", level
         )
         rewriter.insert_op(debug_before, InsertPoint.before(op))

--- a/compiler/transforms/test/insert_debugs.py
+++ b/compiler/transforms/test/insert_debugs.py
@@ -26,6 +26,7 @@ class InsertDebugStatements(RewritePattern):
         kernel_type = op.body.block.first_op
         assert kernel_type
         kernel_name = kernel_type.name
+        kernel_name = kernel_name.replace(".", "_")
 
         memreftype = op.inputs[0].type
         if not isinstance(memreftype, builtin.MemRefType):

--- a/compiler/transforms/test/insert_debugs.py
+++ b/compiler/transforms/test/insert_debugs.py
@@ -48,7 +48,7 @@ class InsertDebugStatements(RewritePattern):
 
 
 class InsertDebugPass(ModulePass):
-    name = "insert-debugs"
+    name = "test-insert-debugs"
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         PatternRewriteWalker(

--- a/kernels/streamer_alu/Makefile
+++ b/kernels/streamer_alu/Makefile
@@ -12,8 +12,7 @@ TESTS += streamer_add_stream.x
 CFLAGS += -std=gnu11
 CFLAGS += -Wall -Wextra
 
-SNAXOPTFLAGS = -p dispatch-kernels,set-memory-space,set-memory-layout,realize-memref-casts,insert-sync-barrier,dispatch-regions,insert-accfg-op{accelerator=snax_alu},guarded-linalg-to-memref-stream,schedule-memref-linalg,memref-streamify,stream-snaxify,convert-linalg-to-accfg,convert-accfg-to-csr,snax-copy-to-dma,memref-to-snax,snax-to-func,clear-memory-space
-
+SNAXOPTFLAGS = -p dispatch-kernels,test-insert-debugs,set-memory-space,set-memory-layout,test-insert-debugs,realize-memref-casts,insert-sync-barrier,dispatch-regions,insert-accfg-op{accelerator=snax_alu},guarded-linalg-to-memref-stream,schedule-memref-linalg,memref-streamify,stream-snaxify,convert-linalg-to-accfg,convert-accfg-to-csr,snax-copy-to-dma,memref-to-snax,snax-to-func,test-debug-to-func,clear-memory-space
 
 data.c data.h:
 	$(PYTHON) gendata.py

--- a/kernels/streamer_alu/main.c
+++ b/kernels/streamer_alu/main.c
@@ -6,20 +6,22 @@
 void _mlir_ciface_streamer_add(OneDMemrefI64_t *A, OneDMemrefI64_t *B,
                                OneDMemrefI64_t *O);
 
-void _mlir_ciface_debug_arith_addi(int32_t _ptr_a, int32_t _ptr_b, int32_t _ptr_c, int32_t when) {
+void _mlir_ciface_debug_arith_addi(int32_t _ptr_a, int32_t _ptr_b,
+                                   int32_t _ptr_c, int32_t when) {
   int64_t *ptr_a, *ptr_b, *ptr_c;
-  ptr_a = (int64_t*) _ptr_a;
-  ptr_b = (int64_t*) _ptr_b;
-  ptr_c = (int64_t*) _ptr_c;
+  ptr_a = (int64_t *)_ptr_a;
+  ptr_b = (int64_t *)_ptr_b;
+  ptr_c = (int64_t *)_ptr_c;
 
   if (snrt_cluster_core_idx() == 0) {
-    printf("Debugging at t = %d with A at %p, B at %p, C at %p\n", when, ptr_a, ptr_b, ptr_c);
+    printf("Debugging at t = %d with A at %p, B at %p, C at %p\n", when, ptr_a,
+           ptr_b, ptr_c);
 
     for (int i = 0; i < 5; i++) {
-      printf("i%d -> A=%d, B=%d, C=%d\n", i, (int32_t) ptr_a[i], (int32_t) ptr_b[i], (int32_t) ptr_c[i]);
+      printf("i%d -> A=%d, B=%d, C=%d\n", i, (int32_t)ptr_a[i],
+             (int32_t)ptr_b[i], (int32_t)ptr_c[i]);
     }
   }
-
 }
 
 int main() {

--- a/kernels/streamer_alu/main.c
+++ b/kernels/streamer_alu/main.c
@@ -6,6 +6,22 @@
 void _mlir_ciface_streamer_add(OneDMemrefI64_t *A, OneDMemrefI64_t *B,
                                OneDMemrefI64_t *O);
 
+void _mlir_ciface_debug_arith_addi(int32_t _ptr_a, int32_t _ptr_b, int32_t _ptr_c, int32_t when) {
+  int64_t *ptr_a, *ptr_b, *ptr_c;
+  ptr_a = (int64_t*) _ptr_a;
+  ptr_b = (int64_t*) _ptr_b;
+  ptr_c = (int64_t*) _ptr_c;
+
+  if (snrt_cluster_core_idx() == 0) {
+    printf("Debugging at t = %d with A at %p, B at %p, C at %p\n", when, ptr_a, ptr_b, ptr_c);
+
+    for (int i = 0; i < 5; i++) {
+      printf("i%d -> A=%d, B=%d, C=%d\n", i, (int32_t) ptr_a[i], (int32_t) ptr_b[i], (int32_t) ptr_c[i]);
+    }
+  }
+
+}
+
 int main() {
   // Set err value for checking
   int err = 0;

--- a/tests/filecheck/transforms/test/debug-to-func.mlir
+++ b/tests/filecheck/transforms/test/debug-to-func.mlir
@@ -6,7 +6,7 @@ builtin.module {
       %0 = kernel.mac %arg3, %arg4 : i64, i64 -> i64
       linalg.yield %0 : i64
     }
-    "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel.mac", "when" = "after", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+    "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "after", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
     func.return
   }
 }
@@ -20,7 +20,7 @@ builtin.module {
 // CHECK-NEXT     %4 = arith.index_cast %1 : index to i32
 // CHECK-NEXT     %5 = arith.index_cast %2 : index to i32
 // CHECK-NEXT     %6 = arith.constant 5 : i32
-// CHECK-NEXT     func.call @snax_debug_kernel.mac(%3, %4, %5, %6) : (i32, i32, i32, i32) -> ()
+// CHECK-NEXT     func.call @debug_kernel_mac(%3, %4, %5, %6) : (i32, i32, i32, i32) -> ()
 // CHECK-NEXT     linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<?xi64>, memref<?xi64>) outs(%arg2 : memref<?xi64>) {
 // CHECK-NEXT     ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
 // CHECK-NEXT       %7 = kernel.mac %arg3, %arg4 : i64, i64 -> i64
@@ -33,8 +33,8 @@ builtin.module {
 // CHECK-NEXT     %12 = arith.index_cast %9 : index to i32
 // CHECK-NEXT     %13 = arith.index_cast %10 : index to i32
 // CHECK-NEXT     %14 = arith.constant 5 : i32
-// CHECK-NEXT     func.call @snax_debug_kernel.mac(%11, %12, %13, %14) : (i32, i32, i32, i32) -> ()
+// CHECK-NEXT     func.call @debug_kernel_mac(%11, %12, %13, %14) : (i32, i32, i32, i32) -> ()
 // CHECK-NEXT     func.return
 // CHECK-NEXT   }
-// CHECK-NEXT   func.func private @snax_debug_kernel.mac(i32, i32, i32, i32) -> ()
+// CHECK-NEXT   func.func private @debug_kernel_mac(i32, i32, i32, i32) -> ()
 // CHECK-NEXT }

--- a/tests/filecheck/transforms/test/debug-to-func.mlir
+++ b/tests/filecheck/transforms/test/debug-to-func.mlir
@@ -1,0 +1,40 @@
+builtin.module {
+  func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %arg2 : memref<?xi64>) {
+    "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel.mac", "when" = "before", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+    linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<?xi64>, memref<?xi64>) outs(%arg2 : memref<?xi64>) {
+    ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
+      %0 = kernel.mac %arg3, %arg4 : i64, i64 -> i64
+      linalg.yield %0 : i64
+    }
+    "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel.mac", "when" = "after", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+    func.return
+  }
+}
+
+// CHECK       builtin.module {
+// CHECK-NEXT   func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %arg2 : memref<?xi64>) {
+// CHECK-NEXT     %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi64>) -> index
+// CHECK-NEXT     %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi64>) -> index
+// CHECK-NEXT     %2 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi64>) -> index
+// CHECK-NEXT     %3 = arith.index_cast %0 : index to i32
+// CHECK-NEXT     %4 = arith.index_cast %1 : index to i32
+// CHECK-NEXT     %5 = arith.index_cast %2 : index to i32
+// CHECK-NEXT     %6 = arith.constant 5 : i32
+// CHECK-NEXT     func.call @snax_debug_kernel.mac(%3, %4, %5, %6) : (i32, i32, i32, i32) -> ()
+// CHECK-NEXT     linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<?xi64>, memref<?xi64>) outs(%arg2 : memref<?xi64>) {
+// CHECK-NEXT     ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
+// CHECK-NEXT       %7 = kernel.mac %arg3, %arg4 : i64, i64 -> i64
+// CHECK-NEXT       linalg.yield %7 : i64
+// CHECK-NEXT     }
+// CHECK-NEXT     %8 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi64>) -> index
+// CHECK-NEXT     %9 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi64>) -> index
+// CHECK-NEXT     %10 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi64>) -> index
+// CHECK-NEXT     %11 = arith.index_cast %8 : index to i32
+// CHECK-NEXT     %12 = arith.index_cast %9 : index to i32
+// CHECK-NEXT     %13 = arith.index_cast %10 : index to i32
+// CHECK-NEXT     %14 = arith.constant 5 : i32
+// CHECK-NEXT     func.call @snax_debug_kernel.mac(%11, %12, %13, %14) : (i32, i32, i32, i32) -> ()
+// CHECK-NEXT     func.return
+// CHECK-NEXT   }
+// CHECK-NEXT   func.func private @snax_debug_kernel.mac(i32, i32, i32, i32) -> ()
+// CHECK-NEXT }

--- a/tests/filecheck/transforms/test/debug-to-func.mlir
+++ b/tests/filecheck/transforms/test/debug-to-func.mlir
@@ -2,13 +2,13 @@
 
 builtin.module {
   func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %arg2 : memref<?xi64>) {
-    "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "before", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+    "debug.linalg"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "before", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
     linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<?xi64>, memref<?xi64>) outs(%arg2 : memref<?xi64>) {
     ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
       %0 = kernel.mac %arg3, %arg4 : i64, i64 -> i64
       linalg.yield %0 : i64
     }
-    "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "after", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+    "debug.linalg"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "after", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
     func.return
   }
 }

--- a/tests/filecheck/transforms/test/debug-to-func.mlir
+++ b/tests/filecheck/transforms/test/debug-to-func.mlir
@@ -1,6 +1,8 @@
+// RUN: ./compiler/snax-opt %s -p test-debug-to-func | filecheck %s
+
 builtin.module {
   func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %arg2 : memref<?xi64>) {
-    "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel.mac", "when" = "before", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+    "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "before", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
     linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<?xi64>, memref<?xi64>) outs(%arg2 : memref<?xi64>) {
     ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
       %0 = kernel.mac %arg3, %arg4 : i64, i64 -> i64
@@ -11,30 +13,30 @@ builtin.module {
   }
 }
 
-// CHECK       builtin.module {
-// CHECK-NEXT   func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %arg2 : memref<?xi64>) {
-// CHECK-NEXT     %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi64>) -> index
-// CHECK-NEXT     %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi64>) -> index
-// CHECK-NEXT     %2 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi64>) -> index
-// CHECK-NEXT     %3 = arith.index_cast %0 : index to i32
-// CHECK-NEXT     %4 = arith.index_cast %1 : index to i32
-// CHECK-NEXT     %5 = arith.index_cast %2 : index to i32
-// CHECK-NEXT     %6 = arith.constant 5 : i32
-// CHECK-NEXT     func.call @debug_kernel_mac(%3, %4, %5, %6) : (i32, i32, i32, i32) -> ()
-// CHECK-NEXT     linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<?xi64>, memref<?xi64>) outs(%arg2 : memref<?xi64>) {
-// CHECK-NEXT     ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
-// CHECK-NEXT       %7 = kernel.mac %arg3, %arg4 : i64, i64 -> i64
-// CHECK-NEXT       linalg.yield %7 : i64
-// CHECK-NEXT     }
-// CHECK-NEXT     %8 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi64>) -> index
-// CHECK-NEXT     %9 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi64>) -> index
-// CHECK-NEXT     %10 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi64>) -> index
-// CHECK-NEXT     %11 = arith.index_cast %8 : index to i32
-// CHECK-NEXT     %12 = arith.index_cast %9 : index to i32
-// CHECK-NEXT     %13 = arith.index_cast %10 : index to i32
-// CHECK-NEXT     %14 = arith.constant 5 : i32
-// CHECK-NEXT     func.call @debug_kernel_mac(%11, %12, %13, %14) : (i32, i32, i32, i32) -> ()
-// CHECK-NEXT     func.return
-// CHECK-NEXT   }
-// CHECK-NEXT   func.func private @debug_kernel_mac(i32, i32, i32, i32) -> ()
-// CHECK-NEXT }
+// CHECK:       builtin.module {
+// CHECK-NEXT:   func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %arg2 : memref<?xi64>) {
+// CHECK-NEXT:     %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi64>) -> index
+// CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi64>) -> index
+// CHECK-NEXT:     %2 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi64>) -> index
+// CHECK-NEXT:     %3 = arith.index_cast %0 : index to i32
+// CHECK-NEXT:     %4 = arith.index_cast %1 : index to i32
+// CHECK-NEXT:     %5 = arith.index_cast %2 : index to i32
+// CHECK-NEXT:     %6 = arith.constant 5 : i32
+// CHECK-NEXT:     func.call @debug_kernel_mac(%3, %4, %5, %6) : (i32, i32, i32, i32) -> ()
+// CHECK-NEXT:     linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<?xi64>, memref<?xi64>) outs(%arg2 : memref<?xi64>) {
+// CHECK-NEXT:     ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
+// CHECK-NEXT:       %7 = kernel.mac %arg3, %arg4 : i64, i64 -> i64
+// CHECK-NEXT:       linalg.yield %7 : i64
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %8 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi64>) -> index
+// CHECK-NEXT:     %9 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi64>) -> index
+// CHECK-NEXT:     %10 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi64>) -> index
+// CHECK-NEXT:     %11 = arith.index_cast %8 : index to i32
+// CHECK-NEXT:     %12 = arith.index_cast %9 : index to i32
+// CHECK-NEXT:     %13 = arith.index_cast %10 : index to i32
+// CHECK-NEXT:     %14 = arith.constant 5 : i32
+// CHECK-NEXT:     func.call @debug_kernel_mac(%11, %12, %13, %14) : (i32, i32, i32, i32) -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @debug_kernel_mac(i32, i32, i32, i32) -> ()
+// CHECK-NEXT:  }

--- a/tests/filecheck/transforms/test/insert-debugs.mlir
+++ b/tests/filecheck/transforms/test/insert-debugs.mlir
@@ -1,3 +1,5 @@
+// RUN: ./compiler/snax-opt %s -p test-insert-debugs | filecheck %s
+
 func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %arg2 : memref<?xi64>) {
   linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<?xi64>, memref<?xi64>) outs(%arg2 : memref<?xi64>) {
   ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
@@ -7,15 +9,15 @@ func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %ar
   func.return
 }
 
-// CHECK      builtin.module {
-// CHECK-NEXT   func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %arg2 : memref<?xi64>) {
-// CHECK-NEXT     "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "before", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
-// CHECK-NEXT     linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<?xi64>, memref<?xi64>) outs(%arg2 : memref<?xi64>) {
-// CHECK-NEXT     ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
-// CHECK-NEXT       %0 = kernel.mac %arg3, %arg4 : i64, i64 -> i64
-// CHECK-NEXT       linalg.yield %0 : i64
-// CHECK-NEXT     }
-// CHECK-NEXT     "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "after", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
-// CHECK-NEXT     func.return
-// CHECK-NEXT   }
-// CHECK-NEXT }
+// CHECK:      builtin.module {
+// CHECK-NEXT:   func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %arg2 : memref<?xi64>) {
+// CHECK-NEXT:     "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "before", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+// CHECK-NEXT:     linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<?xi64>, memref<?xi64>) outs(%arg2 : memref<?xi64>) {
+// CHECK-NEXT:     ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
+// CHECK-NEXT:       %0 = kernel.mac %arg3, %arg4 : i64, i64 -> i64
+// CHECK-NEXT:       linalg.yield %0 : i64
+// CHECK-NEXT:     }
+// CHECK-NEXT:     "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "after", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/tests/filecheck/transforms/test/insert-debugs.mlir
+++ b/tests/filecheck/transforms/test/insert-debugs.mlir
@@ -11,13 +11,13 @@ func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %ar
 
 // CHECK:      builtin.module {
 // CHECK-NEXT:   func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %arg2 : memref<?xi64>) {
-// CHECK-NEXT:     "debug.linalg"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "before", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+// CHECK-NEXT:     "debug.linalg"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "before", "level" = "L3"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
 // CHECK-NEXT:     linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<?xi64>, memref<?xi64>) outs(%arg2 : memref<?xi64>) {
 // CHECK-NEXT:     ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
 // CHECK-NEXT:       %0 = kernel.mac %arg3, %arg4 : i64, i64 -> i64
 // CHECK-NEXT:       linalg.yield %0 : i64
 // CHECK-NEXT:     }
-// CHECK-NEXT:     "debug.linalg"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "after", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+// CHECK-NEXT:     "debug.linalg"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "after", "level" = "L3"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/test/insert-debugs.mlir
+++ b/tests/filecheck/transforms/test/insert-debugs.mlir
@@ -1,0 +1,21 @@
+func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %arg2 : memref<?xi64>) {
+  linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<?xi64>, memref<?xi64>) outs(%arg2 : memref<?xi64>) {
+  ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
+    %0 = kernel.mac %arg3, %arg4 : i64, i64 -> i64
+    linalg.yield %0 : i64
+  }
+  func.return
+}
+
+// CHECK      builtin.module {
+// CHECK-NEXT   func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %arg2 : memref<?xi64>) {
+// CHECK-NEXT     "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel.mac", "when" = "before", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+// CHECK-NEXT     linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<?xi64>, memref<?xi64>) outs(%arg2 : memref<?xi64>) {
+// CHECK-NEXT     ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
+// CHECK-NEXT       %0 = kernel.mac %arg3, %arg4 : i64, i64 -> i64
+// CHECK-NEXT       linalg.yield %0 : i64
+// CHECK-NEXT     }
+// CHECK-NEXT     "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel.mac", "when" = "after", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+// CHECK-NEXT     func.return
+// CHECK-NEXT   }
+// CHECK-NEXT }

--- a/tests/filecheck/transforms/test/insert-debugs.mlir
+++ b/tests/filecheck/transforms/test/insert-debugs.mlir
@@ -11,13 +11,13 @@ func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %ar
 
 // CHECK:      builtin.module {
 // CHECK-NEXT:   func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %arg2 : memref<?xi64>) {
-// CHECK-NEXT:     "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "before", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+// CHECK-NEXT:     "debug.linalg"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "before", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
 // CHECK-NEXT:     linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<?xi64>, memref<?xi64>) outs(%arg2 : memref<?xi64>) {
 // CHECK-NEXT:     ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
 // CHECK-NEXT:       %0 = kernel.mac %arg3, %arg4 : i64, i64 -> i64
 // CHECK-NEXT:       linalg.yield %0 : i64
 // CHECK-NEXT:     }
-// CHECK-NEXT:     "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "after", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+// CHECK-NEXT:     "debug.linalg"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "after", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/test/insert-debugs.mlir
+++ b/tests/filecheck/transforms/test/insert-debugs.mlir
@@ -9,13 +9,13 @@ func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %ar
 
 // CHECK      builtin.module {
 // CHECK-NEXT   func.func public @streamer_add(%arg0 : memref<?xi64>, %arg1 : memref<?xi64>, %arg2 : memref<?xi64>) {
-// CHECK-NEXT     "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel.mac", "when" = "before", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+// CHECK-NEXT     "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "before", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
 // CHECK-NEXT     linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<?xi64>, memref<?xi64>) outs(%arg2 : memref<?xi64>) {
 // CHECK-NEXT     ^0(%arg3 : i64, %arg4 : i64, %arg5 : i64):
 // CHECK-NEXT       %0 = kernel.mac %arg3, %arg4 : i64, i64 -> i64
 // CHECK-NEXT       linalg.yield %0 : i64
 // CHECK-NEXT     }
-// CHECK-NEXT     "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel.mac", "when" = "after", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
+// CHECK-NEXT     "debug.debug"(%arg0, %arg1, %arg2) <{"debug_type" = "kernel_mac", "when" = "after", "level" = "none"}> : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
 // CHECK-NEXT     func.return
 // CHECK-NEXT   }
 // CHECK-NEXT }


### PR DESCRIPTION
This PR adds some testing infrastructure to better inspect larger kernels such as neural networks.
It allows for the automatic insertion of debug statements before and after every linalg.generic kernel.
The debug statements are later transformed into function calls. 
The function definition can be provided by the user in the `main.c` file, where you can inspect the operands given to you by the debug statements.

Because this is not really core infrastructure, i put all the files in a `test/` subfolder