### PR TITLE
transform: (set-memory-layout) only tile layout if all patterns remain affine

### DIFF
--- a/snaxc/transforms/set_memory_layout.py
+++ b/snaxc/transforms/set_memory_layout.py
@@ -99,22 +99,25 @@ class AddCyclicMemoryLayout(RewritePattern):
                 )
 
                 # can we further tile the layout according to the remaining size?
-                # only apply tiling if the entire size is nicely divisible by the tile size for now
                 to_tile = self.tiled_layout
 
-                # only apply tiling if entire size is nicely divisible by the tile size for now (not strictly necessary)
-                if size_remaining % schedule_bound != 0:
-                    to_tile = False
-
-                # only apply tiling if all access patterns remain hyperrectangular
-                # for example if there is one dimensions that accesses with stride=1, bound=3 and another dim with
-                # stride=1, bound=8
-                # we cannot tile for either 8 or 3 because then the other pattern is no longer affine
-                for stride, bound in zip(
-                    schedule.pattern.A[accessed_dim, :], schedule.bounds
-                ):
-                    if stride % schedule_bound != 0 and bound != schedule_bound:
+                if to_tile:
+                    # only apply tiling if entire size is nicely divisible by the tile size for now
+                    # (this isn't strictly necessary but might break some things)
+                    if size_remaining % schedule_bound != 0:
                         to_tile = False
+
+                    # only apply tiling if all access patterns remain hyperrectangular
+                    # for example if there is one dimensions that accesses with stride=1, bound=3 and another dim with
+                    # stride=1, bound=8
+                    # we cannot tile for either 8 or 3 because then the other pattern is no longer affine
+                    else:
+                        for stride, bound in zip(
+                            schedule.pattern.A[accessed_dim, :], schedule.bounds
+                        ):
+                            if stride % schedule_bound != 0 and bound != schedule_bound:
+                                to_tile = False
+
                 if to_tile:
                     layout_bound = schedule_bound
                 else:

--- a/snaxc/transforms/set_memory_layout.py
+++ b/snaxc/transforms/set_memory_layout.py
@@ -100,7 +100,22 @@ class AddCyclicMemoryLayout(RewritePattern):
 
                 # can we further tile the layout according to the remaining size?
                 # only apply tiling if the entire size is nicely divisible by the tile size for now
-                if self.tiled_layout and size_remaining % schedule_bound == 0:
+                to_tile = self.tiled_layout
+
+                # only apply tiling if entire size is nicely divisible by the tile size for now (not strictly necessary)
+                if size_remaining % schedule_bound != 0:
+                    to_tile = False
+
+                # only apply tiling if all access patterns remain hyperrectangular
+                # for example if there is one dimensions that accesses with stride=1, bound=3 and another dim with
+                # stride=1, bound=8
+                # we cannot tile for either 8 or 3 because then the other pattern is no longer affine
+                for stride, bound in zip(
+                    schedule.pattern.A[accessed_dim, :], schedule.bounds
+                ):
+                    if stride % schedule_bound != 0 and bound != schedule_bound:
+                        to_tile = False
+                if to_tile:
                     layout_bound = schedule_bound
                 else:
                     layout_bound = size_remaining

--- a/tests/filecheck/transforms/set-memory-layout.mlir
+++ b/tests/filecheck/transforms/set-memory-layout.mlir
@@ -30,22 +30,22 @@ func.func @snax_main() -> () {
   %4 = memref.alloc() : memref<1x16x18x18xi8, "L1">
   %5 = memref.alloc() : memref<16x16x3x3xi8, "L1">
   %6 = memref.alloc() : memref<1x16x16x16xi32, "L1">
-  "dart.schedule"(%4, %5, %6) <{patterns = [affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (d3, ((d6 * 8) + d9), (((d1 * 8) + d5) + d7), (d0 + d4))>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (((d2 * 8) + d8), ((d6 * 8) + d9), d5, d4)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (d3, ((d2 * 8) + d8), ((d1 * 8) + d7), d0)>], accelerator = "snax_gemmx", tiles = [[]], bounds = [16 : index, 2 : index, 2 : index, 1 : index, 3 : index, 3 : index, 2 : index, 8 : index, 8 : index, 8 : index], operandSegmentSizes = array<i32: 2, 1>}> ({
-  ^0(%arg0 : !dart.stream<i8>, %arg1 : !dart.stream<i8>, %arg2 : !dart.stream<i32>):
-    %7 = "dart.generic"(%arg0, %arg1) <{library_call = "snax_gemmx"}> ({
-    ^1(%arg3 : i8, %arg4 : i8, %arg5 : i32):
-      %8 = kernel.mac %arg3, %arg4 : i8, i8 -> i32
-      dart.yield %8 : i32
-    }) : (!dart.stream<i8>, !dart.stream<i8>) -> !dart.stream<i32>
-    dart.yield %7 : !dart.stream<i32>
-  }) : (memref<1x16x18x18xi8, "L1">, memref<16x16x3x3xi8, "L1">, memref<1x16x16x16xi32, "L1">) -> ()
+  "dart.schedule"(%4, %5, %6) <{patterns = [affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (d0, ((d4 * 8) + d9), (d2 + d5), (((d3 * 8) + d6) + d7))>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (((d1 * 8) + d8), ((d4 * 8) + d9), d5, d6)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (d0, ((d1 * 8) + d8), d2, ((d3 * 8) + d7))>], accelerator = "snax_gemmx", tiles = [[]], bounds = [1 : index, 2 : index, 16 : index, 2 : index, 2 : index, 3 : index, 3 : index, 8 : index, 8 : index, 8 : index], operandSegmentSizes = array<i32: 2, 1>}> ({
+    ^0(%arg0 : !dart.stream<i8>, %arg1 : !dart.stream<i8>, %arg2 : !dart.stream<i32>):
+      %7 = "dart.generic"(%arg0, %arg1) <{library_call = "snax_gemmx"}> ({
+      ^1(%arg3 : i8, %arg4 : i8, %arg5 : i32):
+        %8 = kernel.mac %arg3, %arg4 : i8, i8 -> i32
+        dart.yield %8 : i32
+      }) : (!dart.stream<i8>, !dart.stream<i8>) -> !dart.stream<i32>
+      dart.yield %7 : !dart.stream<i32>
+    }) : (memref<1x16x18x18xi8, "L1">, memref<16x16x3x3xi8, "L1">, memref<1x16x16x16xi32, "L1">) -> ()
   func.return
 }
 
