### PR TITLE
Add SNAX specific events to the tracing script

### DIFF
--- a/benchmarks/dense_matmul/genbenchmark.py
+++ b/benchmarks/dense_matmul/genbenchmark.py
@@ -174,7 +174,7 @@ if __name__ == "__main__":
         bm.trace()
         if to_plot:
             bm.plot()
-        bm.process_traces(folder)
+        bm.process_traces(folder, accelerator="snax_gemmx")
         bm.copy_binary(folder)
         bm.copy_logs(folder)
         if to_plot:

--- a/tests/benchmark/test_snax_benchmark.py
+++ b/tests/benchmark/test_snax_benchmark.py
@@ -17,6 +17,6 @@ def test_snax_benchmark_runner():
     bm.build(build_opts=["ARRAY_SIZE=128", "TILE_SIZE=16", "NO_CHECK=1"])
     bm.run()
     bm.trace()
-    bm.process_traces(folder)
+    bm.process_traces(folder, accelerator="snax_alu")
     bm.copy_binary(folder)
     bm.copy_logs(folder)

--- a/util/snax_benchmark.py
+++ b/util/snax_benchmark.py
@@ -59,7 +59,7 @@ class SNAXBenchmark:
         self.announce("Generating plots")
         subprocess.run(["make", "plots"], cwd=self.src_dir, check=True)
 
-    def process_traces(self, folder: str, file=None):
+    def process_traces(self, folder: str, accelerator: str | None = None, file=None):
         self.announce("Processing Traces")
         dst_folder = self.export_dir / pathlib.Path(folder)
         if file is None:
@@ -78,6 +78,7 @@ class SNAXBenchmark:
             inputs,
             trace_filenames,
             str(self.src_dir / self.binary),
+            accelerator=accelerator,
             addr2line="llvm-addr2line",
             output=output_events,
         )

--- a/util/tracing/snax_event_generator.py
+++ b/util/tracing/snax_event_generator.py
@@ -67,9 +67,9 @@ class SNAXAcceleratorEventGenerator(EventGenerator):
         super().__init__()
         self.state = None
         self.acc = SNAXGEMMAccelerator().generate_acc_op()
-        self.fields = {val.value.data for val in self.acc.fields.data.values}
+        self.fields = {val.value.data for val in self.acc.fields.data.values()}
         self.launch_fields = {
-            val.value.data for val in self.acc.launch_fields.data.values
+            val.value.data for val in self.acc.launch_fields.data.values()
         }
         self.barrier_addr = self.acc.barrier.value.data
 

--- a/util/tracing/snax_event_generator.py
+++ b/util/tracing/snax_event_generator.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass, field
 
-from compiler.accelerators.snax_gemmx import SNAXGEMMXAccelerator
 from compiler.dialects.accfg import AcceleratorOp
 from util.tracing.annotation import EventGenerator
 from util.tracing.event import DurationEvent
@@ -60,10 +59,10 @@ class SNAXAcceleratorEventGenerator(EventGenerator):
     launch_fields: set[int]
     barrier_addr: int
 
-    def __init__(self):
+    def __init__(self, acc_op: AcceleratorOp):
         super().__init__()
         self.state = None
-        self.acc = SNAXGEMMXAccelerator().generate_acc_op()
+        self.acc = acc_op
         self.fields = {val.value.data for val in self.acc.fields.data.values()}
         self.launch_fields = {
             val.value.data for val in self.acc.launch_fields.data.values()

--- a/util/tracing/snax_event_generator.py
+++ b/util/tracing/snax_event_generator.py
@@ -104,7 +104,7 @@ class SNAXAcceleratorEventGenerator(EventGenerator):
                             "setup",
                             self.state.start,
                             state.clock_cycle - self.state.start,
-                            "snax",
+                            ["snax"],
                             {"setup_ins_count": self.state.number_setups},
                         )
                     )
@@ -124,19 +124,19 @@ class SNAXAcceleratorEventGenerator(EventGenerator):
                         "launched",
                         self.state.start,
                         state.clock_cycle - self.state.start,
-                        "snax",
+                        ["snax"],
                         {"setup_ins_count": self.state.number_setups},
                     )
                 )
-                self.state = Stalled(state.clock_cycle)
+                self.state = Stalled(start=state.clock_cycle)
         elif isinstance(self.state, Stalled):
             # stalled state is resolved with the next CSR ins
             events.append(
                 DurationEvent(
                     "stalled",
-                    self.state.start - self.state.start,
-                    state.clock_cycle,
-                    "snax",
+                    self.state.start,
+                    state.clock_cycle - self.state.start,
+                    ["snax"],
                     {},
                 )
             )

--- a/util/tracing/snax_event_generator.py
+++ b/util/tracing/snax_event_generator.py
@@ -118,6 +118,7 @@ class SNAXAcceleratorEventGenerator(EventGenerator):
             # if we see a write to a launch
             elif ins.csr in self.launch_fields:
                 self.state.number_of_zero_writes += 1
