### PR TITLE
bump snax to v0.2.1

### DIFF
--- a/.github/workflows/build-run-kernel.yml
+++ b/.github/workflows/build-run-kernel.yml
@@ -10,7 +10,7 @@ jobs:
   build-and-run-kernels:
     runs-on: ubuntu-latest
     container: 
-      image: ghcr.io/kuleuven-micas/snax:v0.1.14
+      image: ghcr.io/kuleuven-micas/snax:v0.2.1
     steps:
       - uses: actions/checkout@v3
       - name: Install snax compiler

--- a/.github/workflows/build-run-mlperf-tiny.yml
+++ b/.github/workflows/build-run-mlperf-tiny.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-run-networks:
     runs-on: ubuntu-latest
     container: 
-      image: ghcr.io/kuleuven-micas/snax:v0.1.14
+      image: ghcr.io/kuleuven-micas/snax:v0.2.1
     strategy:
       matrix:
         model:

--- a/.github/workflows/lit-tests.yml
+++ b/.github/workflows/lit-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container: 
-      image: ghcr.io/kuleuven-micas/snax:v0.1.14
+      image: ghcr.io/kuleuven-micas/snax:v0.2.1
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container: 
-      image: ghcr.io/kuleuven-micas/snax:v0.1.14
+      image: ghcr.io/kuleuven-micas/snax:v0.2.1
 
     steps:
     - uses: actions/checkout@v3

--- a/compiler/accelerators/snax.py
+++ b/compiler/accelerators/snax.py
@@ -128,9 +128,8 @@ class SNAXStreamer(ABC):
                     continue
                 cst = arith.Constant.from_int_and_width(stride, i32)
                 spatial_strides.append(([cst], cst.result))
-            #innermost spatial stride is not programmed
+            # innermost spatial stride is not programmed
             result.extend(spatial_strides[1:])
-
 
             # loop bounds
             upper_bounds = op.stride_patterns.data[operand].upper_bounds.data
@@ -190,7 +189,7 @@ class SNAXStreamer(ABC):
                     # Irrelevant Spatial Strides are not programmed as they are virtual
                     if flag != StreamerFlag.Irrelevant
                 ][
-                    1: # innermost spatial stride is not programmed
+                    1:  # innermost spatial stride is not programmed
                 ]
             )
             # temporal bounds

--- a/compiler/accelerators/snax.py
+++ b/compiler/accelerators/snax.py
@@ -111,8 +111,28 @@ class SNAXStreamer(ABC):
     ) -> Sequence[tuple[Sequence[Operation], SSAValue]]:
         result: Sequence[tuple[Sequence[Operation], SSAValue]] = []
 
-        # loop bound registers
         for operand, streamer in enumerate(self.streamer_config.data.streamers):