-// TILED:      %3 = "snax.layout_cast"(%0) : (memref<1x16x18x18xi8, "L1">) -> memref<1x16x18x18xi8, #tsl.tsl<[1] -> (5184), [2, 8] -> (144, 1), [18] -> (8), [18] -> (288)>, "L1">
-// TILED-NEXT: %4 = "snax.layout_cast"(%1) : (memref<16x16x3x3xi8, "L1">) -> memref<16x16x3x3xi8, #tsl.tsl<[2, 8] -> (1152, 8), [2, 8] -> (64, 1), [3] -> (128), [3] -> (384)>, "L1">
-// TILED-NEXT: %5 = "snax.layout_cast"(%2) : (memref<1x16x16x16xi32, "L1">) -> memref<1x16x16x16xi32, #tsl.tsl<[1] -> (64), [2, 8] -> (64, 1), [2, 8] -> (128, 8), [16] -> (256)>, "L1">
+// TILED:      %3 = "snax.layout_cast"(%0) : (memref<1x16x18x18xi8, "L1">) -> memref<1x16x18x18xi8, #tsl.tsl<[1] -> (5184), [2, 8] -> (2592, 1), [18] -> (144), [18] -> (8)>, "L1">
+// TILED-NEXT: %4 = "snax.layout_cast"(%1) : (memref<16x16x3x3xi8, "L1">) -> memref<16x16x3x3xi8, #tsl.tsl<[2, 8] -> (1152, 8), [2, 8] -> (576, 1), [3] -> (192), [3] -> (64)>, "L1">
+// TILED-NEXT: %5 = "snax.layout_cast"(%2) : (memref<1x16x16x16xi32, "L1">) -> memref<1x16x16x16xi32, #tsl.tsl<[1] -> (4096), [2, 8] -> (2048, 1), [16] -> (128), [16] -> (8)>, "L1">
 
-// CHECK:      %3 = "snax.layout_cast"(%0) : (memref<1x16x18x18xi8, "L1">) -> memref<1x16x18x18xi8, #tsl.tsl<[1] -> (5184), [16] -> (1), [18] -> (16), [18] -> (288)>, "L1">
-// CHECK-NEXT: %4 = "snax.layout_cast"(%1) : (memref<16x16x3x3xi8, "L1">) -> memref<16x16x3x3xi8, #tsl.tsl<[16] -> (16), [16] -> (1), [3] -> (256), [3] -> (768)>, "L1">
-// CHECK-NEXT: %5 = "snax.layout_cast"(%2) : (memref<1x16x16x16xi32, "L1">) -> memref<1x16x16x16xi32, #tsl.tsl<[1] -> (256), [16] -> (1), [16] -> (16), [16] -> (256)>, "L1">
+// CHECK:      %3 = "snax.layout_cast"(%0) : (memref<1x16x18x18xi8, "L1">) -> memref<1x16x18x18xi8, #tsl.tsl<[1] -> (5184), [16] -> (1), [18] -> (288), [18] -> (16)>, "L1">
+// CHECK-NEXT: %4 = "snax.layout_cast"(%1) : (memref<16x16x3x3xi8, "L1">) -> memref<16x16x3x3xi8, #tsl.tsl<[16] -> (16), [16] -> (1), [3] -> (768), [3] -> (256)>, "L1">
+// CHECK-NEXT: %5 = "snax.layout_cast"(%2) : (memref<1x16x16x16xi32, "L1">) -> memref<1x16x16x16xi32, #tsl.tsl<[1] -> (4096), [16] -> (1), [16] -> (256), [16] -> (16)>, "L1">

