### PR TITLE
add fuse-streaming-regions pass

### DIFF
--- a/compiler/accelerators/snax_gemmx.py
+++ b/compiler/accelerators/snax_gemmx.py
@@ -66,6 +66,7 @@ class SNAXGEMMXAccelerator(
 
     supported_kernels = (
         SupportedKernel(kernel.QMacOp, (i8, i8, i32, i32, i32)),
+        SupportedKernel(kernel.AddOp, (i32, i32, i32)),
         SupportedKernel(kernel.RescaleOp, (i32, i8)),
     )
 

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -28,6 +28,10 @@ from compiler.transforms.convert_tosa_to_kernel import ConvertTosaToKernelPass
 from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
 from compiler.transforms.frontend.preprocess_mlperf_tiny import PreprocessMLPerfTiny
+from compiler.transforms.fuse_streaming_regions import FuseStreamingRegions
+from compiler.transforms.guarded_linalg_to_memref_stream import (
+    GuardedLinalgToMemrefStreamPass,
+)
 from compiler.transforms.insert_accfg_op import InsertAccOp
 from compiler.transforms.insert_sync_barrier import InsertSyncBarrier
 from compiler.transforms.linalg_to_library_call import LinalgToLibraryCall
@@ -122,6 +126,8 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(ConvertLinalgToStream.name, lambda: ConvertLinalgToStream)
         super().register_pass(StreamBufferize.name, lambda: StreamBufferize)
         super().register_pass(SnaxBufferize.name, lambda: SnaxBufferize)
+        super().register_pass(FuseStreamingRegions.name, lambda: FuseStreamingRegions)
+        super().register_pass(GuardedMemrefStreamify.name, lambda: GuardedMemrefStreamify)
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -127,7 +127,6 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(StreamBufferize.name, lambda: StreamBufferize)
         super().register_pass(SnaxBufferize.name, lambda: SnaxBufferize)
         super().register_pass(FuseStreamingRegions.name, lambda: FuseStreamingRegions)
-        super().register_pass(GuardedMemrefStreamify.name, lambda: GuardedMemrefStreamify)
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -29,9 +29,6 @@ from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
 from compiler.transforms.frontend.preprocess_mlperf_tiny import PreprocessMLPerfTiny
 from compiler.transforms.fuse_streaming_regions import FuseStreamingRegions
-from compiler.transforms.guarded_linalg_to_memref_stream import (
-    GuardedLinalgToMemrefStreamPass,
-)
 from compiler.transforms.insert_accfg_op import InsertAccOp
 from compiler.transforms.insert_sync_barrier import InsertSyncBarrier
 from compiler.transforms.linalg_to_library_call import LinalgToLibraryCall

--- a/compiler/transforms/fuse_streaming_regions.py
+++ b/compiler/transforms/fuse_streaming_regions.py
@@ -1,0 +1,154 @@
+from dataclasses import dataclass
+
+from xdsl.context import MLContext
+from xdsl.dialects import builtin
+from xdsl.ir import Block, BlockArgument, Region
+from xdsl.ir.affine import AffineMap
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.rewriter import InsertPoint
+
+from compiler.dialects import stream
+
+
+@dataclass
+class FuseElementwisePattern(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: stream.StreamingRegionOp, rewriter: PatternRewriter):
+        # only ops with 1 tensor result supported for now
+        if len(op.results) != 1:
+            return
+
+        # get result and result_type
+        result = op.results[0]
+        assert isinstance(result_type := result.type, builtin.TensorType)
+
+        # check if the result has exactly one use
+        if len(result.uses) != 1:
+            return
+
+        user_op = list(result.uses)[0].operation
+
+        # must be another streamingregion operation
+        if not isinstance(user_op, stream.StreamingRegionOp):
+            return
+
+        # user op must be elementwise: all indexing maps must be identity maps
+        for pattern in user_op.patterns:
+            if not pattern.data == AffineMap.identity(pattern.data.num_dims):
+                return
+
+        # now we can fuse!
+
+        # find obliteration index:
+        # after fusing regions, one output streamer from producer and one input
+        # streamer from consumer will join and get obliterated. for the producer,
+        # this is the last index (single output), for the consumer, we will find
+        # this index here:
+        obliterating_index = None
+        for i, input in enumerate(user_op.inputs):
+            if input is result:
+                obliterating_index = i
+        assert obliterating_index is not None
+
+        # create a new streaming region op
+        # new inputs: all inputs of both regions except for the fused operand
+        new_inputs = op.inputs + tuple(i for i in user_op.inputs if i is not result)
+        # new outputs: only outputs of consumer region
+        new_outputs = user_op.outputs
+
+        # patterns for producer region (all except fused operand = output):
+        patterns = op.patterns.data[:-1]
+
+        # add patterns for consumer region:
+        num_dims = op.patterns.data[0].data.num_dims
+        for p, operand in zip(user_op.patterns, user_op.operands):
+            # obliterate pattern on which we fuse
+            if operand is result:
+                continue
+            # create pattern with increased nb of dims
+            patterns += (builtin.AffineMapAttr(AffineMap(num_dims, 0, p.data.results)),)
+        patterns = builtin.ArrayAttr(patterns)
+
+        # build arg types for body
+
+        # first op arg types
+        arg_types = tuple(arg.type for arg in op.body.block.args[:-1])
+        # second op arg types
+        arg_types += tuple(
+            arg.type for arg, operand in zip(user_op.body.block.args, user_op.operands) if operand is not result
+        )
+
+        streaming_region_op = stream.StreamingRegionOp(
+            new_inputs, new_outputs, patterns, Region(Block(arg_types=arg_types)), result_types=user_op.result_types
+        )
+
+        producer_generic = None
+        for o in op.body.block.ops:
+            # make copies of generic ops from producer region
+            if isinstance(o, stream.GenericOp):
+                rewriter.insert_op(
+                    producer_generic := stream.GenericOp(
+                        inputs=tuple(
+                            streaming_region_op.body.block.args[i.index]
+                            if isinstance(i, BlockArgument) and isinstance(i.type, stream.StreamType)
+                            else i
+                            for i in o.inputs
+                        ),
+                        body=rewriter.move_region_contents_to_new_regions(o.body),
+                        doc=o.doc,
+                        library_call=o.library_call,
+                        result_types=o.result_types,
+                    ),
+                    InsertPoint.at_end(streaming_region_op.body.block),
+                )
+            # do not use yield op from producer region
+            elif isinstance(o, stream.YieldOp):
+                continue
+            else:
+                raise RuntimeError("Can only fuse with generic bodies")
+        assert producer_generic is not None
+
+        consumer_generic = None
+        for o in user_op.body.block.ops:
+            # make copies of generic ops from consumer region
+            if isinstance(o, stream.GenericOp):
+                rewriter.insert_op(
+                    consumer_generic := stream.GenericOp(
+                        inputs=tuple(
+                            producer_generic.results[0]
+                            if index == obliterating_index
+                            else streaming_region_op.body.block.args[index + len(op.inputs) - 1]
+                            for index in range(len(o.inputs))
+                        ),
+                        body=rewriter.move_region_contents_to_new_regions(o.body),
+                        doc=o.doc,
+                        library_call=o.library_call,
+                        result_types=o.result_types,
+                    ),
+                    InsertPoint.at_end(streaming_region_op.body.block),
+                )
+            elif isinstance(o, stream.YieldOp):
+                assert consumer_generic
+                rewriter.insert_op(
+                    stream.YieldOp(consumer_generic.results[0]), InsertPoint.at_end(streaming_region_op.body.block)
+                )
+
+            else:
+                raise RuntimeError("Can only fuse with generic bodies")
+
+        rewriter.replace_op(user_op, streaming_region_op)
+        rewriter.erase_matched_op()
+
+
+@dataclass(frozen=True)
+class FuseStreamingRegions(ModulePass):
+    name = "fuse-streaming-regions"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(FuseElementwisePattern(), apply_recursively=False).rewrite_module(op)

--- a/compiler/transforms/fuse_streaming_regions.py
+++ b/compiler/transforms/fuse_streaming_regions.py
@@ -116,6 +116,8 @@ class FuseElementwisePattern(RewritePattern):
                     ),
                     InsertPoint.at_end(streaming_region_op.body.block),
                 )
