### PR TITLE
kernels: return 1 on error

### DIFF
--- a/kernels/alloc/main.c
+++ b/kernels/alloc/main.c
@@ -57,5 +57,5 @@ int main() {
       nerr += test_data[i] - memrefA.aligned_data[i];
     }
   }
-  return nerr;
+  return nerr != 0;
 }

--- a/kernels/rescale/main.c
+++ b/kernels/rescale/main.c
@@ -54,5 +54,5 @@ int main() {
     }
   }
 
-  return err;
+  return err != 0;
 }

--- a/kernels/simple_copy/main.c
+++ b/kernels/simple_copy/main.c
@@ -47,5 +47,5 @@ int main() {
       nerr += 1;
   }
 
-  return err != 0;
+  return nerr != 0;
 }

--- a/kernels/simple_copy/main.c
+++ b/kernels/simple_copy/main.c
@@ -47,5 +47,7 @@ int main() {
       nerr += 1;
   }
 
-  return nerr;
+  if (nerr > 0)
+    return 1;
+  return 0;
 }

--- a/kernels/simple_copy/main.c
+++ b/kernels/simple_copy/main.c
@@ -47,7 +47,5 @@ int main() {
       nerr += 1;
   }
 
-  if (nerr > 0)
-    return 1;
-  return 0;
+  return err != 0;
 }

--- a/kernels/streamer_alu/main.c
+++ b/kernels/streamer_alu/main.c
@@ -82,7 +82,5 @@ int main() {
   printf("Accelerator Done! \n");
   printf("Accelerator Cycles: %d \n", perf_count);
 
-  if (err > 0)
-    return 1;
-  return 0;
+  return err != 0;
 }

--- a/kernels/streamer_alu/main.c
+++ b/kernels/streamer_alu/main.c
@@ -81,5 +81,8 @@ int main() {
 
   printf("Accelerator Done! \n");
   printf("Accelerator Cycles: %d \n", perf_count);
-  return err;
+
+  if (err > 0)
+    return 1;
+  return 0;
 }

--- a/kernels/streamer_matmul/main.c
+++ b/kernels/streamer_matmul/main.c
@@ -84,6 +84,9 @@ int main() {
     if (nerr != 0)
       snrt_mcycle();
 
-    return nerr;
+    if (nerr > 0)
+      return 1;
+
+    return 0;
   }
 }

--- a/kernels/streamer_matmul/main.c
+++ b/kernels/streamer_matmul/main.c
@@ -84,9 +84,6 @@ int main() {
     if (nerr != 0)
       snrt_mcycle();
 
-    if (nerr > 0)
-      return 1;
-
-    return 0;
+    return nerr != 0;
   }
 }

--- a/kernels/tiled_add/main.c
+++ b/kernels/tiled_add/main.c
@@ -59,8 +59,6 @@ int main() {
       nerr += 1;
   }
 
-  if (nerr > 0)
-    return 1;
-  return 0;
+  return nerr != 0;
 #endif
 }

--- a/kernels/tiled_add/main.c
+++ b/kernels/tiled_add/main.c
@@ -60,8 +60,7 @@ int main() {
   }
 
   if (nerr > 0)
-    ;
-  return 1;
+    return 1;
   return 0;
 #endif
 }

--- a/kernels/tiled_add/main.c
+++ b/kernels/tiled_add/main.c
@@ -58,6 +58,10 @@ int main() {
       // (int32_t)G[i]);
       nerr += 1;
   }
-  return nerr;
+
+  if (nerr > 0)
+    ;
+  return 1;
+  return 0;
 #endif
 }

--- a/kernels/transform_copy/main.c
+++ b/kernels/transform_copy/main.c
@@ -60,5 +60,8 @@ int main() {
     }
   }
 
-  return nerr;
+  if (nerr > 0)
+    return 1;
+
+  return 0;
 }

--- a/kernels/transform_copy/main.c
+++ b/kernels/transform_copy/main.c
@@ -60,8 +60,5 @@ int main() {
     }
   }
 
-  if (nerr > 0)
-    return 1;
-
-  return 0;
+  return nerr != 0;
 }


### PR DESCRIPTION
Right now, the kernels return the number of errors in `main.c`. However, this seems to cause some kernels succeeding in CI even though they are wrong. For example, upon returning 256, CI will not fail.

Examples:

Succeeding test when returning 256: https://github.com/KULeuven-MICAS/snax-mlir/actions/runs/11012247027/job/30578039634
Failing test when returning 1: https://github.com/KULeuven-MICAS/snax-mlir/actions/runs/11012262776/job/30578088724

This PR just makes sure all kernels return 1 if an error occurs