+            # base pointers (low, high)
+            result.append(([], op.operands[operand]))
+            result.append(
+                ([c0 := arith.Constant.from_int_and_width(0, i32)], c0.result)
+            )
+
+            # spatial strides
+            spatial_strides = []
+            for dim, flag in enumerate(streamer.spatial_dims):
+                stride = op.stride_patterns.data[operand].spatial_strides.data[dim].data
+                if flag == StreamerFlag.Irrelevant:
+                    # Irrelevant spatial strides are not programmed
+                    assert stride == 0
+                    continue
+                cst = arith.Constant.from_int_and_width(stride, i32)
+                spatial_strides.append(([cst], cst.result))
+            #innermost spatial stride is not programmed
+            result.extend(spatial_strides[1:])
+
+
+            # loop bounds
             upper_bounds = op.stride_patterns.data[operand].upper_bounds.data
             # pad unused temporal bounds with 1's'
             upper_bounds = (
@@ -129,8 +149,7 @@ class SNAXStreamer(ABC):
                 # bounds should only be set once
                 break
 
-        # temporal strides
-        for operand, streamer in enumerate(self.streamer_config.data.streamers):
+            # temporal strides
             temporal_strides = op.stride_patterns.data[operand].temporal_strides.data
             # pad unused spatial strides with 0's
             temporal_strides = (
@@ -144,84 +163,40 @@ class SNAXStreamer(ABC):
                 cst = arith.Constant.from_int_and_width(stride.data, i32)
                 result.append(([cst], cst.result))
 
-        # spatial strides
-        for operand, streamer in enumerate(self.streamer_config.data.streamers):
-            strides = iter(op.stride_patterns.data[operand].spatial_strides.data)
-            stride: IntAttr | None = next(strides, None)
-            for dim, flag in enumerate(streamer.spatial_dims):
-                if flag == StreamerFlag.Irrelevant:
-                    # Irrelevant spatial strides are not programmed
-                    if stride and stride.data == 0:
-                        stride = next(strides, None)
-                    continue
-                assert stride is not None  # stride should be intattr here
-                cst = arith.Constant.from_int_and_width(stride, i32)
-                result.append(([cst], cst.result))
-                stride = next(strides, None)
-            assert stride is None  # all strides must be processed by this point
-
-        # input & output base pointers
-        result.extend(([], x) for x in op.inputs)
-        result.extend(([], x) for x in op.outputs)
-
         # transpose specifications
         for operand, streamer in enumerate(self.streamer_config.data.streamers):
             if streamer.type is StreamerType.ReaderTranspose:
-                # always program to 0 for now
-                c0 = arith.Constant.from_int_and_width(0, i32)
-                result.append(([c0], c0.result))
-                # in the current version of the streamer,
-                # transpose fields are bit packed together,
-                # so only one field for all transpose ops
-                # this should be fixed in the new streamer
-                break
+                # if we want to disable transpose, we obviously need to program
+                # a 1 to the transpose field (much logical)
+                # threrefore always program to 1
+                c1 = arith.Constant.from_int_and_width(1, i32)
+                result.append(([c1], c1.result))
 
         return result
 
     def get_streamer_setup_fields(self) -> Sequence[str]:
         result: list[str] = []
 
-        # loop bound registers
-        if not self.streamer_config.data.separate_bounds:
+        for name, streamer in zip(
+            self.streamer_names, self.streamer_config.data.streamers
+        ):
+            # base pointers
+            result.extend([f"{name}_ptr_low", f"{name}_ptr_high"])
+            # spatial strides
             result.extend(
                 [
-                    f"loop_bound_{i}"
-                    for i in range(self.streamer_config.data.temporal_dim())
+                    f"{name}_sstride_{i}"
+                    for i, flag in enumerate(streamer.spatial_dims)
+                    # Irrelevant Spatial Strides are not programmed as they are virtual
+                    if flag != StreamerFlag.Irrelevant
+                ][
+                    1: # innermost spatial stride is not programmed
                 ]
             )
-        else:
-            for name, streamer in zip(
-                self.streamer_names, self.streamer_config.data.streamers
-            ):
-                for i in range(streamer.temporal_dim):
-                    result.append(f"loop_bound_{name}_{i}")
-
-        # temporal strides
-        result.extend(
-            [
-                f"{name}_tstride_{i}"
-                for streamer, name in zip(
-                    self.streamer_config.data.streamers, self.streamer_names
-                )
-                for i in range(streamer.temporal_dim)
-            ]
-        )
-
-        # spatial strides
-        result.extend(
-            [
-                f"{name}_sstride_{i}"
-                for streamer, name in zip(
-                    self.streamer_config.data.streamers, self.streamer_names
-                )
-                for i, flag in enumerate(streamer.spatial_dims)
-                # Irrelevant Spatial Strides are not programmed as they are virtual
-                if flag != StreamerFlag.Irrelevant
-            ]
-        )
-
-        # base pointers
-        result.extend([f"{streamer}_ptr" for streamer in self.streamer_names])
+            # temporal bounds
+            result.extend([f"{name}_bound_{i}" for i in range(streamer.temporal_dim)])
+            # temporal strides
+            result.extend([f"{name}_tstride_{i}" for i in range(streamer.temporal_dim)])
 
         # transpose specifications
         for streamer, name in zip(
@@ -229,11 +204,6 @@ class SNAXStreamer(ABC):
         ):
             if streamer.type is StreamerType.ReaderTranspose:
                 result.append(f"{name}_transpose")
-                # in the current version of the streamer,
-                # transpose fields are bit packed together,
-                # so only one field for all transpose ops
-                # this should be fixed in the new streamer
-                break
 
         return result
 

--- a/compiler/accelerators/snax.py
+++ b/compiler/accelerators/snax.py
@@ -155,9 +155,9 @@ class SNAXStreamer(ABC):
         # transpose specifications
         for operand, streamer in enumerate(self.streamer_config.data.streamers):
             if streamer.type is StreamerType.ReaderTranspose:
-                # if we want to disable transpose, we obviously need to program
-                # a 1 to the transpose field (much logical)
-                # threrefore always program to 1
+                # if we want to disable transpose, we need
+                # a 1 to the transpose field, as it is an
+                # extension bypass signal
                 c1 = arith.Constant.from_int_and_width(1, i32)
                 result.append(([c1], c1.result))
 

--- a/compiler/accelerators/snax_alu.py
+++ b/compiler/accelerators/snax_alu.py
@@ -113,6 +113,12 @@ class SNAXAluAccelerator(
         ]
 
         return [
+            # streamer 1
+            # base pointer
+            (ptrs[0]),
+            ([c0], c0.result),
+            # spatial stride
+            ([c8], c8.result),
             # loop bound streamer
             (
                 [c0_index, dim_0, design_time_parallelism, loop_bound, loop_bound_i32],
@@ -120,18 +126,26 @@ class SNAXAluAccelerator(
             ),
             # temporal strides streamers
             ([c32], c32.result),
-            ([], c32.result),
-            ([], c32.result),
-            # spatial strides streamers
-            ([c8], c8.result),
-            ([], c8.result),
-            ([], c8.result),
-            # base pointers streamers
-            (ptrs[0]),
+            # streamer 2 base ptr
             (ptrs[1]),
+            ([], c0.result),
+            # spatial stride
+            ([], c8.result),
+            # loop bound
+            ([], loop_bound_i32.result),
+            # temporal stride
+            ([], c32.result),
+            # streamer 3 base ptr
             (ptrs[2]),
+            ([], c0.result),
+            # spatial stride
+            ([], c8.result),
+            # loop bound
+            ([], loop_bound_i32.result),
+            # temporal stride
+            ([], c32.result),
             # alu mode
-            ([c0], c0.result),
+            ([], c0.result),
             # alu iterations
             ([], loop_bound_i32.result),
         ]

--- a/compiler/accelerators/snax_gemmx.py
+++ b/compiler/accelerators/snax_gemmx.py
@@ -43,7 +43,7 @@ default_streamer = StreamerConfiguration(
             spatial_dims=("n",),
         ),
         Streamer(  # D32
-            StreamerType.ReaderWriter,
+            StreamerType.Writer,
             temporal_dims=("r", "n", "n"),
             spatial_dims=("n",),
         ),

--- a/compiler/accelerators/snax_gemmx.py
+++ b/compiler/accelerators/snax_gemmx.py
@@ -25,27 +25,27 @@ default_streamer = StreamerConfiguration(
         Streamer(  # A
             StreamerType.ReaderTranspose,
             temporal_dims=("n", "n", "n", "n", "n", "n"),
-            spatial_dims=("n", "i", "n"),
+            spatial_dims=("n",),
         ),
         Streamer(  # B
             StreamerType.ReaderTranspose,
             temporal_dims=("n", "n", "n"),
-            spatial_dims=("n", "n", "i"),
+            spatial_dims=("n",),
         ),
         Streamer(  # D8
             StreamerType.Writer,
             temporal_dims=("r", "n", "n"),
-            spatial_dims=("i", "n", "n"),
+            spatial_dims=("n",),
         ),
         Streamer(  # C
             StreamerType.Reader,
             temporal_dims=("r", "n", "n"),
-            spatial_dims=("i", "n", "n"),
+            spatial_dims=("n",),
         ),
         Streamer(  # D32
             StreamerType.ReaderWriter,
             temporal_dims=("r", "n", "n"),
-            spatial_dims=("i", "n", "n"),
+            spatial_dims=("n",),
         ),
     ],
     separate_bounds=True,

--- a/compiler/accelerators/snax_gemmx.py
+++ b/compiler/accelerators/snax_gemmx.py
@@ -48,7 +48,6 @@ default_streamer = StreamerConfiguration(
             spatial_dims=("n",),
         ),
     ],
-    separate_bounds=True,
 )
 
 

--- a/compiler/accelerators/streamers/streamers.py
+++ b/compiler/accelerators/streamers/streamers.py
@@ -12,8 +12,6 @@ class StreamerType(StrEnum):
     ReaderTranspose = "rt"
     # Streamer with write capabilities
     Writer = "w"
-    # Streamer with read and write capabilities
-    ReaderWriter = "rw"
 
 
 class StreamerFlag(StrEnum):

--- a/compiler/accelerators/streamers/streamers.py
+++ b/compiler/accelerators/streamers/streamers.py
@@ -104,13 +104,9 @@ class StreamerConfiguration:
 
     streamers: Sequence[Streamer]
 
-    # are bounds programmed separately for every streamer?
-    separate_bounds: bool = False
-
-    def __init__(self, streamers: Sequence[Streamer], separate_bounds: bool = False):
+    def __init__(self, streamers: Sequence[Streamer]):
         assert len(streamers)
         self.streamers = streamers
-        self.separate_bounds = separate_bounds
 
     def size(self) -> int:
         """

--- a/compiler/dialects/snax.py
+++ b/compiler/dialects/snax.py
@@ -173,13 +173,6 @@ class StreamerConfigurationAttr(Data[StreamerConfiguration]):
         # snax.streamer_config {optional_properties} <r[temp=n-n-n-n-r, spat=n-i],
         # r[temp=n-n-n, spat=i-n], w[temp=r-n-n, spat=n-n]>
 
-        separate_bounds: bool = False
-
-        if parser.parse_optional_punctuation("{"):
-            parser.parse_keyword("separate_bounds")
-            parser.parse_punctuation("}")
-            separate_bounds = True
-
         with parser.in_angle_brackets():
             streamers: Sequence[Streamer] = []
 
@@ -211,7 +204,7 @@ class StreamerConfigurationAttr(Data[StreamerConfiguration]):
                 if not parser.parse_optional_punctuation(","):
                     break
 
-            return StreamerConfiguration(streamers, separate_bounds)
+            return StreamerConfiguration(streamers)
 
     def print_parameter(self, printer: Printer) -> None:
         # print a streamer config in the following format:
@@ -223,8 +216,7 @@ class StreamerConfigurationAttr(Data[StreamerConfiguration]):
             f"{streamer.type.value}[temp={'-'.join(streamer.temporal_dims)}, spat={'-'.join(streamer.spatial_dims)}]"
             for streamer in self.data.streamers
         ]
-        option_string = " {separate_bounds} " if self.data.separate_bounds else ""
-        printer.print_string(f"{option_string}<{', '.join(streamer_strings)}>")
+        printer.print_string(f"<{', '.join(streamer_strings)}>")
 
 
 Snax = Dialect(

--- a/compiler/transforms/stream_snaxify.py
+++ b/compiler/transforms/stream_snaxify.py
@@ -165,7 +165,7 @@ class MemrefStreamToSnaxPattern(RewritePattern):
                 if spatial_flag == StreamerFlag.Irrelevant and stride != 0:
                     spatial_strides.append(0)
                     continue
-                #FIXME: provide more general solution for new spatial streamer_config
+                # FIXME: provide more general solution for new spatial streamer_config
                 # configuration, this works in all current cases but is not generally correct.
                 assert isinstance(memref_type.element_type, FixedBitwidthType)
                 spatial_strides.append(round(stride / memref_type.element_type.size))

--- a/compiler/transforms/stream_snaxify.py
+++ b/compiler/transforms/stream_snaxify.py
@@ -139,6 +139,7 @@ class MemrefStreamToSnaxPattern(RewritePattern):
                     # gemm
                     template_bounds = (None, None, None, 8, 8, 8)
                 else:
+                    # simd only
                     template_bounds = (None, None, 8, 8)
 
             # Create iterator for all dimensions of the access_mem_map that returns (stride, bound)

--- a/tests/filecheck/dialects/snax/snax_ops.mlir
+++ b/tests/filecheck/dialects/snax/snax_ops.mlir
@@ -18,6 +18,6 @@
 // Test streamer config attribute:
 "test.op"() {"streamer_config" = #snax.streamer_config<r[temp=n-n-n, spat=n-n-n], r[temp=n-r-i, spat=i-n-r], w[temp=i-i-i, spat=n-n]> } : () -> ()
 // CHECK-NEXT: #snax.streamer_config<r[temp=n-n-n, spat=n-n-n], r[temp=n-r-i, spat=i-n-r], w[temp=i-i-i, spat=n-n]>
-"test.op"() {"streamer_config" = #snax.streamer_config {separate_bounds} <r[temp=n-n-n, spat=n-n-n], rw[temp=n-r-i, spat=i-n-r], w[temp=i-i-i, spat=n-n]> } : () -> ()
-// CHECK-NEXT: #snax.streamer_config {separate_bounds} <r[temp=n-n-n, spat=n-n-n], rw[temp=n-r-i, spat=i-n-r], w[temp=i-i-i, spat=n-n]>
+"test.op"() {"streamer_config" = #snax.streamer_config <r[temp=n-n-n, spat=n-n-n], rw[temp=n-r-i, spat=i-n-r], w[temp=i-i-i, spat=n-n]> } : () -> ()
+// CHECK-NEXT: #snax.streamer_config<r[temp=n-n-n, spat=n-n-n], rw[temp=n-r-i, spat=i-n-r], w[temp=i-i-i, spat=n-n]>
 

--- a/tests/filecheck/dialects/snax/snax_ops.mlir
+++ b/tests/filecheck/dialects/snax/snax_ops.mlir
@@ -18,6 +18,6 @@
 // Test streamer config attribute:
 "test.op"() {"streamer_config" = #snax.streamer_config<r[temp=n-n-n, spat=n-n-n], r[temp=n-r-i, spat=i-n-r], w[temp=i-i-i, spat=n-n]> } : () -> ()
 // CHECK-NEXT: #snax.streamer_config<r[temp=n-n-n, spat=n-n-n], r[temp=n-r-i, spat=i-n-r], w[temp=i-i-i, spat=n-n]>
-"test.op"() {"streamer_config" = #snax.streamer_config <r[temp=n-n-n, spat=n-n-n], rw[temp=n-r-i, spat=i-n-r], w[temp=i-i-i, spat=n-n]> } : () -> ()
-// CHECK-NEXT: #snax.streamer_config<r[temp=n-n-n, spat=n-n-n], rw[temp=n-r-i, spat=i-n-r], w[temp=i-i-i, spat=n-n]>
+"test.op"() {"streamer_config" = #snax.streamer_config <r[temp=n-n-n, spat=n-n-n], r[temp=n-r-i, spat=i-n-r], w[temp=i-i-i, spat=n-n]> } : () -> ()
+// CHECK-NEXT: #snax.streamer_config<r[temp=n-n-n, spat=n-n-n], r[temp=n-r-i, spat=i-n-r], w[temp=i-i-i, spat=n-n]>
 

--- a/tests/filecheck/transforms/stream-snaxify.mlir
+++ b/tests/filecheck/transforms/stream-snaxify.mlir
@@ -67,4 +67,4 @@ memref_stream.streaming_region {
     "test.op"(%a, %b, %c) : (!stream.readable<i64>, !stream.readable<i64>, !stream.writable<i64>) -> ()
 }
 
-// CHECK: "stride_patterns" = [#snax_stream.stride_pattern<ub = [4], ts = [8], ss = [40]>, #snax_stream.stride_pattern<ub = [4], ts = [104], ss = [312]>, #snax_stream.stride_pattern<ub = [4], ts = [184], ss = [24]>]
+// CHECK: "stride_patterns" = [#snax_stream.stride_pattern<ub = [4], ts = [8], ss = [8]>, #snax_stream.stride_pattern<ub = [4], ts = [104], ss = [8]>, #snax_stream.stride_pattern<ub = [4], ts = [184], ss = [8]>]


### PR DESCRIPTION
new streamers!
~~new bugs!~~

The most drastic change are in the spatial streamers, which are now all 1-dimensional. We need a better system to support code-generation for this, for which I have some ideas. In this PR, the spatial strides are hardcoded to [8]. Because in all of our tests the data accessed spatially is contiguous, this works, but is off course not a generally accepted solution.

I propose to do this in a follow up-PR to keep these changes nice and separated.

The changes in this PR mostly relate to the order in which the CSRs come, which has changed somewhat.
additionally, the `separate_bounds` flag is removed as it is now always separate
the readerwriter streamertype is removed as it is probably just a hardware concept that is better modeled as a separate reader and writer from a compiler point of view