### PR TITLE
add custom stream dialect

### DIFF
--- a/compiler/dialects/stream.py
+++ b/compiler/dialects/stream.py
@@ -31,6 +31,14 @@ from xdsl.irdl import (
     var_result_def,
 )
 
+"""
+Custom `stream` dialect, to simplify things in a more principled approach, including:
+- inherent support for tensors
+- streams with value semantics
+- no specified static bounds in access patterns: they are just affine maps
+- no stream ops outside of streaming regions allowed
+"""
+
 _StreamTypeElement = TypeVar("_StreamTypeElement", bound=Attribute)
 
 
@@ -42,7 +50,7 @@ class StreamType(
     ContainerType[_StreamTypeElement],
 ):
     """
-    A stream type with value sementics.
+    A stream type with value semantics.
     A stream is defined by an element type, and is produced as the result of
     an operation, or through a streaming region op.
     Streams can only be read from, there is no distinction between readable/writeable streams.
@@ -114,14 +122,14 @@ class YieldOp(AbstractYieldOperation[Attribute]):
 @irdl_op_definition
 class GenericOp(IRDLOperation):
     """
-    Generic that operates on streams.
-    As indexing maps / iterators are thus not relevant, they are removed.
+    Generic that operates on streams, similar to a linalg.generic.
+    Indexing maps / iterators are not relevant, so they are not included.
     """
 
     name = "stream.generic"
 
-    inputs = var_operand_def()
-    outputs = var_result_def()
+    inputs = var_operand_def(StreamType)
+    outputs = var_result_def(StreamType)
 
     body = region_def()
 
@@ -159,3 +167,4 @@ Stream = Dialect(
         StreamType,
     ],
 )
+

--- a/compiler/dialects/stream.py
+++ b/compiler/dialects/stream.py
@@ -122,8 +122,6 @@ class GenericOp(IRDLOperation):
     doc = opt_prop_def(StringAttr)
     library_call = opt_prop_def(StringAttr)
 
-    irdl_options = [AttrSizedOperandSegments(as_property=True)]
-
     def __init__(
         self,
         inputs: Sequence[SSAValue],

--- a/compiler/dialects/stream.py
+++ b/compiler/dialects/stream.py
@@ -111,13 +111,13 @@ class YieldOp(AbstractYieldOperation[Attribute]):
     traits = frozenset([IsTerminator()])
 
 
-
 @irdl_op_definition
 class GenericOp(IRDLOperation):
     """
     Generic that operates on streams.
     As indexing maps / iterators are thus not relevant, they are removed.
     """
+
     name = "stream.generic"
 
     inputs = var_operand_def()

--- a/compiler/dialects/stream.py
+++ b/compiler/dialects/stream.py
@@ -41,6 +41,13 @@ class StreamType(
     TypeAttribute,
     ContainerType[_StreamTypeElement],
 ):
+    """
+    A stream type with value sementics.
+    A stream is defined by an element type, and is produced as the result of
+    an operation, or through a streaming region op.
+    Streams can only be read from, there is no distinction between readable/writeable streams.
+    """
+
     name = "stream.stream"
 
     element_type: ParameterDef[_StreamTypeElement]
@@ -56,7 +63,7 @@ class StreamType(
 class StreamingRegionOp(IRDLOperation):
     """
     An operation that creates streams from tensors or memrefs, which are only available to
-    read from and write to within the body of the operation.
+    read from within the body of the operation.
 
     Within the loop body, memrefs/tensors that are streamed must not be otherwise accessed
     via any other access means, including extraction (e.g.: memref.view).
@@ -108,8 +115,8 @@ class YieldOp(AbstractYieldOperation[Attribute]):
 @irdl_op_definition
 class GenericOp(IRDLOperation):
     """
-    Generic that operates on streams. As indexing maps / iterators are thus not relevant,
-    they are removed. Also not possible to have results.
+    Generic that operates on streams.
+    As indexing maps / iterators are thus not relevant, they are removed.
     """
     name = "stream.generic"
 

