### PR TITLE
transforms (convert-kernel-to-linalg) init pass

### DIFF
--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -15,6 +15,7 @@ from compiler.transforms.accfg_dedup import AccfgDeduplicate
 from compiler.transforms.accfg_insert_resets import InsertResetsPass
 from compiler.transforms.clear_memory_space import ClearMemorySpace
 from compiler.transforms.convert_accfg_to_csr import ConvertAccfgToCsrPass
+from compiler.transforms.convert_kernel_to_linalg import ConvertKernelToLinalg
 from compiler.transforms.convert_linalg_to_accfg import (
     ConvertLinalgToAccPass,
     TraceStatesPass,
@@ -109,6 +110,7 @@ class SNAXOptMain(xDSLOptMain):
         )
         super().register_pass(ScheduleMemrefLinalg.name, lambda: ScheduleMemrefLinalg)
         super().register_pass(ConvertLinalgToKernel.name, lambda: ConvertLinalgToKernel)
+        super().register_pass(ConvertKernelToLinalg.name, lambda: ConvertKernelToLinalg)
         super().register_pass(
             ConvertTosaToKernelPass.name, lambda: ConvertTosaToKernelPass
         )

--- a/compiler/transforms/convert_kernel_to_linalg.py
+++ b/compiler/transforms/convert_kernel_to_linalg.py
@@ -1,0 +1,52 @@
+from xdsl.context import MLContext
+from xdsl.dialects import builtin, linalg
+from xdsl.ir import Block
+from xdsl.parser import IRDLOperation
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.rewriter import InsertPoint
+
+from compiler.dialects.kernel import Kernel, Parsable
+
+
+class LowerLinalgBody(RewritePattern):
+    """
+    Matches on linalg.generic operations to check if
+    their body is kernel op defined in the kernel dialect.
+    Replaces the body with the equivalent arith body if this is true.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, linalg_op: linalg.Generic, rewriter: PatternRewriter):
+
+        # find the kernel op in linalg body
+        if not isinstance(kernel_op := linalg_op.body.block.first_op, Parsable):
+            return
+
+        # only works for non-fused kernels (only 1 kernel op)
+        if not isinstance(kernel_op.next_op, linalg.YieldOp):
+            return
+
+        # replace linalg op
+        rewriter.replace_matched_op(linalg.Generic(
+            linalg_op.inputs,
+            linalg_op.outputs,
+            kernel_op.equivalent_region,
+            linalg_op.indexing_maps,
+            linalg_op.iterator_types,
+            linalg_op.result_types,
+            linalg_op.library_call,
+            linalg_op.doc
+        ))
+
+
+class ConvertKernelToLinalg(ModulePass):
+    name = "convert-kernel-to-linalg"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(LowerLinalgBody()).rewrite_module(op)

--- a/tests/filecheck/transforms/convert-kernel-to-linalg.mlir
+++ b/tests/filecheck/transforms/convert-kernel-to-linalg.mlir
@@ -1,0 +1,77 @@
+// RUN: ./compiler/snax-opt --split-input-file -p convert-kernel-to-linalg %s | filecheck %s
+
+%0, %1, %2 = "test.op"() : () -> (memref<64xi32>, memref<64xi32>, memref<64xi32>)
+linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%0, %1 : memref<64xi32>, memref<64xi32>) outs(%2 : memref<64xi32>) {
+^0(%arg0 : i32, %arg1 : i32, %arg2 : i32):
+  %3 = kernel.mul %arg0, %arg1 : i32, i32 -> i32
+  linalg.yield %3 : i32
+}
+
+// CHECK: builtin.module {
+// CHECK-NEXT:   %0, %1, %2 = "test.op"() : () -> (memref<64xi32>, memref<64xi32>, memref<64xi32>)
+// CHECK-NEXT:   linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%0, %1 : memref<64xi32>, memref<64xi32>) outs(%2 : memref<64xi32>) {
+// CHECK-NEXT:   ^0(%3 : i32, %4 : i32, %5 : i32):
+// CHECK-NEXT:     %6 = arith.muli %3, %4 : i32
+// CHECK-NEXT:     linalg.yield %6 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// -----
+
+%0, %1, %2 = "test.op"() : () -> (memref<64xi32>, memref<64xi32>, memref<64xi32>)
+linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%0, %1 : memref<64xi32>, memref<64xi32>) outs(%2 : memref<64xi32>) {
+^0(%arg0 : i32, %arg1 : i32, %arg2 : i32):
+  %3 = kernel.add %arg0, %arg1 : i32, i32 -> i32
+  linalg.yield %3 : i32
+}
+
+// CHECK: builtin.module {
+// CHECK-NEXT:   %0, %1, %2 = "test.op"() : () -> (memref<64xi32>, memref<64xi32>, memref<64xi32>)
+// CHECK-NEXT:   linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%0, %1 : memref<64xi32>, memref<64xi32>) outs(%2 : memref<64xi32>) {
+// CHECK-NEXT:   ^0(%3 : i32, %4 : i32, %5 : i32):
+// CHECK-NEXT:     %6 = arith.addi %3, %4 : i32
+// CHECK-NEXT:     linalg.yield %6 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// -----
+
+%0, %1, %2 = "test.op"() : () -> (memref<64x64xi32>, memref<64x64xi32>, memref<64x64xi32>)
+linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%0, %1 : memref<64x64xi32>, memref<64x64xi32>) outs(%2 : memref<64x64xi32>) {
+^0(%in : i32, %in_1 : i32, %out : i32):
+  %3 = kernel.mac %in, %in_1 : i32, i32 -> i32
+  linalg.yield %3 : i32
+}
+
+// CHECK: builtin.module {
+// CHECK-NEXT:   %0, %1, %2 = "test.op"() : () -> (memref<64x64xi32>, memref<64x64xi32>, memref<64x64xi32>)
+// CHECK-NEXT:   linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%0, %1 : memref<64x64xi32>, memref<64x64xi32>) outs(%2 : memref<64x64xi32>) {
+// CHECK-NEXT:   ^0(%3 : i32, %4 : i32, %5 : i32):
+// CHECK-NEXT:     %6 = arith.muli %3, %4 : i32
+// CHECK-NEXT:     %7 = arith.addi %5, %6 : i32
+// CHECK-NEXT:     linalg.yield %7 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// -----
+
+%0, %1, %2, %3 = "test.op"() : () -> (memref<?x?xi8>, memref<?x?xi8>, memref<?x?xi32>, i32)
+linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%0, %1, %3, %3 : memref<?x?xi8>, memref<?x?xi8>, i32, i32) outs(%2 : memref<?x?xi32>) {
+^0(%in : i8, %in_1 : i8, %in_2 : i32, %in_3 : i32, %out : i32):
+  %4 = kernel.qmac %in, %in_1 zp_lhs : %in_2 zp_rhs : %in_3 : i8, i8, i32, i32 -> i32
+  linalg.yield %4 : i32
+}
+
+// CHECK: builtin.module {
+// CHECK-NEXT:   %0, %1, %2, %3 = "test.op"() : () -> (memref<?x?xi8>, memref<?x?xi8>, memref<?x?xi32>, i32)
+// CHECK-NEXT:   linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%0, %1, %3, %3 : memref<?x?xi8>, memref<?x?xi8>, i32, i32) outs(%2 : memref<?x?xi32>) {
+// CHECK-NEXT:   ^0(%4 : i8, %5 : i8, %6 : i32, %7 : i32, %8 : i32):
+// CHECK-NEXT:     %9 = arith.extsi %4 : i8 to i32
+// CHECK-NEXT:     %10 = arith.subi %9, %6 : i32
+// CHECK-NEXT:     %11 = arith.extsi %5 : i8 to i32
+// CHECK-NEXT:     %12 = arith.subi %11, %7 : i32
+// CHECK-NEXT:     %13 = arith.muli %10, %12 : i32
+// CHECK-NEXT:     %14 = arith.addi %8, %13 : i32
+// CHECK-NEXT:     linalg.yield %14 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT: }


### PR DESCRIPTION
In case you converted to `kernel` dialect but decided not to dispatch anything, this pass converts the linalg-parsable ops back to core dialects such that llvm understands them.