### PR TITLE
add python frontend

### DIFF
--- a/kernels/streamer_matmul/quantized_matmul.py
+++ b/kernels/streamer_matmul/quantized_matmul.py
@@ -17,7 +17,7 @@ from xdsl.dialects.tensor import EmptyOp
 from xdsl.printer import Printer
 
 
-def matmul(m=16, n=16, k=16):
+def get_module_op(m=16, n=16, k=16):
     # Define Variables For Program:
 
     a_type = TensorType(i8, (m, k))
@@ -73,6 +73,6 @@ if __name__ == "__main__":
     # Generate IR and write it to the specified MLIR file
     output = StringIO()
     printer = Printer(stream=output)
-    printer.print(matmul())
+    printer.print(get_module_op())
     with open(mlir_filename, "w") as output_file:
         output_file.write(output.getvalue())

--- a/kernels/streamer_matmul/tiled_quantized_matmul.py
+++ b/kernels/streamer_matmul/tiled_quantized_matmul.py
@@ -20,7 +20,7 @@ from xdsl.parser import DenseArrayBase, IntegerType
 from xdsl.printer import Printer
 
 
-def matmul(m=16, n=16, k=16):
+def get_module_op(m=16, n=16, k=16):
     # Define Variables For Program:
 
     a_type = TensorType(i8, (m, k))
@@ -100,6 +100,6 @@ if __name__ == "__main__":
     # Generate IR and write it to the specified MLIR file
     output = StringIO()
     printer = Printer(stream=output)
-    printer.print(matmul())
+    printer.print(get_module_op())
     with open(mlir_filename, "w") as output_file:
         output_file.write(output.getvalue())


### PR DESCRIPTION
this allows for `snax-opt matmul.py` instead of `python matmul.py` outputing the mlir file and then running `snax-opt matmul.mlir`