### PR TITLE
split up dart transformations

### DIFF
--- a/benchmarks/dense_matmul/Makefile
+++ b/benchmarks/dense_matmul/Makefile
@@ -20,7 +20,7 @@ else
 REMOVE_MEMREF_COPY=
 endif
 
-SNAXOPTFLAGS = -p convert-linalg-to-kernel,insert-accfg-op{accelerator=snax_gemmx},dispatch-kernels,convert-linalg-to-dart,dart-fuse-operations,snax-bufferize,alloc-to-global,set-memory-space,set-memory-layout{gemm_layout=${LAYOUT}},realize-memref-casts,${REMOVE_MEMREF_COPY}insert-sync-barrier,dispatch-regions{nb_cores=2},convert-dart-to-snax-stream,convert-linalg-to-accfg,test-add-mcycle-around-launch,convert-accfg-to-csr,snax-copy-to-dma,memref-to-snax,snax-to-func,snax-lower-mcycle,clear-memory-space
+SNAXOPTFLAGS = -p convert-linalg-to-kernel,insert-accfg-op{accelerator=snax_gemmx},dispatch-kernels,convert-linalg-to-dart,dart-fuse-operations,snax-bufferize,alloc-to-global,set-memory-space,set-memory-layout{gemm_layout=${LAYOUT}},realize-memref-casts,${REMOVE_MEMREF_COPY}insert-sync-barrier,dispatch-regions{nb_cores=2},dart-scheduler,dart-layout-resolution,convert-dart-to-snax-stream,convert-linalg-to-accfg,test-add-mcycle-around-launch,convert-accfg-to-csr,snax-copy-to-dma,memref-to-snax,snax-to-func,snax-lower-mcycle,clear-memory-space
 
 GEN_DATA_OPTS += --m=${SIZE_M}
 GEN_DATA_OPTS += --n=${SIZE_N}

--- a/compiler/tools/snax_opt_main.py
+++ b/compiler/tools/snax_opt_main.py
@@ -28,6 +28,8 @@ from compiler.transforms.convert_linalg_to_kernel import ConvertLinalgToKernel
 from compiler.transforms.convert_tosa_to_kernel import ConvertTosaToKernelPass
 from compiler.transforms.dart.convert_linalg_to_dart import ConvertLinalgToDart
 from compiler.transforms.dart.dart_fuse_operations import DartFuseOperationsPass
+from compiler.transforms.dart.dart_layout_resolution import DartLayoutResolutionPass
+from compiler.transforms.dart.dart_scheduler import DartSchedulerPass
 from compiler.transforms.dispatch_kernels import DispatchKernels
 from compiler.transforms.dispatch_regions import DispatchRegions
 from compiler.transforms.frontend.preprocess_mlir import PreprocessPass
@@ -128,6 +130,10 @@ class SNAXOptMain(xDSLOptMain):
         super().register_pass(AllocToGlobalPass.name, lambda: AllocToGlobalPass)
         super().register_pass(PreprocessPass.name, lambda: PreprocessPass)
         super().register_pass(PostprocessPass.name, lambda: PostprocessPass)
+        super().register_pass(DartSchedulerPass.name, lambda: DartSchedulerPass)
+        super().register_pass(
+            DartLayoutResolutionPass.name, lambda: DartLayoutResolutionPass
+        )
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)

--- a/compiler/transforms/dart/dart_layout_resolution.py
+++ b/compiler/transforms/dart/dart_layout_resolution.py
@@ -98,7 +98,7 @@ class LayoutResolution(RewritePattern):
 
 
 @dataclass(frozen=True)
-class DartLayoutResolution(ModulePass):
+class DartLayoutResolutionPass(ModulePass):
     name = "dart-layout-resolution"
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:

