### PR TITLE
add add-c to dense matmul kernel

### DIFF
--- a/benchmarks/dense_matmul/Makefile
+++ b/benchmarks/dense_matmul/Makefile
@@ -7,11 +7,19 @@ include ../../runtime/Makefile.rules
 
 TESTS += generated.x
 
-SNAXOPTFLAGS = -p convert-linalg-to-kernel,insert-accfg-op{accelerator=snax_gemmx},dispatch-kernels,set-memory-space,set-memory-layout{gemm_layout=${LAYOUT}},realize-memref-casts,insert-sync-barrier,dispatch-regions{nb_cores=3},convert-linalg-to-stream,convert-stream-to-snax-stream,convert-linalg-to-accfg,test-add-mcycle-around-launch,convert-accfg-to-csr,snax-copy-to-dma,memref-to-snax,snax-to-func,snax-lower-mcycle,clear-memory-space
+MLIRPREPROCFLAGS = --linalg-generalize-named-ops
+MLIRPREPROCFLAGS += --mlir-print-op-generic
+MLIRPREPROCFLAGS += --mlir-print-local-scope
+
+%.preprocfinal.mlir: %.mlir
+	$(MLIROPT) $(MLIRPREPROCFLAGS) -o $@ $<
+
+SNAXOPTFLAGS = -p convert-linalg-to-kernel,insert-accfg-op{accelerator=snax_gemmx},dispatch-kernels,convert-linalg-to-stream,fuse-streaming-regions,stream-bufferize,snax-bufferize,alloc-to-global,set-memory-space,set-memory-layout,realize-memref-casts,insert-sync-barrier,dispatch-regions{nb_cores=3},convert-stream-to-snax-stream,convert-linalg-to-accfg,test-add-mcycle-around-launch,convert-accfg-to-csr,snax-copy-to-dma,memref-to-snax,snax-to-func,snax-lower-mcycle,clear-memory-space
 
 GEN_DATA_OPTS += --m=${SIZE_M}
 GEN_DATA_OPTS += --n=${SIZE_N}
 GEN_DATA_OPTS += --k=${SIZE_K}
+GEN_DATA_OPTS += --add_c=${ADD_C}
 
 
 CFLAGS += -std=gnu11

--- a/benchmarks/dense_matmul/Makefile
+++ b/benchmarks/dense_matmul/Makefile
@@ -20,7 +20,7 @@ else
 REMOVE_MEMREF_COPY=
 endif
 
-SNAXOPTFLAGS = -p convert-linalg-to-kernel,insert-accfg-op{accelerator=snax_gemmx},dispatch-kernels,convert-linalg-to-stream,fuse-streaming-regions,stream-bufferize,snax-bufferize,alloc-to-global,set-memory-space,set-memory-layout,realize-memref-casts,${REMOVE_MEMREF_COPY}insert-sync-barrier,dispatch-regions{nb_cores=3},convert-stream-to-snax-stream,convert-linalg-to-accfg,test-add-mcycle-around-launch,convert-accfg-to-csr,snax-copy-to-dma,memref-to-snax,snax-to-func,snax-lower-mcycle,clear-memory-space
+SNAXOPTFLAGS = -p convert-linalg-to-kernel,insert-accfg-op{accelerator=snax_gemmx},dispatch-kernels,convert-linalg-to-stream,fuse-streaming-regions,stream-bufferize,snax-bufferize,alloc-to-global,set-memory-space,set-memory-layout{gemm_layout=${LAYOUT}},realize-memref-casts,${REMOVE_MEMREF_COPY}insert-sync-barrier,dispatch-regions{nb_cores=3},convert-stream-to-snax-stream,convert-linalg-to-accfg,test-add-mcycle-around-launch,convert-accfg-to-csr,snax-copy-to-dma,memref-to-snax,snax-to-func,snax-lower-mcycle,clear-memory-space
 
 GEN_DATA_OPTS += --m=${SIZE_M}
 GEN_DATA_OPTS += --n=${SIZE_N}

