### PR TITLE
streamers: use channel mask for zero patterns

### DIFF
--- a/compiler/accelerators/snax.py
+++ b/compiler/accelerators/snax.py
@@ -116,7 +116,7 @@ class SNAXStreamer(ABC):
         result: Sequence[tuple[Sequence[Operation], SSAValue]] = []
 
         for operand, streamer in enumerate(self.streamer_config.data.streamers):
-            # streamer must generate zero pattern if it is set to c0
+            # streamer must generate zero pattern if the stream is coming from c0
             is_zero_pattern = False
             if isinstance(opresult := op.operands[operand], OpResult):
                 is_zero_pattern = (

--- a/compiler/accelerators/snax.py
+++ b/compiler/accelerators/snax.py
@@ -116,12 +116,12 @@ class SNAXStreamer(ABC):
         result: Sequence[tuple[Sequence[Operation], SSAValue]] = []
 
         for operand, streamer in enumerate(self.streamer_config.data.streamers):
-
             # streamer must generate zero pattern if it is set to c0
             is_zero_pattern = False
             if isinstance(opresult := op.operands[operand], OpResult):
                 is_zero_pattern = (
-                    isinstance(opresult.op, arith.Constant) and opresult.op.value == c0_attr
+                    isinstance(opresult.op, arith.Constant)
+                    and opresult.op.value == c0_attr
                 )
 
             # base pointers (low, high)

--- a/compiler/transforms/stream_snaxify.py
+++ b/compiler/transforms/stream_snaxify.py
@@ -223,7 +223,8 @@ class MemrefStreamToSnaxPattern(RewritePattern):
 
                 # point C to zero allocated row in TCDM.
                 new_inputs.append(
-                    arith.Constant.from_int_and_width(0x1000_0040, builtin.IndexType())
+                    # zero pointer will generate 0 values
+                    arith.Constant.from_int_and_width(0, builtin.IndexType())
                 )
 
             else:
@@ -246,12 +247,14 @@ class MemrefStreamToSnaxPattern(RewritePattern):
                 snax_stride_patterns.insert(0, zero_pattern)
                 new_inputs.insert(
                     0,
-                    arith.Constant.from_int_and_width(0x1000_0040, builtin.IndexType()),
+                    # zero pointer will generate 0 values
+                    arith.Constant.from_int_and_width(0, builtin.IndexType()),
                 )
                 snax_stride_patterns.insert(1, zero_pattern)
                 new_inputs.insert(
                     1,
-                    arith.Constant.from_int_and_width(0x1000_0080, builtin.IndexType()),
+                    # zero pointer will generate 0 values
+                    arith.Constant.from_int_and_width(0, builtin.IndexType()),
                 )
 
                 # flip D8 and C such that they are in the right order

--- a/compiler/transforms/stream_snaxify.py
+++ b/compiler/transforms/stream_snaxify.py
@@ -221,7 +221,7 @@ class MemrefStreamToSnaxPattern(RewritePattern):
                     ),
                 )
 
-                # point C to zero allocated row in TCDM.
+                # point C to c0
                 new_inputs.append(
                     # zero pointer will generate 0 values
                     arith.Constant.from_int_and_width(0, builtin.IndexType())

--- a/util/snax_benchmark.py
+++ b/util/snax_benchmark.py
@@ -119,4 +119,7 @@ class SNAXBenchmark:
         archive_path = shutil.make_archive(
             self.benchmark + "_results", "gztar", self.export_dir
         )
+        output_folder = pathlib.Path(self.output_dir)
+        if not output_folder.exists():
+            output_folder.mkdir(parents=True)
         shutil.move(archive_path, self.output_dir)


### PR DESCRIPTION
If we generate a zero pattern with the streamers, we can use the optional channel mask to make sure we do not burden the tcdm with zero requests.