### PR TITLE
remove zero bias hack

### DIFF
--- a/kernels/gemm/main.c
+++ b/kernels/gemm/main.c
@@ -54,9 +54,6 @@ int main() {
 
     TwoDMemrefI32_t memrefD;
 
-    // allocate zero row in tcdm
-    snrt_l1alloc(256);
-
     (void)snrt_mcycle();
 
     _mlir_ciface_gemm(&memrefD, &memrefA, &memrefB, &memrefC);

--- a/kernels/streamer_matmul/main.c
+++ b/kernels/streamer_matmul/main.c
@@ -14,9 +14,6 @@ int main() {
   golden = &results[0];
   computed = &results[1];
 
-  // allocate zero row in tcdm
-  snrt_l1alloc(256);
-
   (void)snrt_mcycle();
   snrt_cluster_hw_barrier();
 

--- a/runtime/include/snax_rt.h
+++ b/runtime/include/snax_rt.h
@@ -46,9 +46,6 @@ alloc_result_t *_mlir_ciface_snax_alloc_l1(uint32_t size, uint32_t alignment) {
 
 void _mlir_ciface_snax_clear_l1() {
   snrt_alloc_init();
-  // keep first row of the tcdm free for zero wizardry
-  // this has a similar function to the zero register of risc-v
-  snrt_l1alloc(256);
   // memset all to 0 with DMA
   if (snrt_is_dm_core()) {
     snrt_dma_start_2d((int32_t *)0x10000040, (int32_t *)0x10000000, 0x40, 0x40,

--- a/snaxc/transforms/convert_dart_to_snax_stream.py
+++ b/snaxc/transforms/convert_dart_to_snax_stream.py
@@ -94,26 +94,21 @@ class ConvertStreamToSnaxStreamPattern(RewritePattern):
 
                 # insert empty patterns for D8 and zero pattern for C
                 snax_stride_patterns.insert(2, empty_pattern)
-                new_inputs.append(op.inputs[-1])
+                new_inputs.append(op.outputs[0])
 
-                # insert zero pattern for C, using the same pattern as D32 but pointing to zero
-                # this way, the bias used by the gemm is just a bunch of zeros
+                # insert same pattern for C as for D32
                 snax_stride_patterns.insert(
                     3,
                     snax_stream.StridePattern(
                         upper_bounds=snax_stride_patterns[3].upper_bounds,
-                        temporal_strides=[0]
-                        * len(snax_stride_patterns[3].upper_bounds),
+                        temporal_strides=snax_stride_patterns[3].temporal_strides,
                         spatial_strides=[8],
                     ),
                 )
 
-                # point C to c0
-                ops_to_add.append(
-                    # zero pointer will generate 0 values
-                    ptr := arith.ConstantOp.from_int_and_width(0, builtin.IndexType())
-                )
-                new_inputs.append(ptr.result)
+                # point C to D32
+                new_inputs.append(op.outputs[0])
+
             elif len(snax_stride_patterns) == 4:
                 # gemm
                 #

--- a/tests/filecheck/transforms/convert-dart-to-snax-stream.mlir
+++ b/tests/filecheck/transforms/convert-dart-to-snax-stream.mlir
@@ -42,7 +42,7 @@ func.func @streamer_matmul(%arg0 : memref<16x16xi8>, %arg1 : memref<16x16xi8, st
   func.return
 }
 
-// CHECK:       "snax_stream.streaming_region"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{stride_patterns = [#snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 128, 0], ss = [8]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 0, 128], ss = [8]>, #snax_stream.stride_pattern<ub = [0, 0, 0], ts = [0, 0, 0], ss = [0]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 0, 0], ss = [8, 64]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 512, 32], ss = [8, 64]>], accelerator = "snax_gemmx", operandSegmentSizes = array<i32: 4, 1>}> ({
+// CHECK:       "snax_stream.streaming_region"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{stride_patterns = [#snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 128, 0], ss = [8]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [8, 0, 128], ss = [8]>, #snax_stream.stride_pattern<ub = [0, 0, 0], ts = [0, 0, 0], ss = [0]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 512, 32], ss = [8, 64]>, #snax_stream.stride_pattern<ub = [2, 2, 2], ts = [0, 512, 32], ss = [8, 64]>], accelerator = "snax_gemmx", operandSegmentSizes = array<i32: 4, 1>}> ({
 // CHECK-NEXT:  ^0(%{{.*}} : !dart.stream<i8>, %{{.*}} : !dart.stream<i8>, %{{.*}} : !dart.stream<i32>):
 // CHECK-NEXT:    %{{.*}} = "dart.generic"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{library_call = "snax_gemmx"}> ({
 // CHECK-NEXT:    ^1(%{{.*}} : i8, %{{.*}} : i8, %{{.*}} : i32, %{{.*}} : i32, %{{.*}} : i32):


### PR DESCRIPTION
this removes the hack to load in zeros via the d32 port to disable the bias addition. the hack is causing some issues.

if we want to compute a matmul without starting from the initial values already present in the output memref, we should provide a more explicit solution for this case

in the case of the current kernels, they are functional as tcdm is initialized to zeros anyway