### PR TITLE
transforms: (snax-copy-to-dma) add ignore transform option

### DIFF
--- a/snaxc/transforms/snax_copy_to_dma.py
+++ b/snaxc/transforms/snax_copy_to_dma.py
@@ -494,6 +494,10 @@ class TransformDMA(RewritePattern):
 class SNAXCopyToDMA(ModulePass):
     """
     This pass translates memref copies to snitch DMA calls.
+
+    If you want to ignore all transformations made by the dma because it makes everything very slow, the
+    `test_ignore_transform` gives you the option to replace it by a regular 1D transfer.
+    Note that this renders the data incorrect, yet it can be helpful during debugging
     """
 
     name = "snax-copy-to-dma"

--- a/tests/filecheck/transforms/copy-to-dma-ignore-transform.mlir
+++ b/tests/filecheck/transforms/copy-to-dma-ignore-transform.mlir
@@ -1,6 +1,6 @@
 // RUN: snax-opt --split-input-file %s -p snax-copy-to-dma{test-ignore-transform=true} | filecheck %s
 
-// a very complext transformation:
+// a very complex transformation:
 "builtin.module"() ({
   "func.func"() <{"sym_name" = "transform_copy", "function_type" = (memref<8x8xi32, #tsl.tsl<[2, 4] -> (4, 1), [2, 4] -> (32, 8)>, "L3">, memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 1), [2, 4] -> (32, 4)>, "L1">) -> (), "sym_visibility" = "public"}> ({
   ^0(%arg0 : memref<8x8xi32, #tsl.tsl<[2, 4] -> (4, 1), [2, 4] -> (32, 8)>, "L3">, %arg1 : memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 1), [2, 4] -> (32, 4)>, "L1">):

--- a/tests/filecheck/transforms/copy-to-dma-ignore-transform.mlir
+++ b/tests/filecheck/transforms/copy-to-dma-ignore-transform.mlir
@@ -1,0 +1,15 @@
+// RUN: snax-opt --split-input-file %s -p snax-copy-to-dma{test-ignore-transform=true} | filecheck %s
+
+// a very complext transformation:
+"builtin.module"() ({
+  "func.func"() <{"sym_name" = "transform_copy", "function_type" = (memref<8x8xi32, #tsl.tsl<[2, 4] -> (4, 1), [2, 4] -> (32, 8)>, "L3">, memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 1), [2, 4] -> (32, 4)>, "L1">) -> (), "sym_visibility" = "public"}> ({
+  ^0(%arg0 : memref<8x8xi32, #tsl.tsl<[2, 4] -> (4, 1), [2, 4] -> (32, 8)>, "L3">, %arg1 : memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 1), [2, 4] -> (32, 4)>, "L1">):
+    "memref.copy"(%arg0, %arg1) : (memref<8x8xi32, #tsl.tsl<[2, 4] -> (4, 1), [2, 4] -> (32, 8)>, "L3">, memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 1), [2, 4] -> (32, 4)>, "L1">) -> ()
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// but a very simple 1d transfer applied:
+
+// CHECK: func.call @snax_dma_1d_transfer(%0, %1, %26) : (index, index, index) -> ()
+


### PR DESCRIPTION
sometimes you just want to ignore all transformations made by the dma because it makes everything very slow, this gives you the option to replace it by a regular 1D transfer.
The data will be wrong, but it can be helpful during debugging