### PR TITLE
dialects: (kernel) turn rescale properties into attributes

### DIFF
--- a/compiler/dialects/kernel.py
+++ b/compiler/dialects/kernel.py
@@ -4,7 +4,7 @@ from xdsl.builder import Builder
 from xdsl.dialects import arith, linalg
 from xdsl.dialects.builtin import I8, I32, BoolAttr, IntegerType
 from xdsl.ir import BlockArgument, Dialect, Region, SSAValue
-from xdsl.irdl import attr_def, operand_def, prop_def
+from xdsl.irdl import attr_def, operand_def
 from xdsl.irdl.operations import irdl_op_definition, result_def
 from xdsl.parser import IntegerAttr, IRDLOperation
 

--- a/compiler/dialects/kernel.py
+++ b/compiler/dialects/kernel.py
@@ -4,7 +4,7 @@ from xdsl.builder import Builder
 from xdsl.dialects import arith, linalg
 from xdsl.dialects.builtin import I8, I32, BoolAttr, IntegerType
 from xdsl.ir import BlockArgument, Dialect, Region, SSAValue
-from xdsl.irdl import operand_def, prop_def
+from xdsl.irdl import attr_def, operand_def, prop_def
 from xdsl.irdl.operations import irdl_op_definition, result_def
 from xdsl.parser import IntegerAttr, IRDLOperation
 
@@ -153,13 +153,13 @@ class RescaleOp(KernelOp):
     input = operand_def(IntegerType)
     result = result_def(IntegerType)
 
-    input_zp = prop_def(IntegerAttr[I8])
-    output_zp = prop_def(IntegerAttr[I8])
-    multiplier = prop_def(IntegerAttr[I32])
-    shift = prop_def(IntegerAttr[I8])
-    max_int = prop_def(IntegerAttr[I8])
-    min_int = prop_def(IntegerAttr[I8])
-    double_round = prop_def(BoolAttr)
+    input_zp = attr_def(IntegerAttr[I8])
+    output_zp = attr_def(IntegerAttr[I8])
+    multiplier = attr_def(IntegerAttr[I32])
+    shift = attr_def(IntegerAttr[I8])
+    max_int = attr_def(IntegerAttr[I8])
+    min_int = attr_def(IntegerAttr[I8])
+    double_round = attr_def(BoolAttr)
 
     assembly_format = (
         "$input attr-dict `zero_points` `(` $input_zp `,` $output_zp `)`"

--- a/compiler/transforms/convert_tosa_to_kernel.py
+++ b/compiler/transforms/convert_tosa_to_kernel.py
@@ -61,7 +61,7 @@ class RescaleClampPattern(RewritePattern):
             kernel_op = kernel.RescaleOp(
                 operands=[args[0]],
                 result_types=[args[-1].type],
-                properties={
+                attributes={
                     "input_zp": IntegerAttr(input_zp, i8),
                     "output_zp": IntegerAttr(output_zp, i8),
                     "multiplier": IntegerAttr(multiplier, i32),

--- a/tests/filecheck/dialects/kernel/ops.mlir
+++ b/tests/filecheck/dialects/kernel/ops.mlir
@@ -25,6 +25,6 @@
 // CHECK-GENERIC-NEXT:   %4 = "kernel.qmac"(%0, %0, %0, %0) : (i32, i32, i32, i32) -> i32
 
 
-%5 = "kernel.rescale" (%0) <{"input_zp" = 23 : i8, "output_zp" = -23 : i8, "multiplier" = 12345 : i32, "shift" = 30 : i8, "max_int" = 127 : i8, "min_int" = -128 : i8, "double_round" = true}> : (i32) -> i32
+%5 = "kernel.rescale" (%0) {"input_zp" = 23 : i8, "output_zp" = -23 : i8, "multiplier" = 12345 : i32, "shift" = 30 : i8, "max_int" = 127 : i8, "min_int" = -128 : i8, "double_round" = true} : (i32) -> i32
 // CHECK-NEXT:   %5 = kernel.rescale %0 zero_points(23, -23) rescale(12345 >> 30) clamp(-128, 127) double_round = 1 : i32 -> i32
-// CHECK-GENERIC-NEXT    %5 = "kernel.rescale"(%0) <{"input_zp" = 23 : i8, "output_zp" = -23 : i8, "multiplier" = 12345 : i32, "shift" = 30 : i8, "max_int" = 127 : i8, "min_int" = -128 : i8, "double_round" = true}> : (i32) -> i32
+// CHECK-GENERIC-NEXT    %5 = "kernel.rescale"(%0) {"input_zp" = 23 : i8, "output_zp" = -23 : i8, "multiplier" = 12345 : i32, "shift" = 30 : i8, "max_int" = 127 : i8, "min_int" = -128 : i8, "double_round" = true} : (i32) -> i32


### PR DESCRIPTION
A weird bug in MLIR causes the properties of my unregistered dialect to be removed during the fold tensor cast pattern when applying canonicalization.
Running this through canonicalize shows the bug: https://gist.github.com/jorendumoulin/03b55e6b467914de74a010e60590acb8

For now, this turns the properties into attributes such that we are not bothered by this bug