+                for old_result, new_result in zip(o.results, producer_generic.results):
+                    rewriter._replace_all_uses_with(old_result, new_result)
             # do not use yield op from producer region
             elif isinstance(o, stream.YieldOp):
                 continue
@@ -163,6 +165,4 @@ class FuseStreamingRegions(ModulePass):
     name = "fuse-streaming-regions"
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
-        PatternRewriteWalker(
-            FuseElementwisePattern(), apply_recursively=False
-        ).rewrite_module(op)
+        PatternRewriteWalker(FuseElementwisePattern()).rewrite_module(op)

--- a/tests/filecheck/transforms/fuse-streaming-regions.mlir
+++ b/tests/filecheck/transforms/fuse-streaming-regions.mlir
@@ -27,31 +27,49 @@ func.func @streamer_matmul(%arg0 : tensor<16x16xi8>, %arg1 : tensor<16x16xi8>, %
     }) : (!stream.stream<i32>, !stream.stream<i32>) -> !stream.stream<i32>
     stream.yield %12 : !stream.stream<i32>
   }) : (tensor<16x16xi32>, tensor<16x16xi32>, tensor<16x16xi32>) -> tensor<16x16xi32>
-  func.return %8 : tensor<16x16xi32>
+
+  %13 = tensor.empty() : tensor<16x16xi32>
+
+  // third streaming region (elementwise add):
+  %14 = "stream.streaming_region"(%8, %arg2, %13) <{"patterns" = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], "accelerator" = "snax_gemmx", "operandSegmentSizes" = array<i32: 2, 1>}> ({
+  ^2(%15 : !stream.stream<i32>, %16 : !stream.stream<i32>, %17 : !stream.stream<i32>):
+    %18 = "stream.generic"(%15, %16) <{"library_call" = "snax_gemmx"}> ({
+    ^3(%in_6 : i32, %in_7 : i32, %out_2 : i32):
+      %19 = kernel.add %in_6, %in_7 : i32, i32 -> i32
+      stream.yield %19 : i32
+    }) : (!stream.stream<i32>, !stream.stream<i32>) -> !stream.stream<i32>
+    stream.yield %18 : !stream.stream<i32>
+  }) : (tensor<16x16xi32>, tensor<16x16xi32>, tensor<16x16xi32>) -> tensor<16x16xi32>
+
+  func.return %14 : tensor<16x16xi32>
 }
 
 