--- a/compiler/dialects/stream.py
+++ b/compiler/dialects/stream.py
@@ -1,0 +1,156 @@
+from collections.abc import Sequence
+from typing import Generic, TypeVar
+
+from xdsl.dialects.builtin import (
+    AffineMapAttr,
+    AnyShapedType,
+    ArrayAttr,
+    ContainerType,
+    StringAttr,
+)
+from xdsl.dialects.utils import AbstractYieldOperation
+from xdsl.ir import (
+    Attribute,
+    Dialect,
+    IsTerminator,
+    ParametrizedAttribute,
+    Region,
+    SSAValue,
+    TypeAttribute,
+)
+from xdsl.irdl import (
+    AttrSizedOperandSegments,
+    IRDLOperation,
+    ParameterDef,
+    irdl_attr_definition,
+    irdl_op_definition,
+    opt_prop_def,
+    prop_def,
+    region_def,
+    var_operand_def,
+    var_result_def,
+)
+
+_StreamTypeElement = TypeVar("_StreamTypeElement", bound=Attribute)
+
+
+@irdl_attr_definition
+class StreamType(
+    Generic[_StreamTypeElement],
+    ParametrizedAttribute,
+    TypeAttribute,
+    ContainerType[_StreamTypeElement],
+):
+    name = "stream.stream"
+
+    element_type: ParameterDef[_StreamTypeElement]
+
+    def __init__(self, element_type: _StreamTypeElement):
+        super().__init__([element_type])
+
+    def get_element_type(self) -> _StreamTypeElement:
+        return self.element_type
+
+
+@irdl_op_definition
+class StreamingRegionOp(IRDLOperation):
+    """
+    An operation that creates streams from tensors or memrefs, which are only available to
+    read from and write to within the body of the operation.
+
+    Within the loop body, memrefs/tensors that are streamed must not be otherwise accessed
+    via any other access means, including extraction (e.g.: memref.view).
+    """
+
+    name = "stream.streaming_region"
+
+    inputs = var_operand_def(AnyShapedType())
+    outputs = var_operand_def(AnyShapedType())
+    result_tensors = var_result_def()
+    patterns = prop_def(ArrayAttr[AffineMapAttr])
+
+    body = region_def("single_block")
+
+    accelerator = opt_prop_def(StringAttr)
+
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
+    def __init__(
+        self,
+        inputs: Sequence[SSAValue],
+        outputs: Sequence[SSAValue],
+        patterns: ArrayAttr[AffineMapAttr],
+        body: Region,
+        accelerator: str | StringAttr | None = None,
+        result_types: Sequence[Attribute] = (),
+    ) -> None:
+        if isinstance(accelerator, str):
+            accelerator = StringAttr(accelerator)
+        super().__init__(
+            operands=[inputs, outputs],
+            regions=[body],
+            properties={
+                "patterns": patterns,
+                "accelerator": accelerator,
+            },
+            result_types=[result_types],
+        )
+
+
+@irdl_op_definition
+class YieldOp(AbstractYieldOperation[Attribute]):
+    name = "stream.yield"
+
+    traits = frozenset([IsTerminator()])
+
+
+
+@irdl_op_definition
+class GenericOp(IRDLOperation):
+    """
+    Generic that operates on streams. As indexing maps / iterators are thus not relevant,
+    they are removed. Also not possible to have results.
+    """
+    name = "stream.generic"
+
+    inputs = var_operand_def()
+    outputs = var_result_def()
+
+    body = region_def()
+
+    # Trait attributes
+    doc = opt_prop_def(StringAttr)
+    library_call = opt_prop_def(StringAttr)
+
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
+    def __init__(
+        self,
+        inputs: Sequence[SSAValue],
+        body: Region,
+        doc: StringAttr | None = None,
+        library_call: StringAttr | None = None,
+        result_types: Sequence[Attribute] = (),
+    ) -> None:
+        super().__init__(
+            operands=[inputs],
+            properties={
+                "doc": doc,
+                "library_call": library_call,
+            },
+            regions=[body],
+            result_types=[result_types],
+        )
+
+
+Stream = Dialect(
+    "stream",
+    [
+        StreamingRegionOp,
+        GenericOp,
+        YieldOp,
+    ],
+    [
+        StreamType,
+    ],
+)

