### PR TITLE
add convert-linalg-to-stream pass

### DIFF
--- a/compiler/dialects/stream.py
+++ b/compiler/dialects/stream.py
@@ -128,6 +128,7 @@ class GenericOp(IRDLOperation):
 
     name = "stream.generic"
 
+    # inputs can be streams or integers
     inputs = var_operand_def()
     outputs = var_result_def(StreamType)
 

--- a/compiler/dialects/stream.py
+++ b/compiler/dialects/stream.py
@@ -128,7 +128,7 @@ class GenericOp(IRDLOperation):
 
     name = "stream.generic"
 
-    inputs = var_operand_def(StreamType)
+    inputs = var_operand_def()
     outputs = var_result_def(StreamType)
 
     body = region_def()

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -29,6 +29,7 @@ from compiler.transforms.frontend.preprocess_mlperf_tiny import PreprocessMLPerf
 from compiler.transforms.guarded_linalg_to_memref_stream import (
     GuardedLinalgToMemrefStreamPass,
 )
+from compiler.transforms.guarded_memref_streamify import GuardedMemrefStreamify
 from compiler.transforms.insert_accfg_op import InsertAccOp
 from compiler.transforms.insert_sync_barrier import InsertSyncBarrier
 from compiler.transforms.linalg_to_library_call import LinalgToLibraryCall
@@ -123,6 +124,7 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(DebugToFuncPass.name, lambda: DebugToFuncPass)
         super().register_pass(PreprocessMLPerfTiny.name, lambda: PreprocessMLPerfTiny)
         super().register_pass(AddMcycleAroundLaunch.name, lambda: AddMcycleAroundLaunch)
+        super().register_pass(GuardedMemrefStreamify.name, lambda: GuardedMemrefStreamify)
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -22,6 +22,7 @@ from compiler.transforms.convert_linalg_to_accfg import (
     TraceStatesPass,
 )
 from compiler.transforms.convert_linalg_to_kernel import ConvertLinalgToKernel
+from compiler.transforms.convert_linalg_to_stream import ConvertLinalgToStream
 from compiler.transforms.convert_tosa_to_kernel import ConvertTosaToKernelPass
 from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
@@ -29,7 +30,6 @@ from compiler.transforms.frontend.preprocess_mlperf_tiny import PreprocessMLPerf
 from compiler.transforms.guarded_linalg_to_memref_stream import (
     GuardedLinalgToMemrefStreamPass,
 )
-from compiler.transforms.guarded_memref_streamify import GuardedMemrefStreamify
 from compiler.transforms.insert_accfg_op import InsertAccOp
 from compiler.transforms.insert_sync_barrier import InsertSyncBarrier
 from compiler.transforms.linalg_to_library_call import LinalgToLibraryCall
@@ -124,7 +124,7 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(DebugToFuncPass.name, lambda: DebugToFuncPass)
         super().register_pass(PreprocessMLPerfTiny.name, lambda: PreprocessMLPerfTiny)
         super().register_pass(AddMcycleAroundLaunch.name, lambda: AddMcycleAroundLaunch)
-        super().register_pass(GuardedMemrefStreamify.name, lambda: GuardedMemrefStreamify)
+        super().register_pass(ConvertLinalgToStream.name, lambda: ConvertLinalgToStream)
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/transforms/convert_linalg_to_stream.py
+++ b/compiler/transforms/convert_linalg_to_stream.py
@@ -20,7 +20,6 @@ from compiler.dialects import stream
 class StreamifyGenericOpPattern(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: linalg.Generic, rewriter: PatternRewriter) -> None:
-
         # place guard for library calls ending in _stream
         if not op.library_call:
             return
