### PR TITLE
Update accfg benchmarks

### DIFF
--- a/benchmarks/tiled_matmul/Makefile
+++ b/benchmarks/tiled_matmul/Makefile
@@ -2,7 +2,7 @@
 
 .DEFAULT_GOAL := all
 
-include ../../runtime/snax-streamer-gemm.rules
+include ../../runtime/snax-gemmx.rules
 include ../../runtime/Makefile.rules
 
 TESTS += generated.x
@@ -26,13 +26,7 @@ ifdef ACCFG_BOTH
 ACCFGOPT=accfg-dedup,accfg-config-overlap,
 endif
 
-SNAXOPTFLAGS = -p insert-accfg-op{accelerator=snax_gemm},convert-linalg-to-kernel,dispatch-kernels,set-memory-space,set-memory-layout,realize-memref-casts,${REMOVE_MEMREF_COPY}insert-sync-barrier,reuse-memref-allocs,test-add-mcycle-around-loop,snax-lower-mcycle,dispatch-regions,convert-linalg-to-stream,convert-stream-to-snax-stream,convert-linalg-to-accfg,snax-copy-to-dma,memref-to-snax,snax-to-func,clear-memory-space,function-constant-pinning,mlir-opt{executable=mlir-opt\ generic=true\ arguments="-cse,-canonicalize,-allow-unregistered-dialect,-mlir-print-op-generic"},${ACCFGOPT}convert-accfg-to-csr,
-
-
-GEN_DATA_OPTS += --m=${SIZE_M}
-GEN_DATA_OPTS += --n=${SIZE_N}
-GEN_DATA_OPTS += --k=${SIZE_K}
-
+SNAXOPTFLAGS = -p convert-linalg-to-kernel,insert-accfg-op{accelerator=snax_gemmx},dispatch-kernels,convert-linalg-to-stream,fuse-streaming-regions,snax-bufferize,alloc-to-global,set-memory-space,set-memory-layout,realize-memref-casts,insert-sync-barrier,dispatch-regions{nb_cores=2},convert-stream-to-snax-stream,convert-linalg-to-accfg,snax-copy-to-dma,memref-to-snax,snax-to-func,clear-memory-space,function-constant-pinning,mlir-opt{executable=mlir-opt\ generic=true\ arguments="-cse,-canonicalize,-allow-unregistered-dialect,-mlir-print-op-generic"},${ACCFGOPT}convert-accfg-to-csr,
 
 CFLAGS += -std=gnu11
 CFLAGS += -Wall -Wextra
@@ -42,10 +36,7 @@ ifdef NO_CHECK
 CFLAGS += -DNO_CHECK
 endif
 
-data.c data.h:
-	$(PYTHON) gendata.py ${GEN_DATA_OPTS}
-
-%.x: %.o main.o data.o
+%.x: %.o main.o
 	$(LD) $(LDFLAGS) $^ -o $@
 
 sim_%: %

--- a/benchmarks/tiled_matmul/main.c
+++ b/benchmarks/tiled_matmul/main.c
@@ -1,151 +1,57 @@
-#include "stdint.h"
-
-#include "data.h"
 #include "memref.h"
 #include "snax_rt.h"
-
-/*
- * These libraries are included from github.com/KULeuven-MICAS/snitch_cluster
- * Interested users, might want to look at:
- *
- * /sw/snRuntime/api
- * /target/snitch_cluster/sw/runtime/rtl/src
- * /target/snitch_cluster/sw/runtime/common
- * */
+#include "stdint.h"
 #include <snrt.h>
 
