### PR TITLE
transforms: (convert_stream_to_snax_stream) split up layout resolution pass

### DIFF
--- a/compiler/dialects/stream.py
+++ b/compiler/dialects/stream.py
@@ -198,6 +198,38 @@ class ScheduleOp(StreamingRegionOpBase):
 
 
 @irdl_op_definition
+class AccessPatternOp(StreamingRegionOpBase):
+    name = "stream.access_pattern"
+
+    # The bounds of the iteration space of the schedule
+    bounds = prop_def(ParameterDef[ArrayAttr[IntegerAttr[IndexType]]])
+
+    def __init__(
+        self,
+        inputs: Sequence[SSAValue | Operation],
+        outputs: Sequence[SSAValue | Operation],
+        patterns: ArrayAttr[AffineMapAttr],
+        body: Region,
+        bounds: ArrayAttr[IntegerAttr[IndexType]] | Sequence[int],
+        accelerator: str | StringAttr | None = None,
+        result_types: Sequence[Attribute] = (),
+    ) -> None:
+        if isinstance(bounds, Sequence):
+            bounds = ArrayAttr(
+                [IntegerAttr.from_index_int_value(val) for val in bounds]
+            )
+        super().__init__(
+            inputs,
+            outputs,
+            patterns,
+            body,
+            accelerator,
+            result_types,
+            {"bounds": bounds},
+        )
+
+
+@irdl_op_definition
 class YieldOp(AbstractYieldOperation[Attribute]):
     name = "stream.yield"
 
@@ -247,6 +279,7 @@ Stream = Dialect(
     [
         StreamingRegionOp,
         ScheduleOp,
+        AccessPatternOp,
         GenericOp,
         YieldOp,
     ],

--- a/compiler/dialects/stream.py
+++ b/compiler/dialects/stream.py
@@ -118,6 +118,11 @@ class StreamingRegionOpBase(IRDLOperation):
 
 @irdl_op_definition
 class StreamingRegionOp(StreamingRegionOpBase):
+    """
+    A streaming region op that represents an unscheduled operation,
+    with streams mapping the iteration space to the operand indexing space.
+    """
+
     name = "stream.streaming_region"
 
     def get_pattern_bounds_to_shapes_map(self) -> AffineMap:
@@ -156,6 +161,16 @@ class StreamingRegionOp(StreamingRegionOpBase):
 
 @irdl_op_definition
 class ScheduleOp(StreamingRegionOpBase):
+    """
+    A streaming region op that represents an scheduled operation,
+    with streams mapping the iteration space to the operand indexing space.
+
+    Due to the transformations that took place on the unscheduled op,
+    some extra metadata is needed, consisting of the fixed bounds
+    of the iteration space and the tile sizes that are used if a tiling
+    transformation took place.
+    """
+
     name = "stream.schedule"
 
     # The bounds of the iteration space of the schedule
@@ -199,6 +214,11 @@ class ScheduleOp(StreamingRegionOpBase):
 
 @irdl_op_definition
 class AccessPatternOp(StreamingRegionOpBase):
+    """
+    A streaming region op that represents an scheduled operation, after
+    layout resolution, with streams mapping the iteration space to memory.
+    """
+
     name = "stream.access_pattern"
 
     # The bounds of the iteration space of the schedule

--- a/compiler/transforms/convert_stream_to_snax_stream.py
+++ b/compiler/transforms/convert_stream_to_snax_stream.py
@@ -163,6 +163,12 @@ class LayoutResolution(RewritePattern):
 
 @dataclass
 class ConvertStreamToSnaxStreamPattern(RewritePattern):
+    """
+    Convert stream access patterns (with affinemap patterns mapping the iteration
+    space to memory) into actual stride pattens for SNAX Streamers, with given
+    spatial and temporal strides ready to be programmed through CSRs.
+    """
+
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: stream.AccessPatternOp, rewriter: PatternRewriter):
         template = get_accelerator_info(op)

--- a/compiler/transforms/convert_stream_to_snax_stream.py
+++ b/compiler/transforms/convert_stream_to_snax_stream.py
@@ -85,6 +85,12 @@ class AutoflowScheduler(RewritePattern):
 
 @dataclass
 class LayoutResolution(RewritePattern):
+    """
+    Applies layout resolution by converting a ScheduleOp (mapping the iteration
+    space to the operand index space) into an AccessOp (mapping the iteration space
+    to memory), using a certain memory layout of the memref operands of the operation.
+    """
+
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: stream.ScheduleOp, rewriter: PatternRewriter):
         bounds = [x.value.data for x in op.bounds.data]

