### PR TITLE
split convert_stream_to_snax_stream in scheduler and layout resolution

### DIFF
--- a/compiler/accelerators/snax.py
+++ b/compiler/accelerators/snax.py
@@ -10,8 +10,9 @@ from xdsl.ir import Operation, OpResult, SSAValue
 from compiler.accelerators.accelerator import Accelerator
 from compiler.accelerators.streamers import StreamerConfiguration
 from compiler.accelerators.streamers.streamers import StreamerFlag, StreamerOpts
-from compiler.dialects import accfg, stream
+from compiler.dialects import accfg
 from compiler.dialects.snax_stream import StreamerConfigurationAttr, StreamingRegionOp
+from compiler.dialects.stream import StreamingRegionOpBase
 from compiler.ir.stream import Template
 
 c0_attr = builtin.IntegerAttr(0, builtin.IndexType())
@@ -279,7 +280,7 @@ class SNAXStreamer(ABC):
 
     @staticmethod
     @abstractmethod
-    def get_template(op: stream.StreamingRegionOpBase) -> Template:
+    def get_template(op: StreamingRegionOpBase) -> Template:
         """
         Get the template for this acelerator to schedule a given
         stream.streaming_region operation.

--- a/compiler/accelerators/snax.py
+++ b/compiler/accelerators/snax.py
@@ -279,7 +279,7 @@ class SNAXStreamer(ABC):
 
     @staticmethod
     @abstractmethod
-    def get_template(op: stream.StreamingRegionOp) -> Template:
+    def get_template(op: stream.StreamingRegionOpBase) -> Template:
         """
         Get the template for this acelerator to schedule a given
         stream.streaming_region operation.

--- a/compiler/accelerators/snax_alu.py
+++ b/compiler/accelerators/snax_alu.py
@@ -194,7 +194,7 @@ class SNAXAluAccelerator(
         return op
 
     @staticmethod
-    def get_template(op: stream.StreamingRegionOp):
+    def get_template(op: stream.StreamingRegionOpBase):
         template = [AffineMap.from_callable(lambda x, y: (4 * x + y,))] * 3
         template_bounds = (None, 4)
         return Template(TemplatePattern(template_bounds, tp) for tp in template)

--- a/compiler/accelerators/snax_gemm.py
+++ b/compiler/accelerators/snax_gemm.py
@@ -166,7 +166,7 @@ class SNAXGEMMAccelerator(SNAXAccelerator, SNAXStreamer, DispatchTemplate):
         ]
 
     @staticmethod
-    def get_template(op: stream.StreamingRegionOp) -> Template:
+    def get_template(op: stream.StreamingRegionOpBase) -> Template:
         M, N, K, m, n, k = (AffineDimExpr(i) for i in range(6))
         template = [
             AffineMap(6, 0, (M * 8 + m, K * 8 + k)),

--- a/compiler/accelerators/snax_gemmx.py
+++ b/compiler/accelerators/snax_gemmx.py
@@ -271,7 +271,7 @@ class SNAXGEMMXAccelerator(
         ]
 
     @staticmethod
-    def get_template(op: stream.StreamingRegionOp) -> Template:
+    def get_template(op: stream.StreamingRegionOpBase) -> Template:
         assert isinstance(generic_op := op.body.block.first_op, stream.GenericOp)
         if isinstance(generic_op.body.block.first_op, kernel.QMacOp):
             # matmul

--- a/compiler/dialects/stream.py
+++ b/compiler/dialects/stream.py
@@ -36,11 +36,6 @@ from xdsl.irdl import (
     var_result_def,
 )
 
-from compiler.accelerators.registry import AcceleratorRegistry
-from compiler.accelerators.snax import SNAXStreamer
-from compiler.accelerators.util import find_accelerator_op
-from compiler.ir.stream.access_pattern import Template
-
 """
 Custom `stream` dialect, to simplify things in a more principled approach, including:
 - inherent support for tensors
@@ -119,24 +114,6 @@ class StreamingRegionOpBase(IRDLOperation):
             },
             result_types=[result_types],
         )
-
-    def get_accelerator_info(self) -> Template:
-        assert self.accelerator is not None
-
-        # Go and fetch the accelerator op
-        accelerator_str = self.accelerator.data
-        acc_op = find_accelerator_op(self, accelerator_str)
-
-        if not acc_op:
-            raise RuntimeError("AcceleratorOp not found!")
-
-        # get template and template_bounds
-        accelerator_type = AcceleratorRegistry().get_acc_info(acc_op)
-        assert issubclass(accelerator_type, SNAXStreamer)
-
-        template = accelerator_type.get_template(self)
-
-        return template
 
 
 @irdl_op_definition

--- a/compiler/dialects/stream.py
+++ b/compiler/dialects/stream.py
@@ -36,6 +36,11 @@ from xdsl.irdl import (
     var_result_def,
 )
 
+from compiler.accelerators.registry import AcceleratorRegistry
+from compiler.accelerators.snax import SNAXStreamer
+from compiler.accelerators.util import find_accelerator_op
+from compiler.ir.stream.access_pattern import Template
+
 """
 Custom `stream` dialect, to simplify things in a more principled approach, including:
 - inherent support for tensors
@@ -114,6 +119,24 @@ class StreamingRegionOpBase(IRDLOperation):
             },
             result_types=[result_types],
         )
+
+    def get_accelerator_info(self) -> Template:
+        assert self.accelerator is not None
+
+        # Go and fetch the accelerator op
+        accelerator_str = self.accelerator.data
+        acc_op = find_accelerator_op(self, accelerator_str)
+
+        if not acc_op:
+            raise RuntimeError("AcceleratorOp not found!")
+
+        # get template and template_bounds
+        accelerator_type = AcceleratorRegistry().get_acc_info(acc_op)
+        assert issubclass(accelerator_type, SNAXStreamer)
+
+        template = accelerator_type.get_template(self)
+
+        return template
 
 
 @irdl_op_definition


### PR DESCRIPTION
stacked on #331 

With the addition of the schedule op, this PR splits the `convert_stream_to_snax_stream` (which converts operation -> access pattern) into two separate passes (scheduler: operation -> schedule), (layout resolution: schedule -> access pattern).

The schedule representation is nice to have to run other passes on before doing layout resolution, such as selecting a layout.