--- a/compiler/transforms/dart/dart_layout_resolution.py
+++ b/compiler/transforms/dart/dart_layout_resolution.py
@@ -1,0 +1,105 @@
+from dataclasses import dataclass
+
+import numpy as np
+from xdsl.context import MLContext
+from xdsl.dialects import builtin, memref
+from xdsl.dialects.builtin import AffineMapAttr, ArrayAttr, MemRefType
+from xdsl.ir import Operation
+from xdsl.ir.affine import AffineMap
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+from compiler.dialects import dart
+from compiler.ir.dart.access_pattern import Schedule, SchedulePattern
+from compiler.ir.dart.affine_transform import AffineTransform
+
+
+@dataclass
+class LayoutResolution(RewritePattern):
+    """
+    Applies layout resolution by converting a ScheduleOp (mapping the iteration
+    space to the operand index space) into an AccessOp (mapping the iteration space
+    to memory), using a certain memory layout of the memref operands of the operation.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: dart.ScheduleOp, rewriter: PatternRewriter):
+        bounds = [x.value.data for x in op.bounds.data]
+        schedule = Schedule(
+            SchedulePattern(bounds, pattern.data) for pattern in op.patterns
+        )
+
+        # small function to generate a list of n zeros with the i-th element 1
+        # for example n = 4, i = 1  -> [0, 1, 0, 0]
+        def generate_one_list(n: int, i: int):
+            return [1 if j == i else 0 for j in range(n)]
+
+        access_patterns: list[AffineMap] = []
+
+        # Do this for every operand:
+        for operand in range(len(op.operands)):
+            # Mapping from data to memory:
+            assert isinstance(memref_type := op.operands[operand].type, MemRefType)
+
+            # Mapping from data to memory:
+            data_mem_map: AffineMap = memref_type.get_affine_map_in_bytes()
+
+            # Mapping from access to data:
+            access_data_map: AffineMap = schedule[operand].pattern.to_affine_map()
+
+            # Mapping from access to memory:
+            access_mem_map: AffineMap = data_mem_map.compose(access_data_map)
+
+            # Make sure no symbols are used (not supported yet)
+            if access_mem_map.num_symbols != 0:
+                raise RuntimeError(
+                    "Access patterns with symbols are not supported yet."
+                )
+
+            strides: list[int] = []
+
+            for i in range(access_mem_map.num_dims):
+                strides.append(
+                    access_mem_map.eval(
+                        generate_one_list(access_mem_map.num_dims, i), ()
+                    )[0]
+                )
+
+            access_patterns.append(
+                AffineTransform(np.array([strides]), np.array([0])).to_affine_map()
+            )
+
+        new_inputs: list[Operation] = [
+            memref.ExtractAlignedPointerAsIndexOp.get(input) for input in op.inputs
+        ]
+        new_outputs = [
+            memref.ExtractAlignedPointerAsIndexOp.get(output) for output in op.outputs
+        ]
+
+        new_patterns = ArrayAttr([AffineMapAttr(map) for map in access_patterns])
+
+        access_pattern_op = dart.AccessPatternOp(
+            new_inputs,
+            new_outputs,
+            new_patterns,
+            rewriter.move_region_contents_to_new_regions(op.body),
+            op.bounds,
+            op.accelerator,
+            op.result_types,
+        )
+        rewriter.replace_matched_op(
+            [*new_inputs, *new_outputs, access_pattern_op], access_pattern_op.results
+        )
+
+
+@dataclass(frozen=True)
+class DartLayoutResolution(ModulePass):
+    name = "dart-layout-resolution"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(LayoutResolution()).rewrite_module(op)

--- a/compiler/transforms/dart/dart_scheduler.py
+++ b/compiler/transforms/dart/dart_scheduler.py
@@ -1,0 +1,85 @@
+from dataclasses import dataclass
+
+from xdsl.context import MLContext
+from xdsl.dialects import builtin
+from xdsl.dialects.builtin import AffineMapAttr, ArrayAttr
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+from compiler.accelerators.registry import AcceleratorRegistry
+from compiler.accelerators.snax import SNAXStreamer
+from compiler.accelerators.util import find_accelerator_op
+from compiler.dialects import dart
+from compiler.ir.dart.access_pattern import Schedule, SchedulePattern, Template
+from compiler.ir.dart.scheduler import scheduler
+
+
+def get_accelerator_info(op: dart.StreamingRegionOpBase) -> Template:
+    assert op.accelerator is not None
+
+    # Go and fetch the accelerator op
+    accelerator_str = op.accelerator.data
+    acc_op = find_accelerator_op(op, accelerator_str)
+
+    if not acc_op:
+        raise RuntimeError("AcceleratorOp not found!")
+
+    # get template and template_bounds
+    accelerator_type = AcceleratorRegistry().get_acc_info(acc_op)
+    assert issubclass(accelerator_type, SNAXStreamer)
+
+    template = accelerator_type.get_template(op)
+
+    return template
+
+
+@dataclass
+class AutoflowScheduler(RewritePattern):
+    """
+    A pass to convert streaming region operations to schedules.
+
+    Here, the operation is scheduled to an accelerator according to the accelerator template.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: dart.OperationOp, rewriter: PatternRewriter):
+        template = get_accelerator_info(op)
+
+        # Make sure the operands are memrefs
+        for memref_operand in op.operands:
+            if not isinstance(memref_operand.type, builtin.MemRefType):
+                return
+
+        # First, run the stream scheduling algorithm
+        schedule_bounds = tuple(op.get_static_pattern_bounds())
+        schedule = Schedule(
+            SchedulePattern(schedule_bounds, pattern.data)
+            for pattern in op.patterns.data
+        )
+        schedule = scheduler(template, schedule)
+
+        schedule_op = dart.ScheduleOp(
+            op.inputs,
+            op.outputs,
+            ArrayAttr([AffineMapAttr(s.pattern.to_affine_map()) for s in schedule]),
+            rewriter.move_region_contents_to_new_regions(op.body),
+            schedule[0].bounds,
+            [[]],
+            op.accelerator,
+            op.result_types,
+        )
+
+        rewriter.replace_matched_op(schedule_op)
+
+
+@dataclass(frozen=True)
+class DartSchedulerPass(ModulePass):
+    name = "dart-scheduler"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(AutoflowScheduler()).rewrite_module(op)

