### PR TITLE
fix some dispatch_regions bugs

### DIFF
--- a/compiler/transforms/dispatch_regions.py
+++ b/compiler/transforms/dispatch_regions.py
@@ -64,7 +64,7 @@ class DispatchRegionsRewriter(RewritePattern):
 
                 # add op to the dispatch list if it must be dispatched
                 if dispatch_rule(op):
-                    ops_to_dispatch = [op]
+                    ops_to_dispatch.append(op)
 
             return changes_made
 

--- a/tests/filecheck/transforms/dispatch_regions.mlir
+++ b/tests/filecheck/transforms/dispatch_regions.mlir
@@ -1,5 +1,5 @@
-// RUN: ./compiler/snax-opt --split-input-file %s -p dispatch-regions --print-op-generic | filecheck %s --check-prefixes=CHECK,NB_TWO
-// RUN: ./compiler/snax-opt --split-input-file %s -p dispatch-regions{nb_cores=3} --print-op-generic | filecheck %s --check-prefixes=CHECK,NB_THREE
+// RUN: ./compiler/snax-opt --split-input-file %s -p dispatch-regions | filecheck %s --check-prefixes=CHECK,NB_TWO
+// RUN: ./compiler/snax-opt --split-input-file %s -p dispatch-regions{nb_cores=3} | filecheck %s --check-prefixes=CHECK,NB_THREE
 
 // test function without dispatchable ops
 "builtin.module"() ({
@@ -9,12 +9,12 @@
   }) : () -> ()
 }) : () -> ()
 
-//CHECK: "builtin.module"() ({
-//CHECK-NEXT:   "func.func"() <{sym_name = "simple_mult", function_type = (memref<64xi32>, memref<64xi32>, memref<64xi32>) -> (), sym_visibility = "public"}> ({
-//CHECK-NEXT:   ^0(%arg0 : memref<64xi32>, %arg1 : memref<64xi32>, %arg2 : memref<64xi32>):
-//CHECK-NEXT:     "func.return"() : () -> ()
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT: }) : () -> ()
+// CHECK-NEXT: builtin.module {
+// CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<64xi32>, %arg1 : memref<64xi32>, %arg2 : memref<64xi32>) {
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
 // -----
 // test function with dispatchable op to compute core
 "builtin.module"() ({
@@ -29,28 +29,26 @@
   }) : () -> ()
 }) : () -> ()
 