@@ -32,18 +31,28 @@ class StreamifyGenericOpPattern(RewritePattern):
         input_count = len(op.inputs)
         streamable_input_indices = tuple(
             (index, arg.type)
-            for index, (i, arg) in enumerate(zip(op.inputs, op.body.block.args[:input_count]))
+            for index, (i, arg) in enumerate(
+                zip(op.inputs, op.body.block.args[:input_count])
+            )
             if isinstance(i.type, ShapedType) and arg.uses
         )
         streamable_output_indices = tuple(
             (index, arg.type)
-            for index, (o, arg) in enumerate(zip(op.outputs, op.body.block.args[input_count:]))
+            for index, (o, arg) in enumerate(
+                zip(op.outputs, op.body.block.args[input_count:])
+            )
             if isinstance(o.type, ShapedType)
         )
 
-        input_stream_types = tuple(stream.StreamType(el_type) for _, el_type in streamable_input_indices)
-        output_stream_types = tuple(stream.StreamType(el_type) for _, el_type in streamable_output_indices)
-        result_stream_types = tuple(stream.StreamType(el_type) for _, el_type in streamable_output_indices)
+        input_stream_types = tuple(
+            stream.StreamType(el_type) for _, el_type in streamable_input_indices
+        )
+        output_stream_types = tuple(
+            stream.StreamType(el_type) for _, el_type in streamable_output_indices
+        )
+        result_stream_types = tuple(
+            stream.StreamType(el_type) for _, el_type in streamable_output_indices
+        )
 
         patterns = ArrayAttr(
             indexing_map

--- a/compiler/transforms/guarded_memref_streamify.py
+++ b/compiler/transforms/guarded_memref_streamify.py
@@ -1,0 +1,91 @@
+from dataclasses import dataclass
+
+from xdsl.context import MLContext
+from xdsl.dialects import linalg
+from xdsl.dialects.builtin import ArrayAttr, ModuleOp, ShapedType
+from xdsl.ir import Block, Region
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.rewriter import InsertPoint
+
+from compiler.dialects import stream
+
+
+@dataclass
+class StreamifyGenericOpPattern(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: linalg.Generic, rewriter: PatternRewriter) -> None:
+        input_count = len(op.inputs)
+        streamable_input_indices = tuple(
+            (index, arg.type)
+            for index, (i, arg) in enumerate(zip(op.inputs, op.body.block.args[:input_count]))
+            if isinstance(i.type, ShapedType) and arg.uses
+        )
+        streamable_output_indices = tuple(
+            (index, arg.type)
+            for index, (o, arg) in enumerate(zip(op.outputs, op.body.block.args[input_count:]))
+            if isinstance(o.type, ShapedType)
+        )
+
+        input_stream_types = tuple(stream.StreamType(el_type) for _, el_type in streamable_input_indices)
+        output_stream_types = tuple(stream.StreamType(el_type) for _, el_type in streamable_output_indices)
+        result_stream_types = tuple(stream.StreamType(el_type) for _, el_type in streamable_output_indices)
+
+        patterns = ArrayAttr(
+            indexing_map
+            for index, _ in (*streamable_input_indices, *streamable_output_indices)
+            if (indexing_map := op.indexing_maps.data[index])
+        )
+
+        streaming_region_op = stream.StreamingRegionOp(
+            inputs=tuple(op.inputs[index] for index, _ in streamable_input_indices),
+            outputs=tuple(op.outputs[index] for index, _ in streamable_output_indices),
+            patterns=patterns,
+            body=Region(Block(arg_types=input_stream_types + output_stream_types)),
+            result_types=op.result_types,
+            accelerator=op.library_call,
+        )
+
+        new_body = streaming_region_op.body.block
+
+        new_inputs = list(op.inputs)
+        for stream_index, (index, _) in enumerate(streamable_input_indices):
+            new_inputs[index] = new_body.args[stream_index]
+
+        rewriter.insert_op(
+            (
+                generic := stream.GenericOp(
+                    new_inputs,
+                    rewriter.move_region_contents_to_new_regions(op.body),
+                    op.doc,
+                    op.library_call,
+                    result_stream_types,
+                ),
+                stream.YieldOp(generic.results[0]),
+            ),
+            InsertPoint.at_end(new_body),
+        )
+
+        # replace linalg yield with stream yield
+        assert isinstance(yield_op := generic.body.block.last_op, linalg.YieldOp)
+        rewriter.replace_op(yield_op, stream.YieldOp(yield_op.operands[0]))
+
+        rewriter.replace_matched_op(streaming_region_op)
+
+
+@dataclass(frozen=True)
+class GuardedMemrefStreamify(ModulePass):
+    """
+    Converts a memref generic on memrefs to a memref generic on streams, by moving it into
+    a streaming region.
+    """
+
+    name = "guarded-memref-streamify"
+
+    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        PatternRewriteWalker(StreamifyGenericOpPattern()).rewrite_module(op)

--- a/tests/filecheck/transforms/convert-linalg-to-stream.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-stream.mlir
@@ -1,0 +1,46 @@
+// RUN: ./compiler/snax-opt -p convert-linalg-to-stream %s | filecheck %s
+
+%arg0, %arg1, %arg2 = "test.op"() : () -> (tensor<16x16xi8>, tensor<16x16xi8>, tensor<16x16xi32>)
+%c0_i32 = arith.constant 0 : i32
+// CHECK: builtin.module {
+// CHECK-NEXT:  %arg0, %arg1, %arg2 = "test.op"() : () -> (tensor<16x16xi8>, tensor<16x16xi8>, tensor<16x16xi32>)
+// CHECK-NEXT:  %c0_i32 = arith.constant 0 : i32
+
+%0 = tensor.empty() : tensor<16x16xi32>
+// CHECK-NEXT:  %0 = tensor.empty() : tensor<16x16xi32>
+
+%1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"], library_call = "snax_gemmx_stream"} ins(%arg0, %arg1, %c0_i32, %c0_i32 : tensor<16x16xi8>, tensor<16x16xi8>, i32, i32) outs(%0 : tensor<16x16xi32>) {
+^0(%in : i8, %in_1 : i8, %in_2 : i32, %in_3 : i32, %out : i32):
+  %2 = kernel.qmac %in, %in_1 zp_lhs : %in_2 zp_rhs : %in_3 : i8, i8, i32, i32 -> i32
+  linalg.yield %2 : i32
+} -> tensor<16x16xi32>
+// CHECK-NEXT: %1 = "stream.streaming_region"(%arg0, %arg1, %0) <{"patterns" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d2)>], "accelerator" = "snax_gemmx", "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT: ^0(%2 : !stream.stream<i8>, %3 : !stream.stream<i8>, %4 : !stream.stream<i32>):
+// CHECK-NEXT:   %5 = "stream.generic"(%2, %3, %c0_i32, %c0_i32) <{"library_call" = "snax_gemmx", "operandSegmentSizes" = array<i32: 4>}> ({
+// CHECK-NEXT:   ^1(%in : i8, %in_1 : i8, %in_2 : i32, %in_3 : i32, %out : i32):
+// CHECK-NEXT:     %6 = kernel.qmac %in, %in_1 zp_lhs : %in_2 zp_rhs : %in_3 : i8, i8, i32, i32 -> i32
+// CHECK-NEXT:     stream.yield %6 : i32
+// CHECK-NEXT:   }) : (!stream.stream<i8>, !stream.stream<i8>, i32, i32) -> !stream.stream<i32>
+// CHECK-NEXT:   stream.yield %5 : !stream.stream<i32>
+// CHECK-NEXT: }) : (tensor<16x16xi8>, tensor<16x16xi8>, tensor<16x16xi32>) -> tensor<16x16xi32>
+
+%3 = tensor.empty() : tensor<16x16xi32>
+//CHECK-NEXT:   %7 = tensor.empty() : tensor<16x16xi32>
+
+%4 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"], library_call = "snax_gemmx_stream"} ins(%1, %arg2 : tensor<16x16xi32>, tensor<16x16xi32>) outs(%3 : tensor<16x16xi32>) {
+^1(%in_4 : i32, %in_5 : i32, %out_1 : i32):
+  %5 = kernel.add %in_4, %in_5 : i32, i32 -> i32
+  linalg.yield %5 : i32
+} -> tensor<16x16xi32>
+
+//CHECK-NEXT: %8 = "stream.streaming_region"(%1, %arg2, %7) <{"patterns" = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], "accelerator" = "snax_gemmx", "operandSegmentSizes" = array<i32: 2, 1>}> ({
+//CHECK-NEXT: ^2(%9 : !stream.stream<i32>, %10 : !stream.stream<i32>, %11 : !stream.stream<i32>):
+//CHECK-NEXT:   %12 = "stream.generic"(%9, %10) <{"library_call" = "snax_gemmx", "operandSegmentSizes" = array<i32: 2>}> ({
+//CHECK-NEXT:   ^3(%in_4 : i32, %in_5 : i32, %out_1 : i32):
+//CHECK-NEXT:     %13 = kernel.add %in_4, %in_5 : i32, i32 -> i32
+//CHECK-NEXT:     stream.yield %13 : i32
+//CHECK-NEXT:   }) : (!stream.stream<i32>, !stream.stream<i32>) -> !stream.stream<i32>
+//CHECK-NEXT:   stream.yield %12 : !stream.stream<i32>
+//CHECK-NEXT: }) : (tensor<16x16xi32>, tensor<16x16xi32>, tensor<16x16xi32>) -> tensor<16x16xi32>
+
+

