### PR TITLE
affine transform util: add interoperability with AffineMaps

### DIFF
--- a/compiler/ir/autoflow/affine_transform.py
+++ b/compiler/ir/autoflow/affine_transform.py
@@ -30,12 +30,21 @@ class AffineTransform:
     def from_affine_map(cls, map: AffineMap) -> Self:
         """
         Return the affine transform representation of the given affine map.
+
+        This assumes the affine map is a pure linear transformation (i.e., no floordiv/ceildiv/modulo operations)
         """
 
+        # generate a list with n zeros and a 1 at index d:
+        # [0, 0, 0, 1]
         def generate_one_list(n: int, d: int):
             return [1 if x == d else 0 for x in range(n)]
 
+        # determine indices of the matrices a and b by getting the unit response of every dimension
+
+        # bias b is determined by setting all dimensions to zero
         b = np.array(map.eval(generate_one_list(map.num_dims, -1), []))
+
+        # columns of a are determined by toggling every dimension separately
         a = np.zeros((len(map.results), map.num_dims), dtype=np.int_)
         for dim in range(map.num_dims):
             temp = np.array(map.eval(generate_one_list(map.num_dims, dim), []))

--- a/tests/ir/autoflow/test_affine_transform.py
+++ b/tests/ir/autoflow/test_affine_transform.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from xdsl.ir.affine import AffineMap
 
 from compiler.ir.autoflow import AffineTransform
 from compiler.util.canonicalize_affine import canonicalize_map

--- a/tests/ir/autoflow/test_affine_transform.py
+++ b/tests/ir/autoflow/test_affine_transform.py
@@ -115,3 +115,11 @@ def test_affine_map_interop():
 
     original_map = transform.to_affine_map()
     assert canonicalize_map(map) == canonicalize_map(original_map)
+
+    invalid_map = AffineMap.from_callable(lambda a: (a // 2,))
+
+    with pytest.raises(
+        ValueError,
+        match="Affine map is not a pure linear transformation",
+    ):
+        AffineTransform.from_affine_map(invalid_map)

--- a/tests/ir/autoflow/test_affine_transform.py
+++ b/tests/ir/autoflow/test_affine_transform.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from compiler.ir.autoflow import AffineTransform
+from compiler.util.canonicalize_affine import canonicalize_map
 
 
 def test_affine_transform_initialization_valid():
@@ -95,3 +96,21 @@ def test_affine_transform_str():
     transform = AffineTransform(A, b)
     expected = "AffineTransform(A=\n[[1 0]\n [0 1]],\nb=[1 2])"
     assert str(transform) == expected
+
+
+def test_affine_map_interop():
+    map = AffineMap.from_callable(lambda a, b, c: (a + 2 * b, -b + c, 3 * a + c + 4))
+
+    # convert AffineMap to AffineTransform
+    transform = AffineTransform.from_affine_map(map)
+
+    expected_a = np.array([[1, 2, 0], [0, -1, 1], [3, 0, 1]])
+    expected_b = np.array([0, 0, 4])
+
+    assert (transform.A == expected_a).all()
+    assert (transform.b == expected_b).all()
+
+    # convert back to AffineMap
+
+    original_map = transform.to_affine_map()
+    assert canonicalize_map(map) == canonicalize_map(original_map)


### PR DESCRIPTION
to keep interoperability with xdsl afinemaps, and to enable a more gradual migration to affinetransforms, include the constructors `from_affine_map` and `to_affine_map`