--- a/compiler/transforms/convert_stream_to_snax_stream.py
+++ b/compiler/transforms/convert_stream_to_snax_stream.py
@@ -227,9 +227,6 @@ class ConvertStreamToSnaxStreamPattern(RewritePattern):
 
                 # insert empty patterns for D8 and zero pattern for C
                 snax_stride_patterns.insert(2, empty_pattern)
-                # ops_to_add.append(
-                #         ptr := memref.ExtractAlignedPointerAsIndexOp.get(op.inputs[-1])
-                # )
                 new_inputs.append(op.inputs[-1])
 
                 # insert zero pattern for C, using the same pattern as D32 but pointing to zero
@@ -256,9 +253,6 @@ class ConvertStreamToSnaxStreamPattern(RewritePattern):
                 # for a gemm, the 8bit-output port D8 are unused, so we create
                 # empty patterns for them here
                 snax_stride_patterns.insert(2, empty_pattern)
-                # ops_to_add.insert(
-                #         2, ptr := memref.ExtractAlignedPointerAsIndexOp.get(op.inputs[-1])
-                # )
                 new_inputs.insert(2, op.inputs[-1])
 
             else:

--- a/tests/filecheck/transforms/convert-stream-to-snax-stream.mlir
+++ b/tests/filecheck/transforms/convert-stream-to-snax-stream.mlir
@@ -42,9 +42,9 @@ func.func @streamer_matmul(%arg0 : memref<16x16xi8>, %arg1 : memref<16x16xi8, st
   func.return
 }
 
-// CHECK:       "snax_stream.streaming_region"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{"stride_patterns" = [#snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 0, 128], ss = [8]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 128, 0], ss = [8]>, #snax_stream.stride_pattern<ub = [0, 0, 0], ts = [0, 0, 0], ss = [0]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 0, 0], ss = [8, 64]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 32, 512], ss = [8, 64]>], "accelerator" = "snax_gemmx", "operandSegmentSizes" = array<i32: 4, 1>}> ({
+// CHECK:       "snax_stream.streaming_region"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{"stride_patterns" = [#snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 0, 128], ss = [8]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 128, 0], ss = [8]>, #snax_stream.stride_pattern<ub = [0, 0, 0], ts = [0, 0, 0], ss = [0]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 0, 0], ss = [8, 64]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 32, 512], ss = [8, 64]>], accelerator = "snax_gemmx", operandSegmentSizes = array<i32: 4, 1>}> ({
 // CHECK-NEXT:  ^0(%{{.*}} : !stream.stream<i8>, %{{.*}} : !stream.stream<i8>, %{{.*}} : !stream.stream<i32>):
-// CHECK-NEXT:    %{{.*}} = "stream.generic"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{"library_call" = "snax_gemmx"}> ({
+// CHECK-NEXT:    %{{.*}} = "stream.generic"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{library_call = "snax_gemmx"}> ({
 // CHECK-NEXT:    ^1(%{{.*}} : i8, %{{.*}} : i8, %{{.*}} : i32, %{{.*}} : i32, %{{.*}} : i32):
 // CHECK-NEXT:      %{{.*}} = kernel.qmac %{{.*}}, %{{.*}} zp_lhs : %{{.*}} zp_rhs : %{{.*}} : i8, i8, i32, i32 -> i32
 // CHECK-NEXT:      stream.yield %{{.*}} : i32

--- a/tests/filecheck/transforms/convert-stream-to-snax-stream.mlir
+++ b/tests/filecheck/transforms/convert-stream-to-snax-stream.mlir
@@ -42,12 +42,12 @@ func.func @streamer_matmul(%arg0 : memref<16x16xi8>, %arg1 : memref<16x16xi8, st
   func.return
 }
 