-//CHECK: "builtin.module"() ({
-//CHECK-NEXT:   "func.func"() <{sym_name = "simple_mult", function_type = (memref<64xi32>, memref<64xi32>, memref<64xi32>) -> (), sym_visibility = "public"}> ({
-//CHECK-NEXT:   ^0(%0 : memref<64xi32>, %1 : memref<64xi32>, %2 : memref<64xi32>):
-//NB_TWO-NEXT:      %3 = "func.call"() <{callee = @snax_cluster_core_idx}> {pin_to_constants = [0 : i32, 1 : i32]} : () -> i32
-//NB_THREE-NEXT:      %3 = "func.call"() <{callee = @snax_cluster_core_idx}> {pin_to_constants = [0 : i32, 1 : i32, 2 : i32]} : () -> i32
-//CHECK-NEXT:     %4 = "arith.constant"() <{value = 0 : i32}> : () -> i32
-//CHECK-NEXT:     %5 = "arith.cmpi"(%3, %4) <{predicate = 0 : i64}> : (i32, i32) -> i1
-//CHECK-NEXT:     "scf.if"(%5) ({
-//CHECK-NEXT:       "linalg.generic"(%0, %1, %2) <{indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = [#linalg.iterator_type<parallel>], operandSegmentSizes = array<i32: 2, 1>}> ({
-//CHECK-NEXT:       ^1(%arg0 : i32, %arg1 : i32, %arg2 : i32):
-//CHECK-NEXT:         %6 = "arith.muli"(%arg0, %arg1) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
-//CHECK-NEXT:         "linalg.yield"(%6) : (i32) -> ()
-//CHECK-NEXT:       }) : (memref<64xi32>, memref<64xi32>, memref<64xi32>) -> ()
-//CHECK-NEXT:       "scf.yield"() : () -> ()
-//CHECK-NEXT:     }, {
-//CHECK-NEXT:     }) : (i1) -> ()
-//CHECK-NEXT:     "func.return"() : () -> ()
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT:   "func.func"() <{sym_name = "snax_cluster_core_idx", function_type = () -> i32, sym_visibility = "private"}> ({
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT: }) : () -> ()
+// CHECK: builtin.module {
+// CHECK-NEXT:   func.func public @simple_mult(%0 : memref<64xi32>, %1 : memref<64xi32>, %2 : memref<64xi32>) {
+// NB_TWO-NEXT:    %3 = func.call @snax_cluster_core_idx() {pin_to_constants = [0 : i32, 1 : i32]} : () -> i32
+// NB_THREE-NEXT:  %3 = func.call @snax_cluster_core_idx() {pin_to_constants = [0 : i32, 1 : i32, 2 : i32]} : () -> i32
+// CHECK-NEXT:     %4 = arith.constant 0 : i32
+// CHECK-NEXT:     %5 = arith.cmpi eq, %3, %4 : i32
+// CHECK-NEXT:     scf.if %5 {
+// CHECK-NEXT:       linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%0, %1 : memref<64xi32>, memref<64xi32>) outs(%2 : memref<64xi32>) {
+// CHECK-NEXT:       ^0(%arg0 : i32, %arg1 : i32, %arg2 : i32):
+// CHECK-NEXT:         %6 = arith.muli %arg0, %arg1 : i32
+// CHECK-NEXT:         linalg.yield %6 : i32
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @snax_cluster_core_idx() -> i32
+// CHECK-NEXT: }
+
 // -----