--- a/compiler/transforms/dart/dart_scheduler.py
+++ b/compiler/transforms/dart/dart_scheduler.py
@@ -13,29 +13,9 @@ from xdsl.pattern_rewriter import (
 
 from compiler.accelerators.registry import AcceleratorRegistry
 from compiler.accelerators.snax import SNAXStreamer
-from compiler.accelerators.util import find_accelerator_op
 from compiler.dialects import dart
-from compiler.ir.dart.access_pattern import Schedule, SchedulePattern, Template
+from compiler.ir.dart.access_pattern import Schedule, SchedulePattern
 from compiler.ir.dart.scheduler import scheduler
-
-
-def get_accelerator_info(op: dart.StreamingRegionOpBase) -> Template:
-    assert op.accelerator is not None
-
-    # Go and fetch the accelerator op
-    accelerator_str = op.accelerator.data
-    acc_op = find_accelerator_op(op, accelerator_str)
-
-    if not acc_op:
-        raise RuntimeError("AcceleratorOp not found!")
-
-    # get template and template_bounds
-    accelerator_type = AcceleratorRegistry().get_acc_info(acc_op)
-    assert issubclass(accelerator_type, SNAXStreamer)
-
-    template = accelerator_type.get_template(op)
-
-    return template
 
 
 @dataclass
@@ -48,7 +28,10 @@ class AutoflowScheduler(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: dart.OperationOp, rewriter: PatternRewriter):
-        template = get_accelerator_info(op)
+        assert op.accelerator
+        accelerator_type = AcceleratorRegistry().get_acc_info(op.accelerator.data)
+        assert issubclass(accelerator_type, SNAXStreamer)
+        template = accelerator_type.get_template(op)
 
         # Make sure the operands are memrefs
         for memref_operand in op.operands:

--- a/kernels/gemm/Snakefile
+++ b/kernels/gemm/Snakefile
@@ -17,6 +17,8 @@ config["snaxoptflags"] = ",".join(
         "realize-memref-casts",
         "insert-sync-barrier",
         "dispatch-regions{nb_cores=2}",
+        "dart-scheduler",
+        "dart-layout-resolution",
         "convert-dart-to-snax-stream",
         "convert-linalg-to-accfg",
         "convert-accfg-to-csr",

--- a/kernels/rescale/Snakefile
+++ b/kernels/rescale/Snakefile
@@ -11,6 +11,8 @@ config["snaxoptflags"] = ",".join(
         "realize-memref-casts",
         "insert-sync-barrier",
         "dispatch-regions{nb_cores=2}",
+        "dart-scheduler",
+        "dart-layout-resolution",
         "convert-dart-to-snax-stream",
         "convert-linalg-to-accfg",
         "convert-accfg-to-csr",

--- a/kernels/streamer_alu/Snakefile
+++ b/kernels/streamer_alu/Snakefile
@@ -16,6 +16,8 @@ config["snaxoptflags"] = ",".join(
         "insert-sync-barrier",
         "dispatch-regions",
         "convert-linalg-to-dart",
+        "dart-scheduler",
+        "dart-layout-resolution",
         "convert-dart-to-snax-stream",
         "convert-linalg-to-accfg",
         "convert-accfg-to-csr",

--- a/kernels/streamer_matmul/Snakefile
+++ b/kernels/streamer_matmul/Snakefile
@@ -16,6 +16,8 @@ config["snaxoptflags"] = ",".join(
         "realize-memref-casts",
         "insert-sync-barrier",
         "dispatch-regions{nb_cores=2}",
+        "dart-scheduler",
+        "dart-layout-resolution",
         "convert-dart-to-snax-stream",
         "convert-linalg-to-accfg",
         "convert-accfg-to-csr",

--- a/tests/filecheck/transforms/convert-dart-to-snax-stream.mlir
+++ b/tests/filecheck/transforms/convert-dart-to-snax-stream.mlir
@@ -1,4 +1,4 @@
-// RUN: ./compiler/snax-opt --split-input-file %s -p insert-accfg-op{accelerator=snax_alu},insert-accfg-op{accelerator=snax_gemmx},convert-dart-to-snax-stream | filecheck %s
+// RUN: ./compiler/snax-opt --split-input-file %s -p insert-accfg-op{accelerator=snax_alu},insert-accfg-op{accelerator=snax_gemmx},dart-scheduler,dart-layout-resolution,convert-dart-to-snax-stream | filecheck %s
 
 func.func public @streamer_add(%arg0 : memref<16xi64>, %arg1 : memref<16xi64>, %arg2 : memref<16xi64>) {
   "dart.operation"(%arg0, %arg1, %arg2) <{patterns = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], accelerator = "snax_alu", operandSegmentSizes = array<i32: 2, 1>}> ({


### PR DESCRIPTION
This splits the three patterns into separat transformations. This will allow me to:

- Test the intermediate stages more properly
- Put other transforms in between that act on the intermediate representations