--- a/compiler/dialects/stream.py
+++ b/compiler/dialects/stream.py
@@ -167,4 +167,3 @@ Stream = Dialect(
         StreamType,
     ],
 )
-

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -68,7 +68,7 @@ class SNAXOptMain(xDSLOptMain):
         ## Add custom dialects & passes
         # FIXME: override upstream accfg dialect. Remove this after upstreaming full downstream accfg dialect.
         self.ctx._registered_dialects.pop("accfg", None)  # pyright: ignore
-        # FIXME: override upstream stream dialect. Remove this after upstreaming full downstream stream dialect.
+        # Warning: overrides upstream stream dialect.
         self.ctx._registered_dialects.pop("stream", None)  # pyright: ignore
 
         self.ctx.load_dialect(Snax)

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -8,6 +8,7 @@ from compiler.dialects.accfg import ACCFG
 from compiler.dialects.kernel import Kernel
 from compiler.dialects.snax import Snax
 from compiler.dialects.snax_stream import SnaxStream
+from compiler.dialects.stream import Stream
 from compiler.dialects.test.debug import Debug
 from compiler.dialects.tsl import TSL
 from compiler.transforms.accfg_config_overlap import AccfgConfigOverlapPass
@@ -67,6 +68,8 @@ class SNAXOptMain(xDSLOptMain):
         ## Add custom dialects & passes
         # FIXME: override upstream accfg dialect. Remove this after upstreaming full downstream accfg dialect.
         self.ctx._registered_dialects.pop("accfg", None)  # pyright: ignore
+        # FIXME: override upstream stream dialect. Remove this after upstreaming full downstream stream dialect.
+        self.ctx._registered_dialects.pop("stream", None)  # pyright: ignore
 
         self.ctx.load_dialect(Snax)
         self.ctx.load_dialect(TSL)
@@ -74,6 +77,7 @@ class SNAXOptMain(xDSLOptMain):
         self.ctx.load_dialect(ACCFG)
         self.ctx.load_dialect(SnaxStream)
         self.ctx.load_dialect(Debug)
+        self.ctx.load_dialect(Stream)
         super().register_pass(DispatchKernels.name, lambda: DispatchKernels)
         super().register_pass(LinalgToLibraryCall.name, lambda: LinalgToLibraryCall)
         super().register_pass(SetMemorySpace.name, lambda: SetMemorySpace)

--- a/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
+++ b/tests/filecheck/dialects/snax_stream/snax_stream_ops.mlir
@@ -16,22 +16,17 @@
               #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>
       ], "operandSegmentSizes" = array<i32: 2, 1>,
       "accelerator" = "accelerator_with_streamers"}> ({
-^0(%3 : !stream.readable<i64>, %4 : !stream.readable<i64>, %5 : !stream.writable<i64>):
-  %0 = stream.read from %3 : i64
-  %1 = stream.read from %4 : i64
-  %2 = arith.addi %0, %1 : i64
-  stream.write %2 to %5 : i64
+^0(%3 : !stream.stream<i64>, %4 : !stream.stream<i64>, %5 : !stream.stream<i64>):
+  %0 = "test.op" (%3, %4): (!stream.stream<i64>, !stream.stream<i64>) -> !stream.stream<i64>
+  "stream.yield" (%0): (!stream.stream<i64>) -> ()
 }) : (index, index, index) -> ()
 
 //CHECK:      builtin.module {
 //CHECK-NEXT:   "accfg.accelerator"() <{"name" = @accelerator_with_streamers, "fields" = {}, "launch_fields" = {}, "barrier" = 0 : i64}> {"streamer_config" = #snax.streamer_config<r[temp=n-n, spat=n-n], r[temp=n-n, spat=n-n], w[temp=n-n, spat=n-n]>} : () -> ()
 //CHECK-NEXT:   %x, %y, %z = "test.op"() : () -> (index, index, index)
 //CHECK-NEXT:   "snax_stream.streaming_region"(%x, %y, %z) <{"stride_patterns" = [#snax_stream.stride_pattern<ub = [16, 8], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [19, 7], ts = [13, 7], ss = [8, 1]>, #snax_stream.stride_pattern<ub = [13, 2], ts = [13, 7], ss = [8, 1]>], "operandSegmentSizes" = array<i32: 2, 1>, "accelerator" = "accelerator_with_streamers"}> ({