+            # if we wrote two zeros, transition to stalled state
             if self.state.number_of_zero_writes > 1:
                 events.append(
                     DurationEvent(

--- a/util/tracing/snax_event_generator.py
+++ b/util/tracing/snax_event_generator.py
@@ -103,7 +103,7 @@ class SNAXAcceleratorEventGenerator(EventGenerator):
                         DurationEvent(
                             "setup",
                             self.state.start,
-                            state.clock_cycle,
+                            state.clock_cycle - self.state.start,
                             "snax",
                             {"setup_ins_count": self.state.number_setups},
                         )
@@ -123,7 +123,7 @@ class SNAXAcceleratorEventGenerator(EventGenerator):
                     DurationEvent(
                         "launched",
                         self.state.start,
-                        state.clock_cycle,
+                        state.clock_cycle - self.state.start,
                         "snax",
                         {"setup_ins_count": self.state.number_setups},
                     )
@@ -133,7 +133,11 @@ class SNAXAcceleratorEventGenerator(EventGenerator):
             # stalled state is resolved with the next CSR ins
             events.append(
                 DurationEvent(
-                    "stalled", self.state.start, state.clock_cycle, "snax", {}
+                    "stalled",
+                    self.state.start - self.state.start,
+                    state.clock_cycle,
+                    "snax",
+                    {},
                 )
             )
             self.state = None

--- a/util/tracing/snax_event_generator.py
+++ b/util/tracing/snax_event_generator.py
@@ -1,0 +1,141 @@
+from dataclasses import dataclass, field
+
+from util.tracing.annotation import EventGenerator
+from util.tracing.state import TraceState, CSRInstruction
+
+from util.tracing.event import *
+
+
+from compiler.accelerators.snax_gemm import SNAXGEMMAccelerator
+from compiler.dialects.accfg import AcceleratorOp
+
+
+@dataclass
+class _CurrentEvent:
+    start: int
+
+
+@dataclass
+class SettingUp(_CurrentEvent):
+    number_setups: int = field(default=1)
+    number_of_launches: int = field(default=0)
+    """
+    Since we only end this region when we see the *second* write to launch, we need to keep track of the number 
+    of launches
+    """
+
+
+@dataclass
+class Launched(_CurrentEvent):
+    number_of_zero_writes: int = field(default=0)
+    """
+    How many zero writes to the launch address have happened
+    """
+    number_setups: int = field(default=0)
+
+
+@dataclass
+class Stalled(_CurrentEvent):
+    pass
+
+
+class SNAXAcceleratorEventGenerator(EventGenerator):
+    """
+    Works for the current version of SNAX.
+
+    We emit a "pre-launch" event, that:
+        - starts at the first CSR write to a config register
+        - ends after all launch fields have been written to
+        - records the number of setup instructions executed
+    We emit a "launched but not waiting" event, that:
+        - starts immediately after the "pre-launch" event
+        - ends on the second "write 0 to launch addr"
+    We emit a "waiting" event, that:
+        - starts on the first read from the barrier address
+        - ends when that read return 1
+
+
+    """
+
+    state: _CurrentEvent | None
+    acc: AcceleratorOp
+    fields: set[int]
+    launch_fields: set[int]
+    barrier_addr: int
+
+    def __init__(self):
+        super().__init__()
+        self.state = None
+        self.acc = SNAXGEMMAccelerator().generate_acc_op()
+        self.fields = {val.value.data for val in self.acc.fields.data.values}
+        self.launch_fields = {
+            val.value.data for val in self.acc.launch_fields.data.values
+        }
+        self.barrier_addr = self.acc.barrier.value.data
+
+    def cycle(self, state: TraceState) -> list[DurationEvent]:
+        ins = state.instruction
+        if not isinstance(ins, CSRInstruction):
+            return []
+        events: list[DurationEvent] = []
+
+        # if state is None, check if we are setting up, if so, switch state to "setting up"
+        if self.state is None:
+            if ins.csr in self.fields or self.launch_fields:
+                self.state = SettingUp(
+                    start=state.clock_cycle,
+                )
+        # if we are in setup region:
+        elif isinstance(self.state, SettingUp):
+            # if it's a normal setup, count a setup ins
+            if ins.csr in self.fields:
+                self.state.number_setups += 1
+            # if it's a launch insn
+            elif ins.csr in self.launch_fields:
+                # check that we haven't met the launch threshold yet
+                if self.state.number_of_launches < len(self.launch_fields):
+                    self.state.number_of_launches += 1
+                    # this launch counts as a setup
+                    # self.state.number_setups += 1
+                # otherwise, end this event, switch to launch event
+                else:
+                    events.append(
+                        DurationEvent(
+                            "setup",
+                            self.state.start,
+                            state.clock_cycle,
+                            "snax",
+                            {"setup_ins_count": self.state.number_setups},
+                        )
+                    )
+                    # change state to launched
+                    self.state = Launched(state.clock_cycle)
+        # if we are launched:
+        elif isinstance(self.state, Launched):
+            # if we see a setup ins, count it
+            if ins.csr in self.fields:
+                self.state.number_setups += 1
+            # if we see a write to a launch
+            elif ins.csr in self.launch_fields:
+                self.state.number_of_zero_writes += 1
+            if self.state.number_of_zero_writes > 1:
+                events.append(
+                    DurationEvent(
+                        "launched",
+                        self.state.start,
+                        state.clock_cycle,
+                        "snax",
+                        {"setup_ins_count": self.state.number_setups},
+                    )
+                )
+                self.state = Stalled(state.clock_cycle)
+        elif isinstance(self.state, Stalled):
+            # stalled state is resolved with the next CSR ins
+            events.append(
+                DurationEvent(
+                    "stalled", self.state.start, state.clock_cycle, "snax", {}
+                )
+            )
+            self.state = None
+
+        return events

--- a/util/tracing/state.py
+++ b/util/tracing/state.py
@@ -46,6 +46,22 @@ class CSRInstruction(Instruction):
         return self.funct3 == 0b111
 
     @property
+    def is_reading(self):
+        return self.funct3 in (0b001, 0b101)
+
+    @property
+    def is_writing(self):
+        return self.funct3 in (0b010, 0b110)
+
+    @property
+    def is_clear(self):
+        return self.funct3 in (0b011, 0b111)
+
+    @property
+    def is_immediate_type(self):
+        return (self.funct3 >> 2) == 1
+
+    @property
     def csr(self):
         return self.raw_encoding >> 20
 

--- a/util/tracing/trace_to_perfetto.py
+++ b/util/tracing/trace_to_perfetto.py
@@ -11,6 +11,7 @@ from util.tracing.annotation import (
     StreamingEventGenerator,
     calculate_sections,
 )
+from util.tracing.snax_event_generator import SNAXAcceleratorEventGenerator
 from util.tracing.state import get_trace_state
 
 
@@ -20,6 +21,7 @@ def worker(file: str):
         BarrierEventGenerator(),
         StreamingEventGenerator(),
         DMAEventGenerator(),
+        SNAXAcceleratorEventGenerator(),
     ]
     with open(file) as f:
         for index, l in enumerate(f):

--- a/util/tracing/trace_to_perfetto.py
+++ b/util/tracing/trace_to_perfetto.py
@@ -116,7 +116,7 @@ def process_traces(
     traces: list[str],
     elf: str,
     addr2line: str,
-    accelerator: str,
+    accelerator: str | None = None,
     output: typing.IO[str] | None = None,
     annotate_kernels: bool = False,
     sequential: bool = False,

--- a/util/tracing/trace_to_perfetto.py
+++ b/util/tracing/trace_to_perfetto.py
@@ -6,6 +6,7 @@ import typing
 from concurrent.futures import ProcessPoolExecutor
 
 from compiler.accelerators.registry import AcceleratorRegistry
+from compiler.accelerators.snax import SNAXAccelerator
 from util.tracing.annotation import (
     BarrierEventGenerator,
     DMAEventGenerator,
@@ -66,9 +67,16 @@ def parse_arguments():
         default="llvm-addr2line",
         help="llvm-addr2line from quidditch toolchain",
     )
+
+    # Only allow SNAX accelerators for now
+    snax_accelerators = []
+    for accelerator, acc_class in AcceleratorRegistry().registered_accelerators.items():
+        if issubclass(acc_class, SNAXAccelerator):
+            snax_accelerators.append(accelerator)
+
     parser.add_argument(
         "--accelerator",
-        choices=AcceleratorRegistry().registered_accelerators.keys(),
+        choices=snax_accelerators,
         default=None,
         help="SNAX accelerator for SNAX Event Annotator",
     )


### PR DESCRIPTION
Adds SNAX specific event tracer to the trace_to_perfetto utilty:

The following three events are discerned to produce those traces:

* a "pre-launch" event, that:
        - starts at the first CSR write to a config register
        - ends after all launch fields have been written to
        - records the number of setup instructions executed
 * a "launched but not waiting" event, that:
        - starts immediately after the "pre-launch" event
        - ends on the second "write 0 to launch addr"
 * a "waiting" event, that:
        - starts on the first read from the barrier address
        - ends when that read return 1
        
This should be general enough to support any SNAX accelerator, although I (@JosseVanDelm) am not entirely sure how to verify that in CI.

The utility was already useable standalone, but this patch makes it more difficult to specify a bunch of options that are invalid.
* You can now use `--sequential` to run the tracer in sequential mode, which is useful for debugging with pdb.
* You can use `--accelerator` to specify a SNAX accelerator in order to activate the SNAX specific event tracer (this functionality is also now available for `process_traces` in `SNAXBenchmark`.
* Kernel annotation is now optional  with `--annotate-kernels` and the tool will warn you if you do not specify the `--elf`-file and the `--addr2line` executable


Important note:
In perfetto you might want to change your time format to be anything but timecode, because otherwise it seems to mess up the numbers (not sure why, and also not sure how we can change that default behaviour)
![image](https://github.com/user-attachments/assets/634dc8bb-5798-4caa-94c7-68dd09c139bc)