-/* These libraries are included from github.com/KULeuven-MICAS/snitch_cluster
- * Interested users, might want to look at:
- *
- * /target/snitch_cluster/sw/snax/streamer-gemm/include"
- * /target/snitch_cluster/sw/snax/mac/include"
- *
- * */
-#include "snax-streamer-gemm-lib.h"
-
-#define tileSize 8
-#define meshRow 8
-#define meshCol 8
-
-uint8_t Batch = 1;
-
-/* M_param and N_param can be set to 1 for tiled versions, but not for simple
- version. 2 always works. however, it will impact performance significantly as
- computation cost doubles. For benchmarks, set to 1 */
-uint8_t M_param = 2;
-uint8_t K_param = K_size / tileSize;
-uint8_t N_param = 2;
-
-// Extracted from datagen.py in snitch_cluster repo
-uint32_t strideInnermostA = 256;
-uint32_t strideInnermostB = 256;
-uint32_t strideInnermostC = 256;
-uint32_t ldA = 512;
-uint32_t ldB = 512;
-uint32_t ldC = 512;
-uint32_t strideA = 0;
-uint32_t strideB = 0;
-uint32_t strideC = 0;
-
-// Kernel provided via external definition
-void _mlir_ciface_streamer_matmul(TwoDMemrefI8_t *a, TwoDMemrefI8_t *b,
-                                  TwoDMemrefI32_t *c);
-
-void _mlir_ciface_snax_gemm(TwoDMemrefI8_t *a, TwoDMemrefI8_t *b, int32_t zpa,
-                            int32_t zpb, TwoDMemrefI32_t *c) {
-  {
-    printf("Executing snax_gemm with a=%p, b=%p, c=%p \n", a->aligned_data,
-           b->aligned_data, c->aligned_data);
-    int local_delta_a = (int)a->aligned_data - (int)snrt_l1_next();
-    int local_delta_b = (int)b->aligned_data - (int)snrt_l1_next();
-    int local_delta_c = (int)c->aligned_data - (int)snrt_l1_next();
-
-    set_streamer_csr(K_param, N_param, M_param, strideInnermostA, ldA, 8,
-                     strideInnermostB, ldB, 8, strideInnermostC, ldC, 32,
-                     local_delta_a, local_delta_b, local_delta_c);
-    set_streamer_start();
-    set_block_gemm_csr(K_param, N_param, M_param, 0);
-
-    snrt_mcycle();
-
-    set_block_gemm_start();
-
-    printf("Waiting for snax_gemm\n");
-
-    wait_streamer_gemm();
-
-    snrt_mcycle();
-
-    printf("Finished executing snax_gemm\n");
-  }
-}
+void _mlir_ciface_snax_main(TwoDMemrefI32_t *results);
 
 int main() {
-  {
 
-    // Create memref objects for data stored in L3
-    TwoDMemrefI8_t memrefA;
-    memrefA.data = &A;
-    memrefA.aligned_data = memrefA.data;
-    // Shape and Stride need to be defined for dynamic case
-    memrefA.shape[0] = N_size;
-    memrefA.shape[1] = K_size;
-    memrefA.stride[0] = K_size;
-    memrefA.stride[1] = 1;
-    memrefA.offset = 0;
+  TwoDMemrefI32_t results[2];
 
-    TwoDMemrefI8_t memrefB;
-    memrefB.data = &B;
-    memrefB.aligned_data = memrefB.data;
-    // Shape and Stride need to be defined for dynamic case
-    memrefB.shape[0] = K_size;
-    memrefB.shape[1] = M_size;
-    memrefB.stride[0] = 1;
-    memrefB.stride[1] = K_size;
-    memrefB.offset = 0;
-    printf("M_size: %d, K_size: %d, N_size: %d\n", M_size, K_size, N_size);
+  TwoDMemrefI32_t *golden, *computed;
 
-    TwoDMemrefI32_t memrefC;
-    memrefC.data = &C;
-    memrefC.aligned_data = memrefC.data;
-    // Shape and Stride need to be defined for dynamic case
-    memrefC.shape[0] = N_size;
-    memrefC.shape[1] = M_size;
-    memrefC.stride[0] = M_size;
-    memrefC.stride[1] = 1;
-    memrefC.offset = 0;
+  golden = &results[0];
+  computed = &results[1];
 
-    _mlir_ciface_streamer_matmul(&memrefA, &memrefB, &memrefC);
+  // allocate zero row in tcdm
+  snrt_l1alloc(256);
 
-    snrt_cluster_hw_barrier();
+  (void)snrt_mcycle();
+  snrt_cluster_hw_barrier();
 
-    // Correctness check -
-    // from this point on only core 0 is required to be alive.
-    int thiscore = snrt_cluster_core_idx();
-    if (thiscore != 0)
-      return 0;
+  _mlir_ciface_snax_main(results);
 
-#ifdef NO_CHECK
-    // No correctness check =
-    // Always finish as if nothing happened
+  snrt_cluster_hw_barrier();
+  (void)snrt_mcycle();
+
+  // Correctness check
+  // from this point on only core 0 is required to be alive.
+  int thiscore = snrt_cluster_core_idx();
+  if (thiscore != 0)
     return 0;
-#endif
-    int nerr = 0;
 
-    for (int i = 0; i < M_size * N_size; i++) {
-      {
-        int32_t error = memrefC.aligned_data[i] - C_golden[i];
-        // printf("%d) %d -> %d\n", i, (int32_t)memrefC.aligned_data[i],
-        //        (int32_t)C_golden[i]);
-        if (error != 0)
-          nerr += 1;
-      }
+  int total_results = 1;
+  for (int i = 0; i < 2; i++)
+    total_results *= computed->shape[i];
+
+  printf("Checking %d results...\n", total_results);
+
+  int nerr = 0;
+
+  for (int i = 0; i < total_results; i++) {
+
+    if (golden->aligned_data[i] != computed->aligned_data[i]) {
+      // printf("(%d) %d -> %d\n", i, golden->aligned_data[i],
+      // computed->aligned_data[i]);
+      nerr++;
     }
-
-    // insert mcycle to show fault in trace
-    if (nerr != 0)
-      snrt_mcycle();
-
-    return nerr;
   }
+
+  printf("Finished, nb errors: %d\n", nerr);
+
+  if (nerr > 0)
+    return 1;
+  else
+    return 0;
 }


### PR DESCRIPTION
It seems that since #228 the accfg benchmarks have not properly been maintained because I have messed up the CI in that pull request. I feel like I can not implement #293 if this one is not working properly.

However, I've seen in this benchmark that some warnings are popping up, such as:
```
Op with effects in use-def chain upwards of setup SetupOp(%0 = accfg.setup "snax_gemmx" from %arg8 to ("a_ptr_low" = %1 : index, "a_ptr_high" = %2 : i32, "a_sstride_0" = %3 : i32, "a_bound_0" = %4 : i32, "a_bound_1" = %4 : i32, "a_bound_2" = %4 : i32, "a_bound_3" = %3 : i32, "a_bound_4" = %4 : i32, "a_bound_5" = %4 : i32, "a_tstride_0" = %2 : i32, "a_tstride_1" = %2 : i32, "a_tstride_2" = %2 : i32, "a_tstride_3" = %5 : i32, "a_tstride_4" = %2 : i32, "a_tstride_5" = %6 : i32, "a_address_remap" = %2 : i32, "b_ptr_low" = %7 : index, "b_ptr_high" = %2 : i32, "b_sstride_0" = %3 : i32, "b_bound_0" = %3 : i32, "b_bound_1" = %4 : i32, "b_bound_2" = %4 : i32, "b_tstride_0" = %5 : i32, "b_tstride_1" = %6 : i32, "b_tstride_2" = %2 : i32, "b_address_remap" = %2 : i32, "c_ptr_low" = %7 : index, "c_ptr_high" = %2 : i32, "c_sstride_0" = %2 : i32, "c_bound_0" = %2 : i32, "c_bound_1" = %2 : i32, "c_bound_2" = %2 : i32, "c_tstride_0" = %2 : i32, "c_tstride_1" = %2 : i32, "c_tstride_2" = %2 : i32, "c_address_remap" = %2 : i32, "d_ptr_low" = %8 : i32, "d_ptr_high" = %2 : i32, "d_sstride_0" = %3 : i32, "d_sstride_1" = %5 : i32, "d_bound_0" = %4 : i32, "d_bound_1" = %4 : i32, "d_bound_2" = %4 : i32, "d_tstride_0" = %2 : i32, "d_tstride_1" = %2 : i32, "d_tstride_2" = %2 : i32, "d_address_remap" = %2 : i32, "d_channel_mask" = %2 : i32, "e_ptr_low" = %9 : index, "e_ptr_high" = %2 : i32, "e_sstride_0" = %3 : i32, "e_sstride_1" = %5 : i32, "e_bound_0" = %4 : i32, "e_bound_1" = %4 : i32, "e_bound_2" = %4 : i32, "e_tstride_0" = %2 : i32, "e_tstride_1" = %10 : i32, "e_tstride_2" = %10 : i32, "e_address_remap" = %2 : i32, "a_transpose" = %4 : i32, "b_transpose" = %4 : i32, "d_broadcast" = %4 : i32, "K" = %3 : i32, "N" = %4 : i32, "M" = %4 : i32, "subtractions" = %2 : i32, "csr0" = %2 : i32, "csr1" = %2 : i32, "shift_0" = %2 : i32, "shift_1" = %2 : i32, "mult_0" = %2 : i32, "mult_1" = %2 : i32, "mult_2" = %2 : i32, "mult_3" = %2 : i32, "mult_4" = %2 : i32, "mult_5" = %2 : i32, "mult_6" = %2 : i32, "mult_7" = %2 : i32, "temporal_loop_bound" = %2 : i32, "bypassSIMD" = %4 : i32) : !accfg.state<"snax_gemmx">): LoadOp(%0 = "llvm.load"(%1) <{"ordering" = 0 : i64}> : (!llvm.ptr) -> !llvm.struct<(!llvm.ptr, !llvm.ptr)>)

```