### PR TITLE
transform: (dart-scheduler) enable schedule idx in scheduler

### DIFF
--- a/snaxc/ir/dart/scheduler.py
+++ b/snaxc/ir/dart/scheduler.py
@@ -129,7 +129,11 @@ def scheduler(
         # defaulting to pure output stationary schedules for now
         is_pure_output_stationary
     ],
+    schedule_idx: int | None = None,
 ) -> Schedule:
     # for now just return the first result of the backtracking
+    if schedule_idx is not None:
+        all = list(scheduler_backtrack(template, schedule, extra_checks=extra_checks))
+        return all[schedule_idx]
     result = next(scheduler_backtrack(template, schedule, extra_checks=extra_checks))
     return result

--- a/tests/ir/dart/test_scheduler.py
+++ b/tests/ir/dart/test_scheduler.py
@@ -162,6 +162,9 @@ def test_multiple_results():
     result = list(scheduler_backtrack(template, schedule))
     assert len(result) == 6
 
+    # test if the schedule idx returns the correct index
+    assert scheduler(template, schedule, extra_checks=[], schedule_idx=3) == result[3]
+
 
 def test_pure_output_stationary_check():
     template_pattern = AffineMap.from_callable(lambda e: (e, e, e))


### PR DESCRIPTION
for now, the scheduler just returns the first valid schedule.
while the selection of schedule should be a bit smarter, this allows for a selection of a specific index in the list of valid indeces as shortcut or to explore multiple of them