### PR TITLE
Fix MRO for snax-opt methods

### DIFF
--- a/snaxc/tools/snax_opt_main.py
+++ b/snaxc/tools/snax_opt_main.py
@@ -40,18 +40,16 @@ class SNAXOptMain(xDSLOptMain):
 
         self.ctx = MLContext()
         self.register_all_dialects()
-        super().register_all_frontends()
+        self.register_all_frontends()
         self.register_all_passes()
-        super().register_all_targets()
+        self.register_all_targets()
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)
-        super().register_all_arguments(arg_parser)
+        self.register_all_arguments(arg_parser)
         self.args = arg_parser.parse_args(args=args)
-
         self.ctx.allow_unregistered = self.args.allow_unregistered_dialect
-
-        super().setup_pipeline()
+        self.setup_pipeline()
 
 
 def main():


### PR DESCRIPTION
It seems the snax-opt compiler driver unnecessarily uses methods from the parent class to setup itself, which is rather annoying, as I'm trying to reuse this method in naxirzag, but it hardcodes the use of several methods to be used from xdsl directly, which makes that I can not overwrite them without overwriting the actual constructor itself.

This pull request fixes this by just calling those methods on `self`, as these methods are inherited anyway.