### PR TITLE
add dump l1 operation

### DIFF
--- a/compiler/dialects/snax.py
+++ b/compiler/dialects/snax.py
@@ -151,6 +151,13 @@ class Alloc(IRDLOperation):
         descriptor = LLVMMemrefDescriptor(self.result.type)
         descriptor.verify()
 
+@irdl_op_definition
+class DumpL1(IRDLOperation):
+    """
+    Basically perform a full memory dump of L1.
+    Every allocated memref in L1 is now invalidated.
+    """
+    name = "snax.dump_l1"
 
 @irdl_attr_definition
 class StreamerConfigurationAttr(Data[StreamerConfiguration]):
@@ -208,5 +215,5 @@ class StreamerConfigurationAttr(Data[StreamerConfiguration]):
 
 
 Snax = Dialect(
-    "snax", [ClusterSyncOp, MCycleOp, LayoutCast, Alloc], [StreamerConfigurationAttr]
+    "snax", [ClusterSyncOp, MCycleOp, LayoutCast, Alloc, DumpL1], [StreamerConfigurationAttr]
 )

--- a/runtime/include/snax_rt.h
+++ b/runtime/include/snax_rt.h
@@ -44,6 +44,20 @@ alloc_result_t *_mlir_ciface_snax_alloc_l1(uint32_t size, uint32_t alignment) {
   return allocated_result;
 }
 
+void _mlir_ciface_snax_dump_l1() {
+  snrt_alloc_init();
+  // keep first row of the tcdm free for zero wizardry
+  // this has a similar function to the zero register of risc-v
+  snrt_l1alloc(256);
+  // memset all to 0 with DMA
+  if (snrt_is_dm_core()) {
+    snrt_dma_start_2d((int32_t*) 0x10000040, (int32_t*) 0x10000000, 0x40, 0x40, 0, 0x1800);
+    snrt_dma_wait_all();
+  }
+  snrt_cluster_hw_barrier();
+  return;
+}
+
 void _mlir_ciface_snax_cluster_hw_barrier() {
   snrt_cluster_hw_barrier();
   return;


### PR DESCRIPTION
This operation allows you to clear the entire TCDM and reset everything to zero.
In the purely hypothetical case you haven't figured out how to do proper memory allocation, this can help you.