### PR TITLE
add dart schedule canonicalization

### DIFF
--- a/snaxc/transforms/dart/dart_scheduler.py
+++ b/snaxc/transforms/dart/dart_scheduler.py
@@ -49,6 +49,9 @@ class AutoflowScheduler(RewritePattern):
         )
         schedule = scheduler(template, schedule, schedule_idx=self.schedule_idx)
 
+        schedule = schedule.canonicalize()
+        schedule = scheduler(template, schedule)
+
         schedule_op = dart.ScheduleOp(
             op.inputs,
             op.outputs,

--- a/snaxc/transforms/dart/dart_scheduler.py
+++ b/snaxc/transforms/dart/dart_scheduler.py
@@ -47,10 +47,9 @@ class AutoflowScheduler(RewritePattern):
             SchedulePattern(schedule_bounds, pattern.data)
             for pattern in op.patterns.data
         )
-        schedule = scheduler(template, schedule, schedule_idx=self.schedule_idx)
 
         schedule = schedule.canonicalize()
-        schedule = scheduler(template, schedule)
+        schedule = scheduler(template, schedule, schedule_idx=self.schedule_idx)
 
         schedule_op = dart.ScheduleOp(
             op.inputs,

--- a/snaxc/transforms/set_memory_layout.py
+++ b/snaxc/transforms/set_memory_layout.py
@@ -131,6 +131,11 @@ class AddCyclicMemoryLayout(RewritePattern):
                 # increase current stride
                 current_stride = current_stride * layout_bound
 
+            # fill up empty strides
+            for stride in strides:
+                if not len(stride):
+                    stride.append(Stride(current_stride, 1))
+
             layout = TiledStridedLayout(
                 [TiledStride(s) for s in strides]
             ).canonicalize()

--- a/tests/ir/dart/test_access_pattern.py
+++ b/tests/ir/dart/test_access_pattern.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from xdsl.ir.affine import AffineDimExpr, AffineMap
+from xdsl.ir.affine import AffineConstantExpr, AffineDimExpr, AffineMap
 
 from snaxc.ir.dart.access_pattern import (
     AccessPattern,
@@ -289,3 +289,11 @@ def test_template_matches_schedule_length_mismatch():
     schedule = Schedule([sp1, sp2])
 
     assert template.matches(schedule) is False
+
+
+def test_access_pattern_canonicalize():
+    pattern1 = AffineMap(num_dims=4, num_symbols=0, results=(AffineConstantExpr(0),))
+    tp1 = TemplatePattern((10, 1, 10, 1), pattern1)
+    pattern2 = AffineMap(num_dims=2, num_symbols=0, results=(AffineConstantExpr(0),))
+    tp2 = TemplatePattern((10, 10), pattern2)
+    assert tp1.canonicalize() == tp2


### PR DESCRIPTION
canonicalize operation schedules before applying the scheduler to avoid duplicate results

For example a for loop with bound 1 is useless, but rotating this one around results in several valid schedules that are actually equal. Therefore there is a canonicalization step before applying the scheduler