-// CHECK:       "snax_stream.streaming_region"(%1, %2, %3, %4, %5) <{stride_patterns = [#snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 0, 128], ss = [8]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 128, 0], ss = [8]>, #snax_stream.stride_pattern<ub = [0, 0, 0], ts = [0, 0, 0], ss = [0]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 0, 0], ss = [8, 64]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 32, 512], ss = [8, 64]>], accelerator = "snax_gemmx", operandSegmentSizes = array<i32: 4, 1>}> ({
-// CHECK-NEXT:  ^0(%6 : !stream.stream<i8>, %7 : !stream.stream<i8>, %8 : !stream.stream<i32>):
-// CHECK-NEXT:    %9 = "stream.generic"(%6, %7, %0, %0) <{library_call = "snax_gemmx"}> ({
-// CHECK-NEXT:    ^1(%arg3 : i8, %arg4 : i8, %arg5 : i32, %arg6 : i32, %arg7 : i32):
-// CHECK-NEXT:      %10 = kernel.qmac %arg3, %arg4 zp_lhs : %arg5 zp_rhs : %arg6 : i8, i8, i32, i32 -> i32
-// CHECK-NEXT:      stream.yield %10 : i32
+// CHECK:       "snax_stream.streaming_region"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{"stride_patterns" = [#snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 0, 128], ss = [8]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 128, 0], ss = [8]>, #snax_stream.stride_pattern<ub = [0, 0, 0], ts = [0, 0, 0], ss = [0]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 0, 0], ss = [8, 64]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 32, 512], ss = [8, 64]>], "accelerator" = "snax_gemmx", "operandSegmentSizes" = array<i32: 4, 1>}> ({
+// CHECK-NEXT:  ^0(%{{.*}} : !stream.stream<i8>, %{{.*}} : !stream.stream<i8>, %{{.*}} : !stream.stream<i32>):
+// CHECK-NEXT:    %{{.*}} = "stream.generic"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{"library_call" = "snax_gemmx"}> ({
+// CHECK-NEXT:    ^1(%{{.*}} : i8, %{{.*}} : i8, %{{.*}} : i32, %{{.*}} : i32, %{{.*}} : i32):
+// CHECK-NEXT:      %{{.*}} = kernel.qmac %{{.*}}, %{{.*}} zp_lhs : %{{.*}} zp_rhs : %{{.*}} : i8, i8, i32, i32 -> i32
+// CHECK-NEXT:      stream.yield %{{.*}} : i32
 // CHECK-NEXT:    }) : (!stream.stream<i8>, !stream.stream<i8>, i32, i32) -> !stream.stream<i32>
-// CHECK-NEXT:    stream.yield %9 : !stream.stream<i32>
+// CHECK-NEXT:    stream.yield %{{.*}} : !stream.stream<i32>
 // CHECK-NEXT:  }) : (index, index, index, index, index) -> ()

--- a/tests/filecheck/transforms/convert-stream-to-snax-stream.mlir
+++ b/tests/filecheck/transforms/convert-stream-to-snax-stream.mlir
@@ -42,7 +42,7 @@ func.func @streamer_matmul(%arg0 : memref<16x16xi8>, %arg1 : memref<16x16xi8, st
   func.return
 }
 
-// CHECK:       "snax_stream.streaming_region"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{"stride_patterns" = [#snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 0, 128], ss = [8]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 128, 0], ss = [8]>, #snax_stream.stride_pattern<ub = [0, 0, 0], ts = [0, 0, 0], ss = [0]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 0, 0], ss = [8, 64]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 32, 512], ss = [8, 64]>], accelerator = "snax_gemmx", operandSegmentSizes = array<i32: 4, 1>}> ({
+// CHECK:       "snax_stream.streaming_region"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{stride_patterns = [#snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 0, 128], ss = [8]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 128, 0], ss = [8]>, #snax_stream.stride_pattern<ub = [0, 0, 0], ts = [0, 0, 0], ss = [0]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 0, 0], ss = [8, 64]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 32, 512], ss = [8, 64]>], accelerator = "snax_gemmx", operandSegmentSizes = array<i32: 4, 1>}> ({
 // CHECK-NEXT:  ^0(%{{.*}} : !stream.stream<i8>, %{{.*}} : !stream.stream<i8>, %{{.*}} : !stream.stream<i32>):
 // CHECK-NEXT:    %{{.*}} = "stream.generic"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{library_call = "snax_gemmx"}> ({
 // CHECK-NEXT:    ^1(%{{.*}} : i8, %{{.*}} : i8, %{{.*}} : i32, %{{.*}} : i32, %{{.*}} : i32):


### PR DESCRIPTION
situation before this pr:
```
stream.streaming_region
 --> autoflow-scheduler-pattern
stream.schedule_op
 --> layout_resolution-pattern
snax_stream.streaming_region
```

The layout resolution includes a lot of gemmx specific hacks entagled between the logic of layout resolution, which is not nice. To keep everything clear this should be separated somewhat. This also makes it fit the mathematical model behind the passes more cleanly.

Therefore this pr splits it up into:

```
stream.streaming_region
 --> autoflow-scheduler-pattern
stream.schedule_op
 --> layout_resolution-pattern
stream.access_pattern_op
 --> convert_stream_to_snax_stream-pattern
snax_stream.streaming_region
```

This PR doesn't change any logic, just separates it into two.
 