--- a/tests/filecheck/transforms/set-memory-layout.mlir
+++ b/tests/filecheck/transforms/set-memory-layout.mlir
@@ -23,3 +23,29 @@ func.func @gemm(%arg0 : memref<16x16xi8, "L1">, %arg1 : memref<16x16xi8, "L1">, 
 // CHECK:      %2 = "snax.layout_cast"(%arg0) : (memref<16x16xi8, "L1">) -> memref<16x16xi8, #tsl.tsl<[16] -> (16), [16] -> (1)>, "L1">
 // CHECK-NEXT: %3 = "snax.layout_cast"(%arg1) : (memref<16x16xi8, "L1">) -> memref<16x16xi8, #tsl.tsl<[16] -> (1), [16] -> (16)>, "L1">
 // CHECK-NEXT: %4 = "snax.layout_cast"(%arg2) : (memref<16x16xi32, "L1">) -> memref<16x16xi32, #tsl.tsl<[16] -> (16), [16] -> (1)>, "L1">
+
+// -----
+
+func.func @snax_main() -> () {
+  %4 = memref.alloc() : memref<1x16x18x18xi8, "L1">
+  %5 = memref.alloc() : memref<16x16x3x3xi8, "L1">
+  %6 = memref.alloc() : memref<1x16x16x16xi32, "L1">
+  "dart.schedule"(%4, %5, %6) <{patterns = [affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (d3, ((d6 * 8) + d9), (((d1 * 8) + d5) + d7), (d0 + d4))>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (((d2 * 8) + d8), ((d6 * 8) + d9), d5, d4)>, affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (d3, ((d2 * 8) + d8), ((d1 * 8) + d7), d0)>], accelerator = "snax_gemmx", tiles = [[]], bounds = [16 : index, 2 : index, 2 : index, 1 : index, 3 : index, 3 : index, 2 : index, 8 : index, 8 : index, 8 : index], operandSegmentSizes = array<i32: 2, 1>}> ({
+  ^0(%arg0 : !dart.stream<i8>, %arg1 : !dart.stream<i8>, %arg2 : !dart.stream<i32>):
+    %7 = "dart.generic"(%arg0, %arg1) <{library_call = "snax_gemmx"}> ({
+    ^1(%arg3 : i8, %arg4 : i8, %arg5 : i32):
+      %8 = kernel.mac %arg3, %arg4 : i8, i8 -> i32
+      dart.yield %8 : i32
+    }) : (!dart.stream<i8>, !dart.stream<i8>) -> !dart.stream<i32>
+    dart.yield %7 : !dart.stream<i32>
+  }) : (memref<1x16x18x18xi8, "L1">, memref<16x16x3x3xi8, "L1">, memref<1x16x16x16xi32, "L1">) -> ()
+  func.return
+}
+
+// TILED:      %3 = "snax.layout_cast"(%0) : (memref<1x16x18x18xi8, "L1">) -> memref<1x16x18x18xi8, #tsl.tsl<[1] -> (5184), [2, 8] -> (144, 1), [18] -> (8), [18] -> (288)>, "L1">
+// TILED-NEXT: %4 = "snax.layout_cast"(%1) : (memref<16x16x3x3xi8, "L1">) -> memref<16x16x3x3xi8, #tsl.tsl<[2, 8] -> (1152, 8), [2, 8] -> (64, 1), [3] -> (128), [3] -> (384)>, "L1">
+// TILED-NEXT: %5 = "snax.layout_cast"(%2) : (memref<1x16x16x16xi32, "L1">) -> memref<1x16x16x16xi32, #tsl.tsl<[1] -> (64), [2, 8] -> (64, 1), [2, 8] -> (128, 8), [16] -> (256)>, "L1">
+
+// CHECK:      %3 = "snax.layout_cast"(%0) : (memref<1x16x18x18xi8, "L1">) -> memref<1x16x18x18xi8, #tsl.tsl<[1] -> (5184), [16] -> (1), [18] -> (16), [18] -> (288)>, "L1">
+// CHECK-NEXT: %4 = "snax.layout_cast"(%1) : (memref<16x16x3x3xi8, "L1">) -> memref<16x16x3x3xi8, #tsl.tsl<[16] -> (16), [16] -> (1), [3] -> (256), [3] -> (768)>, "L1">
+// CHECK-NEXT: %5 = "snax.layout_cast"(%2) : (memref<1x16x16x16xi32, "L1">) -> memref<1x16x16x16xi32, #tsl.tsl<[1] -> (256), [16] -> (1), [16] -> (16), [16] -> (256)>, "L1">


### PR DESCRIPTION
when choosing an automatic layout, the selection to tile or not to tile is a bit more complex.
As the streamers can only have affine access patterns, the resulting patterns after tiling must remain affine, which is what this one checks.