### PR TITLE
set-memory-layout: only tile if it is nicely divisible

### DIFF
--- a/snaxc/transforms/set_memory_layout.py
+++ b/snaxc/transforms/set_memory_layout.py
@@ -99,6 +99,7 @@ class AddCyclicMemoryLayout(RewritePattern):
                 )
 
                 # can we further tile the layout according to the remaining size?
+                # only apply tiling if the entire size is nicely divisible by the tile size for now
                 if self.tiled_layout and size_remaining % schedule_bound == 0:
                     layout_bound = schedule_bound
                 else:

--- a/snaxc/transforms/set_memory_layout.py
+++ b/snaxc/transforms/set_memory_layout.py
@@ -99,7 +99,7 @@ class AddCyclicMemoryLayout(RewritePattern):
                 )
 
                 # can we further tile the layout according to the remaining size?
-                if self.tiled_layout:
+                if self.tiled_layout and size_remaining % schedule_bound == 0:
                     layout_bound = schedule_bound
                 else:
                     layout_bound = size_remaining


### PR DESCRIPTION
otherwise the layout transformations get a bit messed up.
this is probably something we want to support in the future, but don't right now.