-// CHECK:      builtin.module {
+// CHECK: builtin.module {
 // CHECK-NEXT:   func.func @streamer_matmul(%arg0 : tensor<16x16xi8>, %arg1 : tensor<16x16xi8>, %arg2 : tensor<16x16xi32>) -> tensor<16x16xi32> {
 // CHECK-NEXT:     %c0_i32 = arith.constant 0 : i32
 // CHECK-NEXT:     %0 = tensor.empty() : tensor<16x16xi32>
 // CHECK-NEXT:     %1 = tensor.empty() : tensor<16x16xi32>
-
-                   // only one streaming region here with two generics inside:
-// CHECK-NEXT:     %2 = "stream.streaming_region"(%arg0, %arg1, %arg2, %1) <{"patterns" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], "operandSegmentSizes" = array<i32: 3, 1>}> ({
-// CHECK-NEXT:     ^0(%3 : !stream.stream<i8>, %4 : !stream.stream<i8>, %5 : !stream.stream<i32>, %6 : !stream.stream<i32>):
-// CHECK-NEXT:       %7 = "stream.generic"(%3, %4, %c0_i32, %c0_i32) <{"library_call" = "snax_gemmx"}> ({
+// CHECK-NEXT:     %2 = tensor.empty() : tensor<16x16xi32>
+// CHECK-NEXT:     %3 = "stream.streaming_region"(%arg0, %arg1, %arg2, %arg2, %2) <{"patterns" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], "operandSegmentSizes" = array<i32: 4, 1>}> ({
+// CHECK-NEXT:     ^0(%4 : !stream.stream<i8>, %5 : !stream.stream<i8>, %6 : !stream.stream<i32>, %7 : !stream.stream<i32>, %8 : !stream.stream<i32>):
+// CHECK-NEXT:       %9 = "stream.generic"(%4, %5, %c0_i32, %c0_i32) <{"library_call" = "snax_gemmx"}> ({
 // CHECK-NEXT:       ^1(%in : i8, %in_1 : i8, %in_2 : i32, %in_3 : i32, %out : i32):