-//CHECK-NEXT:   ^0(%0 : !stream.readable<i64>, %1 : !stream.readable<i64>, %2 : !stream.writable<i64>):
-//CHECK-NEXT:     %3 = stream.read from %0 : i64
-//CHECK-NEXT:     %4 = stream.read from %1 : i64
-//CHECK-NEXT:     %5 = arith.addi %3, %4 : i64
-//CHECK-NEXT:     stream.write %5 to %2 : i64
+//CHECK-NEXT:   ^0(%0 : !stream.stream<i64>, %1 : !stream.stream<i64>, %2 : !stream.stream<i64>):
+//CHECK-NEXT:     %3 = "test.op"(%0, %1) : (!stream.stream<i64>, !stream.stream<i64>) -> !stream.stream<i64>
+//CHECK-NEXT:     stream.yield %3 : !stream.stream<i64>
 //CHECK-NEXT:   }) : (index, index, index) -> ()
 //CHECK-NEXT: }
-

--- a/tests/filecheck/dialects/stream/ops.mlir
+++ b/tests/filecheck/dialects/stream/ops.mlir
@@ -1,0 +1,30 @@
+// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_SINGLETRIP
+
+%s0, %s1, %s2 = "test.op"() : () -> (!stream.stream<i8>, !stream.stream<i32>, !stream.stream<f32>)
+%t0, %t1 = "test.op"() : () -> (tensor<16x16xi8>, tensor<16x16xi32>)
+
+%0 = "stream.streaming_region"(%t0, %t0, %t1) <{"patterns" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d2)>], "accelerator" = "snax_gemmx_stream", "operandSegmentSizes" = array<i32: 2, 1>}> ({
+^0(%1 : !stream.stream<i8>, %2 : !stream.stream<i8>, %3 : !stream.stream<i32>):
+  %4 = "stream.generic"(%1, %2) ({
+  ^1(%in : i8, %in_1 : i8):
+    %5 = "test.op"(%in, %in_1) : (i8, i8) -> i32
+    stream.yield %5 : i32
+  }) : (!stream.stream<i8>, !stream.stream<i8>) -> !stream.stream<i32>
+  stream.yield %4 : !stream.stream<i32>
+}) : (tensor<16x16xi8>, tensor<16x16xi8>, tensor<16x16xi32>) -> tensor<16x16xi32>
+
+
+// CHECK: builtin.module {
+// CHECK-NEXT:   %s0, %s1, %s2 = "test.op"() : () -> (!stream.stream<i8>, !stream.stream<i32>, !stream.stream<f32>)
+// CHECK-NEXT:   %t0, %t1 = "test.op"() : () -> (tensor<16x16xi8>, tensor<16x16xi32>)
+// CHECK-NEXT:   %0 = "stream.streaming_region"(%t0, %t0, %t1) <{"patterns" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d2)>], "accelerator" = "snax_gemmx_stream", "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:   ^0(%1 : !stream.stream<i8>, %2 : !stream.stream<i8>, %3 : !stream.stream<i32>):
+// CHECK-NEXT:     %4 = "stream.generic"(%1, %2) ({
+// CHECK-NEXT:     ^1(%in : i8, %in_1 : i8):
+// CHECK-NEXT:       %5 = "test.op"(%in, %in_1) : (i8, i8) -> i32
+// CHECK-NEXT:       stream.yield %5 : i32
+// CHECK-NEXT:     }) : (!stream.stream<i8>, !stream.stream<i8>) -> !stream.stream<i32>
+// CHECK-NEXT:     stream.yield %4 : !stream.stream<i32>
+// CHECK-NEXT:   }) : (tensor<16x16xi8>, tensor<16x16xi8>, tensor<16x16xi32>) -> tensor<16x16xi32>
+// CHECK-NEXT: }

