### PR TITLE
add affine transform util

### DIFF
--- a/compiler/ir/autoflow/__init__.py
+++ b/compiler/ir/autoflow/__init__.py
@@ -1,0 +1,1 @@
+from .affine_transform import *

--- a/compiler/ir/autoflow/affine_transform.py
+++ b/compiler/ir/autoflow/affine_transform.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+from typing import Self
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class AffineTransform:
+    """
+    An affine transform mirroring the functionality of xDSLs and MLIRs
+    AffineMap, but represented in matrix form to make life much easier.
+    This is possible if you don't have to support floordiv/ceildiv operations.
+    """
+
+    _A: np.ndarray  # Transformation matrix
+    _b: np.ndarray  # Translation vector
+
+    def __post_init__(self):
+        # Validate dimensions
+        if self._A.ndim != 2:
+            raise ValueError("Matrix A must be 2-dimensional.")
+        if self._b.ndim != 1:
+            raise ValueError("Vector b must be 1-dimensional.")
+        if self._A.shape[0] != self._b.shape[0]:
+            raise ValueError("Matrix A and vector b must have compatible dimensions.")
+
+    @property
+    def num_dims(self) -> int:
+        return self._A.shape[0]
+
+    @property
+    def num_results(self) -> int:
+        return self._A.shape[1]
+
+    def eval(self, x: np.ndarray) -> np.ndarray:
+        """
+        Apply the affine transformation to a vector or a set of vectors.
+        """
+        if x.ndim == 1:  # Single vector
+            if x.shape[0] != self._A.shape[1]:
+                raise ValueError("Input vector x must have a dimension matching the number of columns in A.")
+            return self._A @ x + self._b
+        elif x.ndim == 2:  # Batch of vectors
+            if x.shape[1] != self._A.shape[1]:
+                raise ValueError("Input vectors in batch must have a dimension matching the number of columns in A.")
+            return (self._A @ x.T).T + self._b
+        else:
+            raise ValueError("Input x must be 1D (vector) or 2D (batch of vectors).")
+
+    def compose(self, other: Self) -> Self:
+        """
+        Combine this affine transformation with another.
+        The result represents the application of `other` followed by `self`.
+        """
+        if self._A.shape[1] != other._A.shape[0]:
+            raise ValueError("Matrix dimensions of the transformations do not align for composition.")
+        new_A = self._A @ other._A
+        new_b = self._A @ other._b + self._b
+        return type(self)(new_A, new_b)
+
+    def __str__(self):
+        return f"AffineTransform(A=\n{self._A},\nb={self._b})"

--- a/compiler/ir/autoflow/affine_transform.py
+++ b/compiler/ir/autoflow/affine_transform.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 import numpy as np
+import numpy.typing as npt
 from typing_extensions import Self
 
 
@@ -12,38 +13,42 @@ class AffineTransform:
     This is possible if you don't have to support floordiv/ceildiv operations.
     """
 
-    _A: np.ndarray  # Transformation matrix
-    _b: np.ndarray  # Translation vector
+    A: npt.NDArray[np.int_]  # Transformation matrix
+    b: npt.NDArray[np.int_]  # Translation vector
 
     def __post_init__(self):
         # Validate dimensions
-        if self._A.ndim != 2:
+        if self.A.ndim != 2:
             raise ValueError("Matrix A must be 2-dimensional.")
-        if self._b.ndim != 1:
+        if self.b.ndim != 1:
             raise ValueError("Vector b must be 1-dimensional.")
-        if self._A.shape[0] != self._b.shape[0]:
+        if self.A.shape[0] != self.b.shape[0]:
             raise ValueError("Matrix A and vector b must have compatible dimensions.")
 
     @property
     def num_dims(self) -> int:
-        return self._A.shape[0]
+        return self.A.shape[0]
 
     @property
     def num_results(self) -> int:
-        return self._A.shape[1]
+        return self.A.shape[1]
 
-    def eval(self, x: np.ndarray) -> np.ndarray:
+    def eval(self, x: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
         """
         Apply the affine transformation to a vector or a set of vectors.
         """
         if x.ndim == 1:  # Single vector
-            if x.shape[0] != self._A.shape[1]:
-                raise ValueError("Input vector x must have a dimension matching the number of columns in A.")
-            return self._A @ x + self._b
+            if x.shape[0] != self.A.shape[1]:
+                raise ValueError(
+                    "Input vector x must have a dimension matching the number of columns in A."
+                )
+            return self.A @ x + self.b
         elif x.ndim == 2:  # Batch of vectors
-            if x.shape[1] != self._A.shape[1]:
-                raise ValueError("Input vectors in batch must have a dimension matching the number of columns in A.")
-            return (self._A @ x.T).T + self._b
+            if x.shape[1] != self.A.shape[1]:
+                raise ValueError(
+                    "Input vectors in batch must have a dimension matching the number of columns in A."
+                )
+            return (self.A @ x.T).T + self.b
         else:
             raise ValueError("Input x must be 1D (vector) or 2D (batch of vectors).")
 
@@ -52,11 +57,13 @@ class AffineTransform:
         Combine this affine transformation with another.
         The result represents the application of `other` followed by `self`.
         """
