### PR TITLE
move alloc-to-global pass out of frontend

### DIFF
--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -14,6 +14,7 @@ from compiler.dialects.tsl import TSL
 from compiler.transforms.accfg_config_overlap import AccfgConfigOverlapPass
 from compiler.transforms.accfg_dedup import AccfgDeduplicate
 from compiler.transforms.accfg_insert_resets import InsertResetsPass
+from compiler.transforms.alloc_to_global import AllocToGlobalPass
 from compiler.transforms.clear_memory_space import ClearMemorySpace
 from compiler.transforms.convert_accfg_to_csr import ConvertAccfgToCsrPass
 from compiler.transforms.convert_kernel_to_linalg import ConvertKernelToLinalg
@@ -124,6 +125,7 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(StreamBufferize.name, lambda: StreamBufferize)
         super().register_pass(SnaxBufferize.name, lambda: SnaxBufferize)
         super().register_pass(FuseStreamingRegions.name, lambda: FuseStreamingRegions)
+        super().register_pass(AllocToGlobalPass.name, lambda: AllocToGlobalPass)
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/transforms/alloc_to_global.py
+++ b/compiler/transforms/alloc_to_global.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+
+from xdsl.context import MLContext
+from xdsl.dialects import builtin, memref
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.traits import SymbolTable
+
+
+class AllocToGlobal(RewritePattern):
+    """
+    Convert all static allocs to empty statically scheduled memref globals
+
+    Warning: using this pattern multiple times in a lowering flow may lead
+    to over
+    """
+
+    # keep track of index to give memref globals a name
+    index: int = 0
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: memref.Alloc, rewriter: PatternRewriter):
+        # get module op
+        module_op = op
+        while not isinstance(module_op, builtin.ModuleOp):
+            assert module_op is not None
+            module_op = module_op.parent_op()
+
+        symbol_table = module_op.get_trait(SymbolTable)
+        assert symbol_table
+
+        # create global symbol name
+        global_sym_name = "_static_const_" + str(self.index)
+        self.index = self.index + 1
+
+        # check if it is not in the symbol table
+        assert SymbolTable.lookup_symbol(module_op, global_sym_name) is None
+
+        # create global
+        memref_global = memref.Global.get(
+            builtin.StringAttr(global_sym_name),
+            op.results[0].type,
+            initial_value=builtin.UnitAttr(),
+        )
+        SymbolTable.insert_or_update(module_op, memref_global)
+
+        # remove all the deallocs
+        deallocs = [
+            user_op.operation
+            for user_op in op.results[0].uses
+            if isinstance(user_op.operation, memref.Dealloc)
+        ]
+        for dealloc in deallocs:
+            rewriter.erase_op(dealloc)
+
+        # replace op by get global
+        memref_get = memref.GetGlobal(global_sym_name, op.results[0].type)
+
+        rewriter.replace_matched_op(memref_get)
+
+
+@dataclass(frozen=True)
+class AllocToGlobalPass(ModulePass):
+    """
+    Convert all present memref.allocs into statically scheduled memref.globals
+    """
+
+    name = "alloc-to-global"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(AllocToGlobal()).rewrite_module(op)

--- a/tests/filecheck/transforms/alloc-to-global.mlir
+++ b/tests/filecheck/transforms/alloc-to-global.mlir
@@ -1,0 +1,6 @@
+// RUN: ./compiler/snax-opt %s -p alloc-to-global | filecheck %s
+
+%0 = memref.alloc() {"alignment" = 64 : i64} : memref<16x16xi8>
+
+// CHECK:      %0 = memref.get_global @_static_const_0 : memref<16x16xi8>
+// CHECK-NEXT: "memref.global"() <{"sym_name" = "_static_const_0", "type" = memref<16x16xi8>, "initial_value", "sym_visibility" = "private"}> : () -> ()


### PR DESCRIPTION
when doing bufferization in snax-opt itself, this one is quite useful. Now only used in mlperf, I also want to use it when using `stream-bufferize` and such