-// CHECK-NEXT:         %8 = kernel.qmac %in, %in_1 zp_lhs : %in_2 zp_rhs : %in_3 : i8, i8, i32, i32 -> i32
-// CHECK-NEXT:         stream.yield %8 : i32
-// CHECK-NEXT:       }) : (!stream.stream<i8>, !stream.stream<i8>, i32, i32) -> !stream.stream<i32>
-// CHECK-NEXT:       %9 = "stream.generic"(%7, %5) <{"library_call" = "snax_gemmx"}> ({
-// CHECK-NEXT:       ^2(%in_4 : i32, %in_5 : i32, %out_1 : i32):
-// CHECK-NEXT:         %10 = kernel.add %in_4, %in_5 : i32, i32 -> i32
+// CHECK-NEXT:         %10 = kernel.qmac %in, %in_1 zp_lhs : %in_2 zp_rhs : %in_3 : i8, i8, i32, i32 -> i32
 // CHECK-NEXT:         stream.yield %10 : i32
+// CHECK-NEXT:       }) : (!stream.stream<i8>, !stream.stream<i8>, i32, i32) -> !stream.stream<i32>
+// CHECK-NEXT:       %11 = "stream.generic"(%9, %6) <{"library_call" = "snax_gemmx"}> ({
+// CHECK-NEXT:       ^2(%in_4 : i32, %in_5 : i32, %out_1 : i32):
+// CHECK-NEXT:         %12 = kernel.add %in_4, %in_5 : i32, i32 -> i32
+// CHECK-NEXT:         stream.yield %12 : i32
 // CHECK-NEXT:       }) : (!stream.stream<i32>, !stream.stream<i32>) -> !stream.stream<i32>