--- a/tests/filecheck/transforms/convert-linalg-to-stream.mlir
+++ b/tests/filecheck/transforms/convert-linalg-to-stream.mlir
@@ -16,7 +16,7 @@
 } -> tensor<16x16xi32>
 // CHECK-NEXT: %1 = "stream.streaming_region"(%arg0, %arg1, %0) <{"patterns" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d2)>], "accelerator" = "snax_gemmx", "operandSegmentSizes" = array<i32: 2, 1>}> ({
 // CHECK-NEXT: ^0(%2 : !stream.stream<i8>, %3 : !stream.stream<i8>, %4 : !stream.stream<i32>):
-// CHECK-NEXT:   %5 = "stream.generic"(%2, %3, %c0_i32, %c0_i32) <{"library_call" = "snax_gemmx", "operandSegmentSizes" = array<i32: 4>}> ({
+// CHECK-NEXT:   %5 = "stream.generic"(%2, %3, %c0_i32, %c0_i32) <{"library_call" = "snax_gemmx"}> ({
 // CHECK-NEXT:   ^1(%in : i8, %in_1 : i8, %in_2 : i32, %in_3 : i32, %out : i32):
 // CHECK-NEXT:     %6 = kernel.qmac %in, %in_1 zp_lhs : %in_2 zp_rhs : %in_3 : i8, i8, i32, i32 -> i32
 // CHECK-NEXT:     stream.yield %6 : i32
@@ -35,7 +35,7 @@
 
 //CHECK-NEXT: %8 = "stream.streaming_region"(%1, %arg2, %7) <{"patterns" = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], "accelerator" = "snax_gemmx", "operandSegmentSizes" = array<i32: 2, 1>}> ({
 //CHECK-NEXT: ^2(%9 : !stream.stream<i32>, %10 : !stream.stream<i32>, %11 : !stream.stream<i32>):
-//CHECK-NEXT:   %12 = "stream.generic"(%9, %10) <{"library_call" = "snax_gemmx", "operandSegmentSizes" = array<i32: 2>}> ({
+//CHECK-NEXT:   %12 = "stream.generic"(%9, %10) <{"library_call" = "snax_gemmx"}> ({
 //CHECK-NEXT:   ^3(%in_4 : i32, %in_5 : i32, %out_1 : i32):
 //CHECK-NEXT:     %13 = kernel.add %in_4, %in_5 : i32, i32 -> i32
 //CHECK-NEXT:     stream.yield %13 : i32


### PR DESCRIPTION
With the simplifications of the custom stream dialect, this combines the `guarded-convert-linalg-to-stream`, `convert-linalg-to-stream`, `memref-streamify` into a single pass, with a significant loc reduction.

Awaits #274 