--- a/benchmarks/dense_matmul/Makefile
+++ b/benchmarks/dense_matmul/Makefile
@@ -14,7 +14,13 @@ MLIRPREPROCFLAGS += --mlir-print-local-scope
 %.preprocfinal.mlir: %.mlir
 	$(MLIROPT) $(MLIRPREPROCFLAGS) -o $@ $<
 
-SNAXOPTFLAGS = -p convert-linalg-to-kernel,insert-accfg-op{accelerator=snax_gemmx},dispatch-kernels,convert-linalg-to-stream,fuse-streaming-regions,stream-bufferize,snax-bufferize,alloc-to-global,set-memory-space,set-memory-layout,realize-memref-casts,insert-sync-barrier,dispatch-regions{nb_cores=3},convert-stream-to-snax-stream,convert-linalg-to-accfg,test-add-mcycle-around-launch,convert-accfg-to-csr,snax-copy-to-dma,memref-to-snax,snax-to-func,snax-lower-mcycle,clear-memory-space
+ifdef NO_CHECK
+REMOVE_MEMREF_COPY=test-remove-memref-copy,
+else
+REMOVE_MEMREF_COPY=
+endif
+
+SNAXOPTFLAGS = -p convert-linalg-to-kernel,insert-accfg-op{accelerator=snax_gemmx},dispatch-kernels,convert-linalg-to-stream,fuse-streaming-regions,stream-bufferize,snax-bufferize,alloc-to-global,set-memory-space,set-memory-layout,realize-memref-casts,${REMOVE_MEMREF_COPY}insert-sync-barrier,dispatch-regions{nb_cores=3},convert-stream-to-snax-stream,convert-linalg-to-accfg,test-add-mcycle-around-launch,convert-accfg-to-csr,snax-copy-to-dma,memref-to-snax,snax-to-func,snax-lower-mcycle,clear-memory-space
 
 GEN_DATA_OPTS += --m=${SIZE_M}
 GEN_DATA_OPTS += --n=${SIZE_N}

