### PR TITLE
add access pattern inner_dims method

### DIFF
--- a/compiler/ir/dart/access_pattern.py
+++ b/compiler/ir/dart/access_pattern.py
@@ -42,7 +42,7 @@ class AccessPattern(ABC):
     def num_dims(self):
         return len(self.bounds)
 
-    @deprecated
+    @deprecated("use inner_dims instead")
     def disable_dims(self, dim: int) -> Self:
         """
         Returns an affine map with the leftmost `dim` dimensions set to 0

--- a/compiler/ir/dart/access_pattern.py
+++ b/compiler/ir/dart/access_pattern.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from typing import Generic, cast
 
-from typing_extensions import Self, TypeVar, deprecated, overload
+from typing_extensions import Self, TypeVar, overload
 from xdsl.ir.affine import AffineDimExpr, AffineMap
 
 from compiler.ir.dart.affine_transform import AffineTransform
@@ -42,7 +42,6 @@ class AccessPattern(ABC):
     def num_dims(self):
         return len(self.bounds)
 
-    @deprecated("use inner_dims instead")
     def disable_dims(self, dim: int) -> Self:
         """
         Returns an affine map with the leftmost `dim` dimensions set to 0

--- a/compiler/ir/dart/access_pattern.py
+++ b/compiler/ir/dart/access_pattern.py
@@ -3,8 +3,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from typing import Generic, cast
 
-from numpy import deprecate
-from typing_extensions import Self, TypeVar, overload
+from typing_extensions import Self, TypeVar, deprecated, overload
 from xdsl.ir.affine import AffineDimExpr, AffineMap
 
 from compiler.ir.dart.affine_transform import AffineTransform
@@ -43,7 +42,7 @@ class AccessPattern(ABC):
     def num_dims(self):
         return len(self.bounds)
 
-    @deprecate
+    @deprecated
     def disable_dims(self, dim: int) -> Self:
         """
         Returns an affine map with the leftmost `dim` dimensions set to 0

--- a/compiler/ir/dart/access_pattern.py
+++ b/compiler/ir/dart/access_pattern.py
@@ -68,10 +68,8 @@ class AccessPattern(ABC):
         For `dim` = 1, will return:
             (d2) -> d2
         """
-        if dim == 0:
-            raise ValueError("Cannot return innermost 0 dimensions")
-        if dim > self.num_dims:
-            raise ValueError("Requested more dimensions than there exist")
+        if dim <= 0:
+            raise ValueError("can only select a positive number of dimensions")
         return type(self)(
             self.bounds[-dim:],
             AffineTransform(self.pattern.A[:, -dim:], self.pattern.b),

--- a/compiler/ir/dart/access_pattern.py
+++ b/compiler/ir/dart/access_pattern.py
@@ -251,6 +251,9 @@ class PatternCollection(Sequence[P], Generic[P], ABC):
     def disable_dims(self, dim: int) -> Self:
         return type(self)(sp.disable_dims(dim) for sp in self)
 
+    def inner_dims(self, dim: int) -> Self:
+        return type(self)(sp.inner_dims(dim) for sp in self)
+
     def clear_unused_dims(self, bounds: tuple[int] | None = None) -> Self:
         """
         Returns a PatternCollection of which all dimensions that have bound 1 are cleared.

--- a/tests/ir/dart/test_access_pattern.py
+++ b/tests/ir/dart/test_access_pattern.py
@@ -102,9 +102,12 @@ def test_access_pattern_inner_dims():
     with pytest.raises(ValueError):
         access_pattern.inner_dims(0)
 
-    # request more inner dims than there exist (invalid)
-    with pytest.raises(ValueError):
-        access_pattern.inner_dims(4)
+    # requesting more inner dims than available should
+    # just return the original pattern
+    inner_pattern = access_pattern.inner_dims(4)
+    assert inner_pattern.bounds == bounds
+    assert inner_pattern.pattern == pattern
+    assert isinstance(inner_pattern, AccessPattern)
 
 
 def test_schedule_pattern_creation():

--- a/tests/ir/dart/test_access_pattern.py
+++ b/tests/ir/dart/test_access_pattern.py
@@ -67,6 +67,46 @@ def test_access_pattern_disable_dims():
     assert isinstance(disabled_pattern, AccessPattern)
 
 
+def test_access_pattern_inner_dims():
+    pattern = AffineTransform(
+        np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]), b=np.array([1, 2, 3])
+    )
+    bounds = (10, 20, 30)
+    access_pattern = AccessPattern(bounds, pattern)
+
+    # test 1: keep all dims
+    inner_pattern = access_pattern.inner_dims(3)
+    assert inner_pattern.bounds == bounds
+    assert inner_pattern.pattern == pattern
+    assert isinstance(inner_pattern, AccessPattern)
+
+    # test 2: get 2 dims
+    inner_pattern = access_pattern.inner_dims(2)
+    expected_bounds = (20, 30)
+    expected_results = np.array([[0, 0], [1, 0], [0, 1]])
+    assert inner_pattern.bounds == expected_bounds
+    assert (inner_pattern.pattern.A == expected_results).all()
+    assert (inner_pattern.pattern.b == pattern.b).all()
+    assert isinstance(inner_pattern, AccessPattern)
+
+    # test 3: get 1 dim
+    inner_pattern = access_pattern.inner_dims(1)
+    expected_bounds = (30,)
+    expected_results = np.array([[0], [0], [1]])
+    assert inner_pattern.bounds == expected_bounds
+    assert (inner_pattern.pattern.A == expected_results).all()
+    assert (inner_pattern.pattern.b == pattern.b).all()
+    assert isinstance(inner_pattern, AccessPattern)
+
+    # request 0 inner dims (invalid)
+    with pytest.raises(ValueError):
+        access_pattern.inner_dims(0)
+
+    # request more inner dims than there exist (invalid)
+    with pytest.raises(ValueError):
+        access_pattern.inner_dims(4)
+
+
 def test_schedule_pattern_creation():
     pattern = AffineTransform(np.array([[1, 0], [0, 1]]), np.array([0, 0]))
     bounds = (15, 25)


### PR DESCRIPTION
This is meant to replace `disable_dims`, as it is much more intuitive and easier to use. The algorithms are still processing this change, so `disable_dims` is just deprecated for now.