### PR TITLE
template matching: only look at the inner dims of the schedule

### DIFF
--- a/compiler/ir/dart/access_pattern.py
+++ b/compiler/ir/dart/access_pattern.py
@@ -198,7 +198,7 @@ class TemplatePattern(AccessPattern):
         """
         if sp.num_dims > self.num_dims:
             sp = sp.inner_dims(self.num_dims)
-        if sp.num_dims != self.num_dims:
+        elif sp.num_dims < self.num_dims:
             return False
         if sp.pattern != self.pattern:
             return False

--- a/compiler/ir/dart/access_pattern.py
+++ b/compiler/ir/dart/access_pattern.py
@@ -196,6 +196,8 @@ class TemplatePattern(AccessPattern):
         Check if a given schedule pattern matches this
         template pattern.
         """
+        if sp.num_dims > self.num_dims:
+            sp = sp.inner_dims(self.num_dims)
         if sp.num_dims != self.num_dims:
             return False
         if sp.pattern != self.pattern:

--- a/tests/ir/dart/test_access_pattern.py
+++ b/tests/ir/dart/test_access_pattern.py
@@ -240,7 +240,7 @@ def test_template_pattern_matches():
     )
     assert tp.matches(sp_non_matching_pattern) is False
 
-    # check pattern with wrong bounds (should be irellevant for template check)
+    # check pattern with wrong bounds (should be irrelevant for template check)
     sp_non_matching_bounds = SchedulePattern((5, 15), pattern)
     assert tp.matches(sp_non_matching_bounds)
 

--- a/tests/ir/dart/test_access_pattern.py
+++ b/tests/ir/dart/test_access_pattern.py
@@ -226,20 +226,34 @@ def test_template_pattern_matches():
     )
     bounds = (10, 20)
     tp = TemplatePattern(bounds, pattern)
+
+    # test matching pattern
     sp_matching = SchedulePattern(bounds, pattern)
+    assert tp.matches(sp_matching)
+
+    # test non matching pattern
     sp_non_matching_pattern = SchedulePattern(
         bounds,
         AffineMap(
             num_dims=2, num_symbols=0, results=(AffineDimExpr(1), AffineDimExpr(0))
         ),
     )
-    sp_non_matching_bounds = SchedulePattern((5, 15), pattern)
-
-    assert tp.matches(sp_matching) is True
     assert tp.matches(sp_non_matching_pattern) is False
-    assert (
-        tp.matches(sp_non_matching_bounds) is True
-    )  # Bounds are not checked in matches
+
+    # check pattern with wrong bounds (should be irellevant for template check)
+    sp_non_matching_bounds = SchedulePattern((5, 15), pattern)
+    assert tp.matches(sp_non_matching_bounds)
+
+    # if the schedule has higher dimensionality than the template, only the innermost
+    # are considered
+    larger_pattern = AffineMap(
+        num_dims=3,
+        num_symbols=0,
+        results=(AffineDimExpr(1) + AffineDimExpr(0), AffineDimExpr(2)),
+    )
+    larger_bounds = (44, 10, 20)
+    sp_matching_larger = SchedulePattern(larger_bounds, larger_pattern)
+    assert tp.matches(sp_matching_larger)
 
 
 def test_schedule_rotate():


### PR DESCRIPTION
stacked on #349 

with this PR, when doing a template check with a template and a schedule, previously they are forced to the same number of dims. This PR checks if the schedule has larger dimensionality than the template, and reduces it to the number of dims of the template in this case.