--- a/benchmarks/dense_matmul/genbenchmark.py
+++ b/benchmarks/dense_matmul/genbenchmark.py
@@ -33,28 +33,34 @@ def create_matrix_multiply(m, n, k, add_c: bool = False):
     """
 
     arg_types = [
-        builtin.TensorType(i8, (m, k)), # A
-        builtin.TensorType(i8, (k, n)), # B
-        builtin.TensorType(i32, (m, n)), # C
+        builtin.TensorType(i8, (m, k)),  # A
+        builtin.TensorType(i8, (k, n)),  # B
+        builtin.TensorType(i32, (m, n)),  # C
     ]
 
     res_types = [
-        builtin.TensorType(i32, (m, n)), # D
+        builtin.TensorType(i32, (m, n)),  # D
     ]
 
     @Builder.implicit_region(arg_types)
     def func_body(args: tuple[BlockArgument, ...]) -> None:
         c0 = arith.Constant.from_int_and_width(0, 32)
         empty_tensor = tensor.EmptyOp([], (arg_types[-1]))
-        result = linalg.QuantizedMatmulOp([args[0], args[1], c0.result, c0.result], [empty_tensor.tensor])
+        result = linalg.QuantizedMatmulOp(
+            [args[0], args[1], c0.result, c0.result], [empty_tensor.tensor]
+        )
         if add_c:
             empty_tensor_2 = tensor.EmptyOp([], (arg_types[-1]))
-            newresult = linalg.AddOp([args[2], result.results[0]], [empty_tensor_2.tensor])
+            newresult = linalg.AddOp(
+                [args[2], result.results[0]], [empty_tensor_2.tensor]
+            )
             func.Return(newresult)
         else:
             func.Return(result)
 
-    function = func.FuncOp.from_region("streamer_matmul", arg_types, res_types, func_body)
+    function = func.FuncOp.from_region(
+        "streamer_matmul", arg_types, res_types, func_body
+    )
 
     module = builtin.ModuleOp([function])
 
@@ -201,7 +207,9 @@ if __name__ == "__main__":
 
     output_report: dict[str, dict] = {}
 
-    for size, layout, add_c in itertools.product(sizes, ("cyclic", "banked"), (True, False)):
+    for size, layout, add_c in itertools.product(
+        sizes, ("cyclic", "banked"), (True, False)
+    ):
         m, n, k = size
 
         # plot:
@@ -217,7 +225,7 @@ if __name__ == "__main__":
                 f"SIZE_N={n}",
                 f"SIZE_K={k}",
                 f"LAYOUT={layout}",
-                f"ADD_C={int(add_c)}"
+                f"ADD_C={int(add_c)}",
             ]
         )
         bm.run()

--- a/benchmarks/dense_matmul/genbenchmark.py
+++ b/benchmarks/dense_matmul/genbenchmark.py
@@ -216,7 +216,7 @@ if __name__ == "__main__":
         # only plot if max(m,n,k) <= 48
         to_plot = max(m, n, k) <= 48
         folder = f"test_{'gemm' if add_c else 'matmul'}_{layout}_{k}x{m}x{m}"
-        bm = generate_dense_benchmark(k, m, n, add_c)
+        bm = generate_dense_benchmark(m, n, k, add_c)
         bm.clean()
         bm.build(
             build_opts=[

--- a/benchmarks/dense_matmul/gendata.py
+++ b/benchmarks/dense_matmul/gendata.py
@@ -59,7 +59,9 @@ if __name__ == "__main__":
     parser.add_argument("--m", type=int, default=16, help="Value for m (default: 16)")
     parser.add_argument("--n", type=int, default=16, help="Value for n (default: 16)")
     parser.add_argument("--k", type=int, default=16, help="Value for k (default: 16)")
-    parser.add_argument("--add_c", type=int, default=False, help="Add C value to result")
+    parser.add_argument(
+        "--add_c", type=int, default=False, help="Add C value to result"
+    )
 
     # Parse the arguments
     args = parser.parse_args()

--- a/benchmarks/dense_matmul/gendata.py
+++ b/benchmarks/dense_matmul/gendata.py
@@ -7,43 +7,43 @@ import numpy as np
 from util.gendata import create_data, create_header
 
 
-def create_test_data(n, m, k):
-    print(f"Creating test data with n={n}, m={m}, k={k}")
+def create_test_data(m, n, k, add_c: bool = False):
+    print(f"Creating test data with m={m}, n={n}, k={k}, add_c={add_c}")
     # Reset random seed for reproducible behavior
 
     np.random.seed(0)
 
-    A_size = [n, k]
-    B_size = [k, m]
+    A_size = [m, k]
+    B_size = [k, n]
+    C_size = [m, n]
 
-    # C = A.B
+    # D = AxB (+ C)
     low_bound = -128
     high_bound = 127
 
     A = np.random.randint(low_bound, high_bound, size=A_size, dtype=np.dtype("int8"))
     B = np.random.randint(low_bound, high_bound, size=B_size, dtype=np.dtype("int8"))
+    C = np.random.randint(low_bound, high_bound, size=C_size, dtype=np.dtype("int32"))
 
     # Make sure the product is possible!
     assert A.shape[1] == B.shape[0]
-    C_golden = np.matmul(A.astype(np.dtype("int32")), B.astype(np.dtype("int32")))
-    C = np.zeros(C_golden.shape, np.dtype("int32"))
 
-    # Perform layout transformations before writing to memory
+    # Compute golden output D
+    D = np.matmul(A.astype(np.dtype("int32")), B.astype(np.dtype("int32")))
 
-    # only thing necessary: transform B from row-major to column-major
-    B_new_layout = np.transpose(B)
+    if add_c:
+        D += C
 
-    # C are just all zeros, so layout not important
     sizes = {
-        "N_size": A.shape[0],
-        "K_size": A.shape[1],
-        "M_size": B.shape[1],
+        "M_size": A.shape[0],
+        "N_size": A.shape[1],
+        "K_size": B.shape[1],
     }
     variables = {
         "A": A,
-        "B": B_new_layout,
-        "C_golden": C_golden,
+        "B": B,
         "C": C,
+        "D": D,
     }
 
     create_header("data.h", sizes, variables)
@@ -56,12 +56,13 @@ if __name__ == "__main__":
         description="Generate test data with specified parameters."
     )
     # Adding arguments
-    parser.add_argument("--n", type=int, default=16, help="Value for n (default: 16)")
     parser.add_argument("--m", type=int, default=16, help="Value for m (default: 16)")
+    parser.add_argument("--n", type=int, default=16, help="Value for n (default: 16)")
     parser.add_argument("--k", type=int, default=16, help="Value for k (default: 16)")
+    parser.add_argument("--add_c", type=int, default=False, help="Add C value to result")
 
     # Parse the arguments
     args = parser.parse_args()
 
     # Call the function with parsed arguments
-    create_test_data(n=args.n, m=args.m, k=args.k)
+    create_test_data(n=args.n, m=args.m, k=args.k, add_c=bool(args.add_c))

--- a/benchmarks/dense_matmul/main.c
+++ b/benchmarks/dense_matmul/main.c
@@ -15,8 +15,7 @@
 #include <snrt.h>
 
 // Kernel provided via external definition
-void _mlir_ciface_streamer_matmul(TwoDMemrefI8_t *a, TwoDMemrefI8_t *b,
-                                  TwoDMemrefI32_t *c);
+void _mlir_ciface_streamer_matmul(TwoDMemrefI32_t *d, TwoDMemrefI8_t *a, TwoDMemrefI8_t *b, TwoDMemrefI32_t *c);
 
 int main() {
   {
@@ -49,7 +48,9 @@ int main() {
     memrefC.stride[1] = 1;
     memrefC.offset = 0;
 
-    _mlir_ciface_streamer_matmul(&memrefA, &memrefB, &memrefC);
+    TwoDMemrefI32_t memrefD;
+
+    _mlir_ciface_streamer_matmul(&memrefD, &memrefA, &memrefB, &memrefC);
 
     snrt_cluster_hw_barrier();
 
@@ -68,9 +69,9 @@ int main() {
 
     for (int i = 0; i < M_size * N_size; i++) {
       {
-        int32_t error = memrefC.aligned_data[i] - C_golden[i];
-        // printf("%d) %d -> %d\n", i, (int32_t)memrefC.aligned_data[i],
-        //        (int32_t)C_golden[i]);
+        int32_t error = memrefD.aligned_data[i] - D[i];
+        // printf("%d) %d -> %d\n", i, (int32_t)memrefD.aligned_data[i],
+        //        (int32_t)D[i]);
         if (error != 0)
           nerr += 1;
       }

--- a/benchmarks/dense_matmul/main.c
+++ b/benchmarks/dense_matmul/main.c
@@ -15,7 +15,8 @@
 #include <snrt.h>
 
 // Kernel provided via external definition
-void _mlir_ciface_streamer_matmul(TwoDMemrefI32_t *d, TwoDMemrefI8_t *a, TwoDMemrefI8_t *b, TwoDMemrefI32_t *c);
+void _mlir_ciface_streamer_matmul(TwoDMemrefI32_t *d, TwoDMemrefI8_t *a,
+                                  TwoDMemrefI8_t *b, TwoDMemrefI32_t *c);
 
 int main() {
   {

--- a/compiler/transforms/clear_memory_space.py
+++ b/compiler/transforms/clear_memory_space.py
@@ -1,5 +1,6 @@
 from xdsl.context import MLContext
-from xdsl.dialects import builtin, func, memref
+from xdsl.dialects import builtin, func
+from xdsl.ir import BlockArgument
 from xdsl.passes import ModulePass
 
 from compiler.dialects.tsl import TiledStridedLayoutAttr
@@ -8,20 +9,20 @@ from compiler.dialects.tsl import TiledStridedLayoutAttr
 class ClearMemorySpace(ModulePass):
     name = "clear-memory-space"
 
-    def apply(self, ctx: MLContext, module: builtin.ModuleOp) -> None:
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         # helper function to clear the memory space of a memref
         # also clears the layout information of the memref - not used anymore
         def clear_memory_space(t):
-            if isinstance(t, memref.MemRefType):
+            if isinstance(t, builtin.MemRefType):
                 if isinstance(t.layout, TiledStridedLayoutAttr):
-                    return memref.MemRefType(
+                    return builtin.MemRefType(
                         t.element_type,
                         t.get_shape(),
                         builtin.NoneAttr(),
                         builtin.NoneAttr(),
                     )
                 else:
-                    return memref.MemRefType(
+                    return builtin.MemRefType(
                         t.element_type,
                         t.get_shape(),
                         t.layout,
@@ -29,7 +30,7 @@ class ClearMemorySpace(ModulePass):
                     )
             return t
 
-        for op_in_module in module.walk():
+        for op_in_module in op.walk():
             for operand in op_in_module.operands:
                 operand.type = clear_memory_space(operand.type)
             for result in op_in_module.results:
@@ -46,3 +47,11 @@ class ClearMemorySpace(ModulePass):
                 )
 
                 op_in_module.function_type = new_function_type
+
+                # change block args ssa values
+                if op_in_module.body.blocks:
+                    old_args = [old_arg for old_arg in op_in_module.body.block._args]
+                    new_args = [BlockArgument(clear_memory_space(old_arg.type), op_in_module.body.block, index) for index, old_arg in enumerate(old_args)]
+                    for old_arg, new_arg in zip(old_args, new_args):
+                        old_arg.replace_by(new_arg)
+                    op_in_module.body.block._args = tuple(new_args)

--- a/compiler/transforms/clear_memory_space.py
+++ b/compiler/transforms/clear_memory_space.py
@@ -51,7 +51,14 @@ class ClearMemorySpace(ModulePass):
                 # change block args ssa values
                 if op_in_module.body.blocks:
                     old_args = [old_arg for old_arg in op_in_module.body.block._args]
-                    new_args = [BlockArgument(clear_memory_space(old_arg.type), op_in_module.body.block, index) for index, old_arg in enumerate(old_args)]
+                    new_args = [
+                        BlockArgument(
+                            clear_memory_space(old_arg.type),
+                            op_in_module.body.block,
+                            index,
+                        )
+                        for index, old_arg in enumerate(old_args)
+                    ]
                     for old_arg, new_arg in zip(old_args, new_args):
                         old_arg.replace_by(new_arg)
                     op_in_module.body.block._args = tuple(new_args)

--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -4,5 +4,19 @@ Here you can find the latest results of all relevant Benchmarks
 
 ## [Dense Matrix Multiplication](dense_matmul)
 
-Testing peak utilization of the `snax-gemmx` accelerator, for different matrix sizes.
-Measures max performance without considering control overhead.
+Testing peak utilization of the `snax-gemmx` accelerator, for different matrix sizes. Measures max performance without considering control overhead. This test generates a lot of results and plots to get deep insight into the performance of the accelerator combined with the TCDM interconnect and data layout strategies.
+
+The following operations are compared:
+
+- matmul (D = AxB)
+- gemm (D = AxB)
+
+The following layout strategies are compared:
+
+- cyclic
+- banked
+
+The following sizes are run:
+
+- every combination of (32, 48, 64)
+- some common sizes for neural networks


### PR DESCRIPTION
From the updated docs:

> Testing peak utilization of the `snax-gemmx` accelerator, for different matrix sizes. Measures max performance without considering control overhead. This test generates a lot of results and plots to get deep insight into the performance of the accelerator combined with the TCDM interconnect and data layout strategies.
> 
> The following operations are compared:
> 
> - matmul (D = AxB)
> - gemm (D = AxB)
> 
> The following layout strategies are compared:
> 
> - cyclic
> - banked
> 
> The following sizes are run:
> 
> - every combination of (32, 48, 64)
> - some common sizes for neural networks
> 

This PR adds the gemm to this benchmark (previously only matmul)