--- a/tests/filecheck/transforms/stream-snaxify.mlir
+++ b/tests/filecheck/transforms/stream-snaxify.mlir
@@ -9,16 +9,16 @@ memref_stream.streaming_region {
         #memref_stream.stride_pattern<ub = [4, 4], index_map = (d0, d1) -> (4 * d0 + d1)>
     ]
 } ins(%A, %B : memref<16xi64>, memref<16xi64>) outs(%C : memref<16xi64>) attrs = {accelerator="snax_alu"} {
-^bb0(%a: !stream.readable<i64>, %b: !stream.readable<i64>, %c: !stream.writable<i64>):
-    "test.op"(%a, %b, %c) : (!stream.readable<i64>, !stream.readable<i64>, !stream.writable<i64>) -> ()
+^bb0(%a: !stream.stream<i64>, %b: !stream.stream<i64>, %c: !stream.stream<i64>):
+    "test.op"(%a, %b, %c) : (!stream.stream<i64>, !stream.stream<i64>, !stream.stream<i64>) -> ()
 }
 
 //CHECK:        %0 = "memref.extract_aligned_pointer_as_index"(%A) : (memref<16xi64>) -> index
 //CHECK-NEXT:   %1 = "memref.extract_aligned_pointer_as_index"(%B) : (memref<16xi64>) -> index
 //CHECK-NEXT:   %2 = "memref.extract_aligned_pointer_as_index"(%C) : (memref<16xi64>) -> index
 //CHECK-NEXT:   "snax_stream.streaming_region"(%0, %1, %2) <{"stride_patterns" = [#snax_stream.stride_pattern<ub = [4], ts = [32], ss = [8]>, #snax_stream.stride_pattern<ub = [4], ts = [32], ss = [8]>, #snax_stream.stride_pattern<ub = [4], ts = [32], ss = [8]>], "accelerator" = "snax_alu", "operandSegmentSizes" = array<i32: 2, 1>}> ({
-//CHECK-NEXT:   ^0(%a : !stream.readable<i64>, %b : !stream.readable<i64>, %c : !stream.writable<i64>):
-//CHECK-NEXT:     "test.op"(%a, %b, %c) : (!stream.readable<i64>, !stream.readable<i64>, !stream.writable<i64>) -> ()
+//CHECK-NEXT:   ^0(%a : !stream.stream<i64>, %b : !stream.stream<i64>, %c : !stream.stream<i64>):
+//CHECK-NEXT:     "test.op"(%a, %b, %c) : (!stream.stream<i64>, !stream.stream<i64>, !stream.stream<i64>) -> ()
 //CHECK-NEXT:   }) : (index, index, index) -> ()
 
 // -----
