### PR TITLE
singular value template matching

### DIFF
--- a/tests/ir/dart/test_access_pattern.py
+++ b/tests/ir/dart/test_access_pattern.py
@@ -194,7 +194,7 @@ def test_template_pattern_matches():
     sp_non_matching_pattern = SchedulePattern(
         bounds,
         AffineMap(
-            num_dims=2, num_symbols=0, results=(AffineDimExpr(1), AffineDimExpr(0))
+            num_dims=2, num_symbols=0, results=(AffineDimExpr(0), AffineDimExpr(0))
         ),
     )
     assert tp.matches(sp_non_matching_pattern) is False
@@ -270,7 +270,7 @@ def test_template_matches_schedule():
     sp3 = SchedulePattern(
         (10, 20),
         AffineMap(
-            num_dims=2, num_symbols=0, results=(AffineDimExpr(1), AffineDimExpr(0))
+            num_dims=2, num_symbols=0, results=(AffineDimExpr(0), AffineDimExpr(0))
         ),
     )
     schedule_non_matching = Schedule([sp1, sp3])

--- a/tests/ir/dart/test_scheduler.py
+++ b/tests/ir/dart/test_scheduler.py
@@ -16,7 +16,7 @@ from snaxc.ir.dart.scheduler import (
 def test_matching_1o():
     # test matching template and schedule for 1 operand
 
-    pattern = AffineMap.from_callable(lambda i, j, k: (i, j, k))
+    pattern = AffineMap.from_callable(lambda i, j, k: (i + j + k,))
     template = Template((TemplatePattern(bounds=(4, 4, 4), pattern=pattern),))
     schedule = Schedule((SchedulePattern(bounds=(4, 4, 4), pattern=pattern),))
 
@@ -28,7 +28,7 @@ def test_matching_1o():
 def test_matching_2o():
     # test matching template and schedule for 2 operands
 
-    pattern = AffineMap.from_callable(lambda i, j, k: (i, j, k))
+    pattern = AffineMap.from_callable(lambda i, j, k: (i + j + k,))
     template = Template((TemplatePattern(bounds=(4, 4, 4), pattern=pattern),) * 2)
     schedule = Schedule((SchedulePattern(bounds=(4, 4, 4), pattern=pattern),) * 2)
 
@@ -127,9 +127,9 @@ def test_tiling_1o2_1d():
         (SchedulePattern(bounds=(2, 2, 2, 2), pattern=pattern_expected),)
     )
 
-    result = scheduler(template, schedule)
+    results = list(scheduler_backtrack(template, schedule, extra_checks=[]))
 
-    assert result == expected
+    assert expected in results
 
 
 def test_tiling_1o_1d2():


### PR DESCRIPTION
This replaces the naive check if a template matches a schedule with a bit more of a robust one.
While this one is pretty slow, it seems to work very reliably.

If we were to replace this with a better check, at least this one can serve as a benchmark for matching schedules.

This is mainly necessary for convs where the index space is 4D (NCHW) but the accelerator only considers 2 dimensional inputs and outputs