-        if self._A.shape[1] != other._A.shape[0]:
-            raise ValueError("Matrix dimensions of the transformations do not align for composition.")
-        new_A = self._A @ other._A
-        new_b = self._A @ other._b + self._b
+        if self.A.shape[1] != other.A.shape[0]:
+            raise ValueError(
+                "Matrix dimensions of the transformations do not align for composition."
+            )
+        new_A = self.A @ other.A
+        new_b = self.A @ other.b + self.b
         return type(self)(new_A, new_b)
 
     def __str__(self):
-        return f"AffineTransform(A=\n{self._A},\nb={self._b})"
+        return f"AffineTransform(A=\n{self.A},\nb={self.b})"

--- a/compiler/ir/autoflow/affine_transform.py
+++ b/compiler/ir/autoflow/affine_transform.py
@@ -27,11 +27,11 @@ class AffineTransform:
 
     @property
     def num_dims(self) -> int:
-        return self.A.shape[0]
+        return self.A.shape[1]
 
     @property
     def num_results(self) -> int:
-        return self.A.shape[1]
+        return self.A.shape[0]
 
     def eval(self, x: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
         """

--- a/compiler/ir/autoflow/affine_transform.py
+++ b/compiler/ir/autoflow/affine_transform.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from typing import Self
 
 import numpy as np
+from typing_extensions import Self
 
 
 @dataclass(frozen=True)

--- a/tests/ir/autoflow/test_affine_transform.py
+++ b/tests/ir/autoflow/test_affine_transform.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pytest
+
+from compiler.ir.autoflow import AffineTransform
+
+
+def test_affine_transform_initialization_valid():
+    A = np.array([[1, 2], [3, 4]])
+    b = np.array([5, 6])
+    transform = AffineTransform(A, b)
+    assert np.array_equal(transform._A, A)
+    assert np.array_equal(transform._b, b)
+    assert transform.num_dims == 2
+    assert transform.num_results == 2
+
+def test_affine_transform_initialization_invalid_dimensions():
+    A = np.array([[1, 2], [3, 4]])
+    b = np.array([5])  # Incompatible size
+    with pytest.raises(ValueError, match="Matrix A and vector b must have compatible dimensions."):
+        AffineTransform(A, b)
+
+def test_affine_transform_eval_single_vector():
+    A = np.array([[1, 0], [0, 1]])
+    b = np.array([1, 2])
+    transform = AffineTransform(A, b)
+    x = np.array([3, 4])
+    result = transform.eval(x)
+    expected = np.array([4, 6])
+    assert np.array_equal(result, expected)
+
+def test_affine_transform_eval_batch_of_vectors():
+    A = np.array([[1, 0], [0, 1]])
+    b = np.array([1, 2])
+    transform = AffineTransform(A, b)
+    x_batch = np.array([[3, 4], [5, 6]])
+    result = transform.eval(x_batch)
+    expected = np.array([[4, 6], [6, 8]])
+    assert np.array_equal(result, expected)
+
+def test_affine_transform_eval_invalid_vector_dimension():
+    A = np.array([[1, 0], [0, 1]])
+    b = np.array([1, 2])
+    transform = AffineTransform(A, b)
+    x = np.array([3])  # Incompatible dimension
+    with pytest.raises(ValueError, match="Input vector x must have a dimension matching the number of columns in A."):
+        transform.eval(x)
+
+def test_affine_transform_compose():
+    A1 = np.array([[1, 2], [3, 4]])
+    b1 = np.array([5, 6])
+    transform1 = AffineTransform(A1, b1)
+
+    A2 = np.array([[0, 1], [1, 0]])
+    b2 = np.array([7, 8])
+    transform2 = AffineTransform(A2, b2)
+
+    composed = transform1.compose(transform2)
+
+    expected_A = A1 @ A2
+    expected_b = A1 @ b2 + b1
+
+    assert np.array_equal(composed._A, expected_A)
+    assert np.array_equal(composed._b, expected_b)
+
+def test_affine_transform_compose_invalid_dimensions():
+    A1 = np.array([[1, 2], [3, 4]])
+    b1 = np.array([5, 6])
+    transform1 = AffineTransform(A1, b1)
+
+    A2 = np.array([[1, 0, 0], [0, 1, 0]])
+    b2 = np.array([7, 8, 9])  # Incompatible with A1
+    transform2 = AffineTransform(A2, b2)
+
+    with pytest.raises(ValueError, match="Matrix dimensions of the transformations do not align for composition."):
+        transform1.compose(transform2)
+
+def test_affine_transform_str():
+    A = np.array([[1, 0], [0, 1]])
+    b = np.array([1, 2])
+    transform = AffineTransform(A, b)
+    expected = "AffineTransform(A=\n[[1 0]\n [0 1]],\nb=[1 2])"
+    assert str(transform) == expected

--- a/tests/ir/autoflow/test_affine_transform.py
+++ b/tests/ir/autoflow/test_affine_transform.py
@@ -1,18 +1,18 @@
 import numpy as np
 import pytest
+from xdsl.ir.affine import AffineMap
 
 from compiler.ir.autoflow import AffineTransform
 
 
 def test_affine_transform_initialization_valid():
-    A = np.array([[1, 2], [3, 4]])
-    b = np.array([5, 6])
+    A = np.array([[1, 2, 3], [4, 5, 6]])
+    b = np.array([7, 8])
     transform = AffineTransform(A, b)
     assert np.array_equal(transform.A, A)
     assert np.array_equal(transform.b, b)
     assert transform.num_dims == 2
     assert transform.num_results == 2
-
 
 def test_affine_transform_initialization_invalid_dimensions():
     A = np.array([[1, 2], [3, 4]])

--- a/tests/ir/autoflow/test_affine_transform.py
+++ b/tests/ir/autoflow/test_affine_transform.py
@@ -8,16 +8,20 @@ def test_affine_transform_initialization_valid():
     A = np.array([[1, 2], [3, 4]])
     b = np.array([5, 6])
     transform = AffineTransform(A, b)
-    assert np.array_equal(transform._A, A)
-    assert np.array_equal(transform._b, b)
+    assert np.array_equal(transform.A, A)
+    assert np.array_equal(transform.b, b)
     assert transform.num_dims == 2
     assert transform.num_results == 2
+
 
 def test_affine_transform_initialization_invalid_dimensions():
     A = np.array([[1, 2], [3, 4]])
     b = np.array([5])  # Incompatible size
-    with pytest.raises(ValueError, match="Matrix A and vector b must have compatible dimensions."):
+    with pytest.raises(
+        ValueError, match="Matrix A and vector b must have compatible dimensions."
+    ):
         AffineTransform(A, b)
+
 
 def test_affine_transform_eval_single_vector():
     A = np.array([[1, 0], [0, 1]])
@@ -28,6 +32,7 @@ def test_affine_transform_eval_single_vector():
     expected = np.array([4, 6])
     assert np.array_equal(result, expected)
 
+
 def test_affine_transform_eval_batch_of_vectors():
     A = np.array([[1, 0], [0, 1]])
     b = np.array([1, 2])
@@ -37,13 +42,18 @@ def test_affine_transform_eval_batch_of_vectors():
     expected = np.array([[4, 6], [6, 8]])
     assert np.array_equal(result, expected)
 
+
 def test_affine_transform_eval_invalid_vector_dimension():
     A = np.array([[1, 0], [0, 1]])
     b = np.array([1, 2])
     transform = AffineTransform(A, b)
     x = np.array([3])  # Incompatible dimension
-    with pytest.raises(ValueError, match="Input vector x must have a dimension matching the number of columns in A."):
+    with pytest.raises(
+        ValueError,
+        match="Input vector x must have a dimension matching the number of columns in A.",
+    ):
         transform.eval(x)
+
 
 def test_affine_transform_compose():
     A1 = np.array([[1, 2], [3, 4]])
@@ -59,8 +69,9 @@ def test_affine_transform_compose():
     expected_A = A1 @ A2
     expected_b = A1 @ b2 + b1
 
-    assert np.array_equal(composed._A, expected_A)
-    assert np.array_equal(composed._b, expected_b)
+    assert np.array_equal(composed.A, expected_A)
+    assert np.array_equal(composed.b, expected_b)
+
 
 def test_affine_transform_compose_invalid_dimensions():
     A1 = np.array([[1, 2], [3, 4]])
@@ -71,8 +82,12 @@ def test_affine_transform_compose_invalid_dimensions():
     b2 = np.array([7, 8, 9])  # Incompatible with A1
     transform2 = AffineTransform(A2, b2)
 
-    with pytest.raises(ValueError, match="Matrix dimensions of the transformations do not align for composition."):
+    with pytest.raises(
+        ValueError,
+        match="Matrix dimensions of the transformations do not align for composition.",
+    ):
         transform1.compose(transform2)
+
 
 def test_affine_transform_str():
     A = np.array([[1, 0], [0, 1]])

--- a/tests/ir/autoflow/test_affine_transform.py
+++ b/tests/ir/autoflow/test_affine_transform.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-from xdsl.ir.affine import AffineMap
 
 from compiler.ir.autoflow import AffineTransform
 
@@ -11,8 +10,9 @@ def test_affine_transform_initialization_valid():
     transform = AffineTransform(A, b)
     assert np.array_equal(transform.A, A)
     assert np.array_equal(transform.b, b)
-    assert transform.num_dims == 2
+    assert transform.num_dims == 3
     assert transform.num_results == 2
+
 
 def test_affine_transform_initialization_invalid_dimensions():
     A = np.array([[1, 2], [3, 4]])

--- a/tests/ir/autoflow/test_affine_transform.py
+++ b/tests/ir/autoflow/test_affine_transform.py
@@ -79,14 +79,14 @@ def test_affine_transform_compose_invalid_dimensions():
     transform1 = AffineTransform(A1, b1)
 
     A2 = np.array([[1, 0, 0], [0, 1, 0]])
-    b2 = np.array([7, 8, 9])  # Incompatible with A1
+    b2 = np.array([7, 8])
     transform2 = AffineTransform(A2, b2)
 
     with pytest.raises(
         ValueError,
         match="Matrix dimensions of the transformations do not align for composition.",
     ):
-        transform1.compose(transform2)
+        transform2.compose(transform1)
 
 
 def test_affine_transform_str():


### PR DESCRIPTION
An AffineTransform helper, similar to the implementation in MLIR/xDSL.
However, the representation is handled by a matrix A and B instead of the AffineExpr tree, which should make things much easier. I plan to use this class inside the `compiler/ir/stream/access_pattern.py` utility classes.
This also gets rid of the canonicalization problem for affine transforms.