### PR TITLE
init gh-pages workflows

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,57 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Build and deploy gh-pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["gh-pages"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  schedule:
+    - cron: "0 0 * * *" # run daily at 12 am
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          ref: gh-pages
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs/
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 # snax stuff
-*generated*
 *logs*
-*results*
 
 .env
 .venv

--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -1,0 +1,8 @@
+# Benchmarks
+
+Here you can find the latest results of all relevant Benchmarks
+
+## [Dense Matrix Multiplication](dense_matmul)
+
+Testing peak utilization of the `snax-gemmx` accelerator, for different matrix sizes.
+Measures max performance without considering control overhead.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+# Project Documentation
+
+Welcome to the project documentation of snax-mlir. Here you'll find an overview of the project.
+
+## Benchmarks
+
+
+For performance benchmarks, please visit [Benchmarks](benchmarks).


### PR DESCRIPTION
While most of the docs can remain on the `gh-pages` branch, the workflow needs to be in main to be able to be manually dispatched or through the cron schedule.

I also think it makes sense to keep the non-auto-generated docs in the main branch as well