### PR TITLE
fix alloc kernel

### DIFF
--- a/.github/workflows/build-run-kernel.yml
+++ b/.github/workflows/build-run-kernel.yml
@@ -20,4 +20,4 @@ jobs:
         working-directory: kernels/${{ matrix.kernel }}
     strategy:
       matrix:
-        kernel: [simple_copy, transform_copy, streamer_alu, tiled_add, streamer_matmul, gemmini, rescale, gemm]
+        kernel: [alloc, simple_copy, transform_copy, streamer_alu, tiled_add, streamer_matmul, gemmini, rescale, gemm]

--- a/kernels/alloc/main.c
+++ b/kernels/alloc/main.c
@@ -35,8 +35,8 @@ int main() {
   if (memrefA.shape[0] != 10) {
     return 420;
   }
-  // Assert that the alloc is alligned correctly to 256 bytes
-  if (((int32_t)memrefA.aligned_data) % 256) {
+  // Assert that the alloc is alligned correctly to 64 bytes
+  if (((int32_t)memrefA.aligned_data) % 64) {
     return 421;
   }
 


### PR DESCRIPTION
There was a check for alignment to 256 bytes, but 64 bytes is sufficient.

Also add the kernel to ci

Resolves #260 