### PR TITLE
transform: (convert-tosa-to-kernel) use correct output type

### DIFF
--- a/compiler/transforms/convert_tosa_to_kernel.py
+++ b/compiler/transforms/convert_tosa_to_kernel.py
@@ -1,8 +1,8 @@
 from xdsl.builder import Builder
 from xdsl.context import MLContext
-from xdsl.dialects import builtin, linalg, tosa
+from xdsl.dialects import arith, builtin, linalg, tensor, tosa
 from xdsl.dialects.builtin import IntegerAttr, i1, i8, i32
-from xdsl.ir import BlockArgument
+from xdsl.ir import BlockArgument, Operation
 from xdsl.ir.affine import AffineDimExpr, AffineMap
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -15,10 +15,11 @@ from xdsl.pattern_rewriter import (
 from compiler.dialects import kernel
 
 
-def assert_int8(val):
+def assert_int8(val) -> int:
     assert isinstance(val, int)
     assert -128 <= val
     assert val <= 127
+    return val
 
 
 class RescaleClampPattern(RewritePattern):
@@ -45,24 +46,13 @@ class RescaleClampPattern(RewritePattern):
         # create linalg body with kernel op with the params of tosa ops
 
         # Extract all values:
-        input_zp = rescale_op.input_zp.value.data
-        assert_int8(input_zp)
-
-        output_zp = rescale_op.output_zp.value.data
-        assert_int8(output_zp)
-
+        input_zp = assert_int8(rescale_op.input_zp.value.data)
+        output_zp = assert_int8(rescale_op.output_zp.value.data)
         multiplier = rescale_op.multiplier.data.data[0].data
         assert isinstance(multiplier, int)
-
-        shift = rescale_op.shift.data.data[0].data
-        assert_int8(shift)
-
-        max_int = clamp_op.max_int.value.data
-        assert_int8(max_int)
-
-        min_int = clamp_op.min_int.value.data
-        assert_int8(min_int)
-
+        shift = assert_int8(rescale_op.shift.data.data[0].data)
+        max_int = assert_int8(clamp_op.max_int.value.data)
+        min_int = assert_int8(clamp_op.min_int.value.data)
         double_round = rescale_op.double_round.value.data
         assert double_round in (0, 1)
 
@@ -86,9 +76,21 @@ class RescaleClampPattern(RewritePattern):
         # create elementwise linalg op
         nb_dims = inp_type.get_num_dims()
 
+        # destination type:
+        dim_idx_ops: list[arith.Constant] = []
+        dim_ops: list[tensor.DimOp] = []
+        for dim_idx, shape in enumerate(out_type.get_shape()):
+            if shape == -1:
+                # create dim op
+                dim_idx_ops.append(dim_idx := arith.Constant.from_int_and_width(dim_idx, builtin.IndexType()))
+                dim_ops.append(tensor.DimOp(rescale_op.input, dim_idx))
+
+        dim_op_values = [dim_op.result for dim_op in dim_ops]
+        output_tensor = tensor.EmptyOp(dim_op_values, out_type)
+
         new_op = linalg.Generic(
             inputs=[rescale_op.input],
-            outputs=[rescale_op.input],
+            outputs=[output_tensor.tensor],
             body=linalg_body,
             indexing_maps=[
                 builtin.AffineMapAttr(
@@ -103,7 +105,7 @@ class RescaleClampPattern(RewritePattern):
         )
 
         # insert new op
-        rewriter.replace_op(clamp_op, new_op)
+        rewriter.replace_op(clamp_op, (*dim_idx_ops, *dim_ops, output_tensor, new_op))
         rewriter.erase_matched_op()
 
 

--- a/compiler/transforms/convert_tosa_to_kernel.py
+++ b/compiler/transforms/convert_tosa_to_kernel.py
@@ -2,7 +2,7 @@ from xdsl.builder import Builder
 from xdsl.context import MLContext
 from xdsl.dialects import arith, builtin, linalg, tensor, tosa
 from xdsl.dialects.builtin import IntegerAttr, i1, i8, i32
-from xdsl.ir import BlockArgument, Operation
+from xdsl.ir import BlockArgument
 from xdsl.ir.affine import AffineDimExpr, AffineMap
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -82,7 +82,11 @@ class RescaleClampPattern(RewritePattern):
         for dim_idx, shape in enumerate(out_type.get_shape()):
             if shape == -1:
                 # create dim op
-                dim_idx_ops.append(dim_idx := arith.Constant.from_int_and_width(dim_idx, builtin.IndexType()))
+                dim_idx_ops.append(
+                    dim_idx := arith.Constant.from_int_and_width(
+                        dim_idx, builtin.IndexType()
+                    )
+                )
                 dim_ops.append(tensor.DimOp(rescale_op.input, dim_idx))
 
         dim_op_values = [dim_op.result for dim_op in dim_ops]

--- a/tests/filecheck/transforms/convert-tosa-to-kernel.mlir
+++ b/tests/filecheck/transforms/convert-tosa-to-kernel.mlir
@@ -6,9 +6,12 @@
 
 // CHECK: builtin.module {
 // CHECK-NEXT:   %0 = "test.op"() : () -> tensor<?x8xi32>
-// CHECK-NEXT:   %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0 : tensor<?x8xi32>) outs(%0 : tensor<?x8xi32>) {
-// CHECK-NEXT:   ^0(%2 : i32, %3 : i8):
-// CHECK-NEXT:     %4 = kernel.rescale %2 zero_points(0, -128) rescale(1085889731 >> 37) clamp(-128, 127) double_round = 1 : i32 -> i8
-// CHECK-NEXT:     linalg.yield %4 : i8
+// CHECK-NEXT:   %1 = arith.constant 0 : index
+// CHECK-NEXT:   %2 = tensor.dim %0, %1 : tensor<?x8xi32>
+// CHECK-NEXT:   %3 = tensor.empty(%2) : tensor<?x8xi8>
+// CHECK-NEXT:   %4 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0 : tensor<?x8xi32>) outs(%3 : tensor<?x8xi8>) {
+// CHECK-NEXT:   ^0(%5 : i32, %6 : i8):
+// CHECK-NEXT:     %7 = kernel.rescale %5 zero_points(0, -128) rescale(1085889731 >> 37) clamp(-128, 127) double_round = 1 : i32 -> i8
+// CHECK-NEXT:     linalg.yield %7 : i8
 // CHECK-NEXT:   } -> tensor<?x8xi8>
 // CHECK-NEXT: }


### PR DESCRIPTION
The output type was not set correctly in the resulting linalg.generic. The outs of a linalg on tensors must have the correct type, as it uses the `DestinationStyleOpInterface`. This output type can be generated with a `tensor.empty` operation 