+
 // test function with dispatchable op to dm core
 "builtin.module"() ({
   "func.func"() <{sym_name = "simple_mult", "function_type" = (memref<64xi32>, memref<64xi32>) -> (), "sym_visibility" = "public"}> ({
@@ -59,25 +57,24 @@
     "func.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()
-//CHECK: "builtin.module"() ({
-//CHECK-NEXT:   "func.func"() <{sym_name = "simple_mult", function_type = (memref<64xi32>, memref<64xi32>) -> (), sym_visibility = "public"}> ({
-//CHECK-NEXT:   ^0(%0 : memref<64xi32>, %1 : memref<64xi32>):
-//NB_TWO-NEXT:     %2 = "func.call"() <{callee = @snax_cluster_core_idx}> {pin_to_constants = [0 : i32, 1 : i32]} : () -> i32
-//NB_TWO-NEXT:     %3 = "arith.constant"() <{value = 1 : i32}> : () -> i32
-//NB_THREE-NEXT:     %2 = "func.call"() <{callee = @snax_cluster_core_idx}> {pin_to_constants = [0 : i32, 1 : i32, 2 : i32]} : () -> i32
-//NB_THREE-NEXT:     %3 = "arith.constant"() <{value = 2 : i32}> : () -> i32
-//CHECK-NEXT:     %4 = "arith.cmpi"(%2, %3) <{predicate = 0 : i64}> : (i32, i32) -> i1
-//CHECK-NEXT:     "scf.if"(%4) ({
-//CHECK-NEXT:       "memref.copy"(%0, %1) : (memref<64xi32>, memref<64xi32>) -> ()
-//CHECK-NEXT:       "scf.yield"() : () -> ()
-//CHECK-NEXT:     }, {
-//CHECK-NEXT:     }) : (i1) -> ()
-//CHECK-NEXT:     "func.return"() : () -> ()
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT:   "func.func"() <{sym_name = "snax_cluster_core_idx", function_type = () -> i32, sym_visibility = "private"}> ({
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT: }) : () -> ()
+
+// CHECK: builtin.module {
+// CHECK-NEXT:   func.func public @simple_mult(%0 : memref<64xi32>, %1 : memref<64xi32>) {
+// NB_TWO-NEXT:    %2 = func.call @snax_cluster_core_idx() {pin_to_constants = [0 : i32, 1 : i32]} : () -> i32
+// NB_TWO-NEXT:    %3 = arith.constant 1 : i32
+// NB_THREE-NEXT:  %2 = func.call @snax_cluster_core_idx() {pin_to_constants = [0 : i32, 1 : i32, 2 : i32]} : () -> i32
+// NB_THREE-NEXT:  %3 = arith.constant 2 : i32
+// CHECK-NEXT:     %4 = arith.cmpi eq, %2, %3 : i32
+// CHECK-NEXT:     scf.if %4 {
+// CHECK-NEXT:       "memref.copy"(%0, %1) : (memref<64xi32>, memref<64xi32>) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @snax_cluster_core_idx() -> i32
+// CHECK-NEXT: }
+
 // -----
+
 // test function with dispatchable ops to both cores
 "builtin.module"() ({
   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32>, memref<64xi32>, memref<64xi32>) -> (), "sym_visibility" = "public"}> ({
@@ -93,38 +90,33 @@
     "func.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()
-//CHECK: "builtin.module"() ({
-//CHECK-NEXT:   "func.func"() <{sym_name = "simple_mult", function_type = (memref<64xi32>, memref<64xi32>, memref<64xi32>) -> (), sym_visibility = "public"}> ({
-//CHECK-NEXT:   ^0(%0 : memref<64xi32>, %1 : memref<64xi32>, %2 : memref<64xi32>):
-//NB_TWO-NEXT:     %3 = "func.call"() <{callee = @snax_cluster_core_idx}> {pin_to_constants = [0 : i32, 1 : i32]} : () -> i32
-//NB_THREE-NEXT:     %3 = "func.call"() <{callee = @snax_cluster_core_idx}> {pin_to_constants = [0 : i32, 1 : i32, 2 : i32]} : () -> i32
-//CHECK-NEXT:     %4 = "arith.constant"() <{value = 0 : i32}> : () -> i32
-//CHECK-NEXT:     %5 = "arith.cmpi"(%3, %4) <{predicate = 0 : i64}> : (i32, i32) -> i1
-//NB_TWO-NEXT:     %6 = "arith.constant"() <{value = 1 : i32}> : () -> i32
-//NB_THREE-NEXT:     %6 = "arith.constant"() <{value = 2 : i32}> : () -> i32
-//CHECK-NEXT:     %7 = "arith.cmpi"(%3, %6) <{predicate = 0 : i64}> : (i32, i32) -> i1
-//CHECK-NEXT:     %alloc = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> {alignment = 64 : i64} : () -> memref<64xi32>
-//CHECK-NEXT:     "scf.if"(%7) ({
-//CHECK-NEXT:       "memref.copy"(%0, %1) : (memref<64xi32>, memref<64xi32>) -> ()
-//CHECK-NEXT:       "scf.yield"() : () -> ()
-//CHECK-NEXT:     }, {
-//CHECK-NEXT:     }) : (i1) -> ()
-//CHECK-NEXT:     "snax.cluster_sync_op"() : () -> ()
-//CHECK-NEXT:     "scf.if"(%5) ({
-//CHECK-NEXT:       "linalg.generic"(%0, %1, %2) <{indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = [#linalg.iterator_type<parallel>], operandSegmentSizes = array<i32: 2, 1>}> ({
-//CHECK-NEXT:       ^1(%arg0 : i32, %arg1 : i32, %arg2 : i32):
-//CHECK-NEXT:         %8 = "arith.muli"(%arg0, %arg1) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
-//CHECK-NEXT:         "linalg.yield"(%8) : (i32) -> ()
-//CHECK-NEXT:       }) : (memref<64xi32>, memref<64xi32>, memref<64xi32>) -> ()
-//CHECK-NEXT:       "scf.yield"() : () -> ()
-//CHECK-NEXT:     }, {
-//CHECK-NEXT:     }) : (i1) -> ()
-//CHECK-NEXT:     "func.return"() : () -> ()
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT:   "func.func"() <{sym_name = "snax_cluster_core_idx", function_type = () -> i32, sym_visibility = "private"}> ({
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT: }) : () -> ()
+
+// CHECK: builtin.module {
+// CHECK-NEXT:   func.func public @simple_mult(%0 : memref<64xi32>, %1 : memref<64xi32>, %2 : memref<64xi32>) {
+// CHECK-NEXT:     %3 = func.call @snax_cluster_core_idx() {pin_to_constants = [{{[^\]]*}}]} : () -> i32
+// CHECK-NEXT:     %4 = arith.constant 0 : i32
+// CHECK-NEXT:     %5 = arith.cmpi eq, %3, %4 : i32
+// CHECK-NEXT:     %6 = arith.constant {{\d}} : i32
+// CHECK-NEXT:     %7 = arith.cmpi eq, %3, %6 : i32
+// CHECK-NEXT:     %alloc = memref.alloc() {alignment = 64 : i64} : memref<64xi32>
+// CHECK-NEXT:     scf.if %7 {
+// CHECK-NEXT:       "memref.copy"(%0, %1) : (memref<64xi32>, memref<64xi32>) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:     "snax.cluster_sync_op"() : () -> ()
+// CHECK-NEXT:     scf.if %5 {
+// CHECK-NEXT:       linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%0, %1 : memref<64xi32>, memref<64xi32>) outs(%2 : memref<64xi32>) {
+// CHECK-NEXT:       ^0(%arg0 : i32, %arg1 : i32, %arg2 : i32):
+// CHECK-NEXT:         %8 = arith.muli %arg0, %arg1 : i32
+// CHECK-NEXT:         linalg.yield %8 : i32
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @snax_cluster_core_idx() -> i32
+// CHECK-NEXT: }
+
 // -----
+
 // test dispatchable region in nested if-statements
 "builtin.module"() ({
   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32>, memref<64xi32>, memref<64xi32>) -> (), "sym_visibility" = "public"}> ({
@@ -152,39 +144,94 @@
 }) : () -> ()
 
 
-//CHECK: "builtin.module"() ({
-//CHECK-NEXT:   "func.func"() <{sym_name = "simple_mult", function_type = (memref<64xi32>, memref<64xi32>, memref<64xi32>) -> (), sym_visibility = "public"}> ({
-//CHECK-NEXT:   ^0(%0 : memref<64xi32>, %1 : memref<64xi32>, %2 : memref<64xi32>):
-//NB_TWO-NEXT:     %3 = "func.call"() <{callee = @snax_cluster_core_idx}> {pin_to_constants = [0 : i32, 1 : i32]} : () -> i32
-//NB_THREE-NEXT:     %3 = "func.call"() <{callee = @snax_cluster_core_idx}> {pin_to_constants = [0 : i32, 1 : i32, 2 : i32]} : () -> i32
-//CHECK-NEXT:     %4 = "arith.constant"() <{value = 0 : i32}> : () -> i32
-//CHECK-NEXT:     %5 = "arith.cmpi"(%3, %4) <{predicate = 0 : i64}> : (i32, i32) -> i1
-//CHECK-NEXT:     %6 = "arith.constant"() <{value = true}> : () -> i1
-//CHECK-NEXT:     "scf.if"(%6) ({
-//CHECK-NEXT:       "scf.if"(%6) ({
-//CHECK-NEXT:         "scf.if"(%6) ({
-//CHECK-NEXT:           "scf.if"(%5) ({
-//CHECK-NEXT:             "linalg.generic"(%0, %1, %2) <{indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = [#linalg.iterator_type<parallel>], operandSegmentSizes = array<i32: 2, 1>}> ({
-//CHECK-NEXT:             ^1(%arg0 : i32, %arg1 : i32, %arg2 : i32):
-//CHECK-NEXT:               %7 = "arith.muli"(%arg0, %arg1) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
-//CHECK-NEXT:               "linalg.yield"(%7) : (i32) -> ()
-//CHECK-NEXT:             }) : (memref<64xi32>, memref<64xi32>, memref<64xi32>) -> ()
-//CHECK-NEXT:             "scf.yield"() : () -> ()
-//CHECK-NEXT:           }, {
-//CHECK-NEXT:           }) : (i1) -> ()
-//CHECK-NEXT:           "scf.yield"() : () -> ()
-//CHECK-NEXT:         }, {
-//CHECK-NEXT:         }) : (i1) -> ()
-//CHECK-NEXT:         "scf.yield"() : () -> ()
-//CHECK-NEXT:       }, {
-//CHECK-NEXT:       }) : (i1) -> ()
-//CHECK-NEXT:       "scf.yield"() : () -> ()
-//CHECK-NEXT:     }, {
-//CHECK-NEXT:     }) : (i1) -> ()
-//CHECK-NEXT:     "func.return"() : () -> ()
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT:   "func.func"() <{sym_name = "snax_cluster_core_idx", function_type = () -> i32, sym_visibility = "private"}> ({
-//CHECK-NEXT:   }) : () -> ()
-//CHECK-NEXT: }) : () -> ()
+// CHECK: builtin.module {
+// CHECK-NEXT:   func.func public @simple_mult(%0 : memref<64xi32>, %1 : memref<64xi32>, %2 : memref<64xi32>) {
+// CHECK-NEXT:     %3 = func.call @snax_cluster_core_idx() {pin_to_constants = [{{[^\]]*}}]} : () -> i32
+// CHECK-NEXT:     %4 = arith.constant 0 : i32
+// CHECK-NEXT:     %5 = arith.cmpi eq, %3, %4 : i32
+// CHECK-NEXT:     %6 = arith.constant true
+// CHECK-NEXT:     scf.if %6 {
+// CHECK-NEXT:       scf.if %6 {
+// CHECK-NEXT:         scf.if %6 {
+// CHECK-NEXT:           scf.if %5 {
+// CHECK-NEXT:             linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%0, %1 : memref<64xi32>, memref<64xi32>) outs(%2 : memref<64xi32>) {
+// CHECK-NEXT:             ^0(%arg0 : i32, %arg1 : i32, %arg2 : i32):
+// CHECK-NEXT:               %7 = arith.muli %arg0, %arg1 : i32
+// CHECK-NEXT:               linalg.yield %7 : i32
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @snax_cluster_core_idx() -> i32
+// CHECK-NEXT: }
 
+// -----
 
+func.func public @func() {
+	%0 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
+	%1 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
+	"memref.copy"(%0, %1) : (memref<16x16xi8>, memref<16x16xi8>) -> ()
+	"test.op"() ({
+		"test.op"() : () -> ()
+		"test.termop"() : () -> ()
+	}): () -> () 
+	func.return
+}
+
+// CHECK: builtin.module {
+// CHECK-NEXT:   func.func public @func() {
+// CHECK-NEXT:     %0 = func.call @snax_cluster_core_idx() {pin_to_constants = [{{[^\]]*}}]} : () -> i32
+// CHECK-NEXT:     %1 = arith.constant {{\d}} : i32
+// CHECK-NEXT:     %2 = arith.cmpi eq, %0, %1 : i32
+// CHECK-NEXT:     %3 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
+// CHECK-NEXT:     %4 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
+// CHECK-NEXT:     scf.if %2 {
+// CHECK-NEXT:       "memref.copy"(%3, %4) : (memref<16x16xi8>, memref<16x16xi8>) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:     "test.op"() ({
+// CHECK-NEXT:       "test.op"() : () -> ()
+// CHECK-NEXT:       "test.termop"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @snax_cluster_core_idx() -> i32
+// CHECK-NEXT: }
+
+// -----
+
+func.func public @func() {
+	%0 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
+	%1 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
+	"memref.copy"(%0, %1) : (memref<16x16xi8>, memref<16x16xi8>) -> ()
+	"test.op"() ({
+		"memref.copy"(%0, %1) : (memref<16x16xi8>, memref<16x16xi8>) -> ()
+		"test.op"() : () -> ()
+		"test.termop"() : () -> ()
+	}): () -> () 
+	func.return
+}
+
+// CHECK: builtin.module {
+// CHECK-NEXT:   func.func public @func() {
+// CHECK-NEXT:     %0 = func.call @snax_cluster_core_idx() {pin_to_constants = [{{[^\]]*}}]} : () -> i32
+// CHECK-NEXT:     %1 = arith.constant {{\d}} : i32
+// CHECK-NEXT:     %2 = arith.cmpi eq, %0, %1 : i32
+// CHECK-NEXT:     %3 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
+// CHECK-NEXT:     %4 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
+// CHECK-NEXT:     scf.if %2 {
+// CHECK-NEXT:       "memref.copy"(%3, %4) : (memref<16x16xi8>, memref<16x16xi8>) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:     "test.op"() ({
+// CHECK-NEXT:       scf.if %2 {
+// CHECK-NEXT:         "memref.copy"(%3, %4) : (memref<16x16xi8>, memref<16x16xi8>) -> ()
+// CHECK-NEXT:       }
+// CHECK-NEXT:       "test.op"() : () -> ()
+// CHECK-NEXT:       "test.termop"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @snax_cluster_core_idx() -> i32
+// CHECK-NEXT: }

--- a/tests/filecheck/transforms/dispatch_regions.mlir
+++ b/tests/filecheck/transforms/dispatch_regions.mlir
@@ -75,6 +75,34 @@
 
 // -----
 
+// two copies after each other
+
+func.func public @func() {
+	%0 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
+	"memref.copy"(%0, %0) : (memref<16x16xi8>, memref<16x16xi8>) -> ()
+	"memref.copy"(%0, %0) : (memref<16x16xi8>, memref<16x16xi8>) -> ()
+	"snax.cluster_sync_op"() : () -> ()
+	func.return
+}
+
+// CHECK: 		builtin.module {
+// CHECK-NEXT:   func.func public @func() {
+// CHECK-NEXT:     %0 = func.call @snax_cluster_core_idx() {pin_to_constants =
+// CHECK-NEXT:     %1 = arith.constant
+// CHECK-NEXT:     %2 = arith.cmpi eq, %0, %1 : i32
+// CHECK-NEXT:     %3 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
+// CHECK-NEXT:     scf.if %2 {
+// CHECK-NEXT:       "memref.copy"(%3, %3) : (memref<16x16xi8>, memref<16x16xi8>) -> ()
+// CHECK-NEXT:       "memref.copy"(%3, %3) : (memref<16x16xi8>, memref<16x16xi8>) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:     "snax.cluster_sync_op"() : () -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @snax_cluster_core_idx() -> i32
+// CHECK-NEXT: }
+
+// -----
+
 // test function with dispatchable ops to both cores
 "builtin.module"() ({
   "func.func"() <{"sym_name" = "simple_mult", "function_type" = (memref<64xi32>, memref<64xi32>, memref<64xi32>) -> (), "sym_visibility" = "public"}> ({
@@ -93,10 +121,10 @@
 
 // CHECK: builtin.module {
 // CHECK-NEXT:   func.func public @simple_mult(%0 : memref<64xi32>, %1 : memref<64xi32>, %2 : memref<64xi32>) {
-// CHECK-NEXT:     %3 = func.call @snax_cluster_core_idx() {pin_to_constants = [{{[^\]]*}}]} : () -> i32
+// CHECK-NEXT:     %3 = func.call @snax_cluster_core_idx() {pin_to_constants =
 // CHECK-NEXT:     %4 = arith.constant 0 : i32
 // CHECK-NEXT:     %5 = arith.cmpi eq, %3, %4 : i32
-// CHECK-NEXT:     %6 = arith.constant {{\d}} : i32
+// CHECK-NEXT:     %6 = arith.constant
 // CHECK-NEXT:     %7 = arith.cmpi eq, %3, %6 : i32
 // CHECK-NEXT:     %alloc = memref.alloc() {alignment = 64 : i64} : memref<64xi32>
 // CHECK-NEXT:     scf.if %7 {
@@ -146,7 +174,7 @@
 
 // CHECK: builtin.module {
 // CHECK-NEXT:   func.func public @simple_mult(%0 : memref<64xi32>, %1 : memref<64xi32>, %2 : memref<64xi32>) {
-// CHECK-NEXT:     %3 = func.call @snax_cluster_core_idx() {pin_to_constants = [{{[^\]]*}}]} : () -> i32
+// CHECK-NEXT:     %3 = func.call @snax_cluster_core_idx() {pin_to_constants =
 // CHECK-NEXT:     %4 = arith.constant 0 : i32
 // CHECK-NEXT:     %5 = arith.cmpi eq, %3, %4 : i32
 // CHECK-NEXT:     %6 = arith.constant true
@@ -216,8 +244,8 @@ func.func public @func() {
 
 // CHECK: builtin.module {
 // CHECK-NEXT:   func.func public @func() {
-// CHECK-NEXT:     %0 = func.call @snax_cluster_core_idx() {pin_to_constants = [{{[^\]]*}}]} : () -> i32
-// CHECK-NEXT:     %1 = arith.constant {{\d}} : i32
+// CHECK-NEXT:     %0 = func.call @snax_cluster_core_idx() {pin_to_constants =
+// CHECK-NEXT:     %1 = arith.constant
 // CHECK-NEXT:     %2 = arith.cmpi eq, %0, %1 : i32
 // CHECK-NEXT:     %3 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
 // CHECK-NEXT:     %4 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>


### PR DESCRIPTION
I encountered some bugs with the following two tests relating regions, where a dispatchable op just before another op with a region is moved to that region, instead of before the op

(I also converted the filecheck to not use generic format to make it much more readable in general)

Input:
```
func.func public @func() {
	%0 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
	%1 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
	"memref.copy"(%0, %1) : (memref<16x16xi8>, memref<16x16xi8>) -> ()
	"test.op"() ({
		"test.op"() : () -> ()
		"test.termop"() : () -> ()
	}): () -> () 
	func.return
}
```

Output (before this PR)
```
builtin.module {
  func.func public @func() {
    %0 = func.call @snax_cluster_core_idx() {pin_to_constants = [0 : i32, 1 : i32]} : () -> i32
    %1 = arith.constant 1 : i32
    %2 = arith.cmpi eq, %0, %1 : i32
    %3 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
    %4 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
    "test.op"() ({
      scf.if %2 {
        "memref.copy"(%3, %4) : (memref<16x16xi8>, memref<16x16xi8>) -> ()
      }
      "test.op"() : () -> ()
      "test.termop"() : () -> ()
    }) : () -> ()
    func.return
  }
  func.func private @snax_cluster_core_idx() -> i32
}  
```

Expected output: (new in this PR)
```
builtin.module {
  func.func public @func() {
    %0 = func.call @snax_cluster_core_idx() {pin_to_constants = [0 : i32, 1 : i32]} : () -> i32
    %1 = arith.constant 1 : i32
    %2 = arith.cmpi eq, %0, %1 : i32
    %3 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
    %4 = memref.alloc() {alignment = 64 : i64} : memref<16x16xi8>
    scf.if %2 {
      "memref.copy"(%3, %4) : (memref<16x16xi8>, memref<16x16xi8>) -> ()
    }
    "test.op"() ({
      "test.op"() : () -> ()
      "test.termop"() : () -> ()
    }) : () -> ()
    func.return
  }
  func.func private @snax_cluster_core_idx() -> i32
}
```