-// CHECK-NEXT:       stream.yield %9 : !stream.stream<i32>
-// CHECK-NEXT:     }) : (tensor<16x16xi8>, tensor<16x16xi8>, tensor<16x16xi32>, tensor<16x16xi32>) -> tensor<16x16xi32>
-// CHECK-NEXT:     func.return %2 : tensor<16x16xi32>
+// CHECK-NEXT:       %13 = "stream.generic"(%11, %7) <{"library_call" = "snax_gemmx"}> ({
+// CHECK-NEXT:       ^3(%in_6 : i32, %in_7 : i32, %out_2 : i32):
+// CHECK-NEXT:         %14 = kernel.add %in_6, %in_7 : i32, i32 -> i32
+// CHECK-NEXT:         stream.yield %14 : i32
+// CHECK-NEXT:       }) : (!stream.stream<i32>, !stream.stream<i32>) -> !stream.stream<i32>
+// CHECK-NEXT:       stream.yield %13 : !stream.stream<i32>
+// CHECK-NEXT:     }) : (tensor<16x16xi8>, tensor<16x16xi8>, tensor<16x16xi32>, tensor<16x16xi32>, tensor<16x16xi32>) -> tensor<16x16xi32>
+// CHECK-NEXT:     func.return %3 : tensor<16x16xi32>
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/fuse-streaming-regions.mlir
+++ b/tests/filecheck/transforms/fuse-streaming-regions.mlir
@@ -1,0 +1,57 @@
+// RUN: ./compiler/snax-opt -p fuse-streaming-regions %s | filecheck %s
+
+func.func @streamer_matmul(%arg0 : tensor<16x16xi8>, %arg1 : tensor<16x16xi8>, %arg2 : tensor<16x16xi32>) -> tensor<16x16xi32> {
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tensor.empty() : tensor<16x16xi32>
+
+  // first streaming region (matmul):
+  %1 = "stream.streaming_region"(%arg0, %arg1, %0) <{"patterns" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d2)>], "accelerator" = "snax_gemmx", "operandSegmentSizes" = array<i32: 2, 1>}> ({
+  ^0(%2 : !stream.stream<i8>, %3 : !stream.stream<i8>, %4 : !stream.stream<i32>):
+    %5 = "stream.generic"(%2, %3, %c0_i32, %c0_i32) <{"library_call" = "snax_gemmx"}> ({
+    ^1(%in : i8, %in_1 : i8, %in_2 : i32, %in_3 : i32, %out : i32):
+      %6 = kernel.qmac %in, %in_1 zp_lhs : %in_2 zp_rhs : %in_3 : i8, i8, i32, i32 -> i32
+      stream.yield %6 : i32
+    }) : (!stream.stream<i8>, !stream.stream<i8>, i32, i32) -> !stream.stream<i32>
+    stream.yield %5 : !stream.stream<i32>
+  }) : (tensor<16x16xi8>, tensor<16x16xi8>, tensor<16x16xi32>) -> tensor<16x16xi32>
+
+  %7 = tensor.empty() : tensor<16x16xi32>
+
+  // second streaming region (elementwise add):
+  %8 = "stream.streaming_region"(%1, %arg2, %7) <{"patterns" = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], "accelerator" = "snax_gemmx", "operandSegmentSizes" = array<i32: 2, 1>}> ({
+  ^2(%9 : !stream.stream<i32>, %10 : !stream.stream<i32>, %11 : !stream.stream<i32>):
+    %12 = "stream.generic"(%9, %10) <{"library_call" = "snax_gemmx"}> ({
+    ^3(%in_4 : i32, %in_5 : i32, %out_1 : i32):
+      %13 = kernel.add %in_4, %in_5 : i32, i32 -> i32
+      stream.yield %13 : i32
+    }) : (!stream.stream<i32>, !stream.stream<i32>) -> !stream.stream<i32>
+    stream.yield %12 : !stream.stream<i32>
+  }) : (tensor<16x16xi32>, tensor<16x16xi32>, tensor<16x16xi32>) -> tensor<16x16xi32>
+  func.return %8 : tensor<16x16xi32>
+}
+
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   func.func @streamer_matmul(%arg0 : tensor<16x16xi8>, %arg1 : tensor<16x16xi8>, %arg2 : tensor<16x16xi32>) -> tensor<16x16xi32> {
+// CHECK-NEXT:     %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:     %0 = tensor.empty() : tensor<16x16xi32>
+// CHECK-NEXT:     %1 = tensor.empty() : tensor<16x16xi32>
+
+                   // only one streaming region here with two generics inside:
+// CHECK-NEXT:     %2 = "stream.streaming_region"(%arg0, %arg1, %arg2, %1) <{"patterns" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], "operandSegmentSizes" = array<i32: 3, 1>}> ({
+// CHECK-NEXT:     ^0(%3 : !stream.stream<i8>, %4 : !stream.stream<i8>, %5 : !stream.stream<i32>, %6 : !stream.stream<i32>):
+// CHECK-NEXT:       %7 = "stream.generic"(%3, %4, %c0_i32, %c0_i32) <{"library_call" = "snax_gemmx"}> ({
+// CHECK-NEXT:       ^1(%in : i8, %in_1 : i8, %in_2 : i32, %in_3 : i32, %out : i32):
+// CHECK-NEXT:         %8 = kernel.qmac %in, %in_1 zp_lhs : %in_2 zp_rhs : %in_3 : i8, i8, i32, i32 -> i32
+// CHECK-NEXT:         stream.yield %8 : i32
+// CHECK-NEXT:       }) : (!stream.stream<i8>, !stream.stream<i8>, i32, i32) -> !stream.stream<i32>
+// CHECK-NEXT:       %9 = "stream.generic"(%7, %5) <{"library_call" = "snax_gemmx"}> ({
+// CHECK-NEXT:       ^2(%in_4 : i32, %in_5 : i32, %out_1 : i32):
+// CHECK-NEXT:         %10 = kernel.add %in_4, %in_5 : i32, i32 -> i32
+// CHECK-NEXT:         stream.yield %10 : i32
+// CHECK-NEXT:       }) : (!stream.stream<i32>, !stream.stream<i32>) -> !stream.stream<i32>
+// CHECK-NEXT:       stream.yield %9 : !stream.stream<i32>
+// CHECK-NEXT:     }) : (tensor<16x16xi8>, tensor<16x16xi8>, tensor<16x16xi32>, tensor<16x16xi32>) -> tensor<16x16xi32>
+// CHECK-NEXT:     func.return %2 : tensor<16x16xi32>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }


### PR DESCRIPTION
A pass to fuse multiple streaming regions if their bodies can be executed by the same accelerator.

This pass fuses single producer-consumer streaming regions if the consumer applies an elementwise function to the tensor, with the assumption that this will always be possible to fuse in the accelerator.

This works on tensor operands, so after this pass there should still be some form of bufferization.