@@ -32,7 +32,7 @@ memref_stream.streaming_region {
     #memref_stream.stride_pattern<ub = [64], index_map = (d0) -> (d0)>
   ]
 } ins(%0, %1 : memref<64xi32>, memref<64xi32>) outs(%2 : memref<64xi32>) {
-^0(%3 : !stream.readable<i32>, %4 : !stream.readable<i32>, %5 : !stream.writable<i32>):
+^0(%3 : !stream.stream<i32>, %4 : !stream.stream<i32>, %5 : !stream.stream<i32>):
   memref_stream.generic {
     bounds = [64],
     indexing_maps = [
@@ -42,7 +42,7 @@ memref_stream.streaming_region {
     ],
     iterator_types = ["parallel"],
     library_call = "snax_alu"
-  } ins(%3, %4 : !stream.readable<i32>, !stream.readable<i32>) outs(%5 : !stream.writable<i32>) {
+  } ins(%3, %4 : !stream.stream<i32>, !stream.stream<i32>) outs(%5 : !stream.stream<i32>) {
   ^1(%arg0 : i32, %arg1 : i32, %arg2 : i32):
     %6 = arith.muli %arg0, %arg1 : i32
     memref_stream.yield %6 : i32
@@ -63,8 +63,8 @@ memref_stream.streaming_region {
         #memref_stream.stride_pattern<ub = [4, 4], index_map = (d0, d1) -> (4 * d0 + d1)>
     ]
 } ins(%A, %B : memref<16xi64, #tsl.tsl<[4, 4] -> (1, 5)>>, memref<16xi64, #tsl.tsl<[4, 4] -> (13, 39)>>) outs(%C:  memref<16xi64, #tsl.tsl<[4, 4] -> (23, 3)>>) attrs = {accelerator="snax_alu"} {
-^bb0(%a: !stream.readable<i64>, %b: !stream.readable<i64>, %c: !stream.writable<i64>):
-    "test.op"(%a, %b, %c) : (!stream.readable<i64>, !stream.readable<i64>, !stream.writable<i64>) -> ()
+^bb0(%a: !stream.stream<i64>, %b: !stream.stream<i64>, %c: !stream.stream<i64>):
+    "test.op"(%a, %b, %c) : (!stream.stream<i64>, !stream.stream<i64>, !stream.stream<i64>) -> ()
 }
 
 // CHECK: "stride_patterns" = [#snax_stream.stride_pattern<ub = [4], ts = [8], ss = [8]>, #snax_stream.stride_pattern<ub = [4], ts = [104], ss = [8]>, #snax_stream.stride_pattern<ub = [4], ts = [184], ss = [8]>]

--- a/tests/filecheck/transforms/stream-snaxify.mlir
+++ b/tests/filecheck/transforms/stream-snaxify.mlir
@@ -1,4 +1,4 @@
-// RUN: ./compiler/snax-opt --split-input-file %s -p insert-accfg-op{accelerator=snax_alu},stream-snaxify | filecheck %s
+// RUN: ./compiler/snax-opt --split-input-file %s -p insert-accfg-op{accelerator=snax_alu},stream-snaxify --disable-verify | filecheck %s
 
 %A, %B, %C = "test.op"() : () -> (memref<16xi64>, memref<16xi64>, memref<16xi64>)
 


### PR DESCRIPTION
There are certain things a bit annoying about the upstream `stream` + `memref_stream` dialect for our purposes, but I don't know what an optimal solution is, to experiment with this, this creates a more simplified, principled approach to the stream dialect to experiment what would be good for our purposes.

Changes made here:

- Inherent compatability with tensors for easier tiling/splitting/fusing
- Stream types have value semantics, e.g, no `stream.writeable` or `stream.readable`, just `stream.stream`.
- A stream.generic can **only** operate on streams, not on memrefs, and thus is always part of a streaming region
- no attempt to support imperfectly nested loops. to do this, add multiple stream.generics in a stream.streaming region
- stream.generic is kept as a subset of linalg.generic, without specified indexing patterns / iterator types, as they have no relevance on streams
- The access patterns are not specified as custom StridePatterns, but with regular affine maps. These do not include the bounds of the operation, but should always be able to be extracted from the entire op through `get_static_bounds`.
- All of the access patterns should have the same number of dimensions.