### PR TITLE
dart scheduler: add memory flexibility test 

### DIFF
--- a/snaxc/ir/dart/scheduler.py
+++ b/snaxc/ir/dart/scheduler.py
@@ -122,12 +122,34 @@ def is_pure_output_stationary(template: Template, schedule: Schedule):
     return first_reduction_idx > last_parallel_idx
 
 
+def is_memory_flexible_enough(template: Template, schedule: Schedule):
+    """
+    Checks whether the TCDM flexibility is sufficient to actually execute
+    the schedule.
+
+    There must be one spatial stride of 1 that doesn't need more fine-grained
+    temporal access within one bank, such that that dimension can be packed together.
+    """
+    # this check only makes sense if there are temporal dimensions:
+    if not schedule.num_dims > template.num_dims:
+        return True
+    for s in schedule:
+        # is there temporary fine-grained access for this dimension?
+        temporal = (s.pattern.A[:, 0 : -template.num_dims] % 8).any(axis=1)
+        # is the dimension spatially unrolled?
+        spatial = (s.pattern.A[:, -template.num_dims :] == 1).any(axis=1)
+        if (False, True) not in zip(temporal, spatial):
+            return False
+    return True
+
+
 def scheduler(
     template: Template,
     schedule: Schedule,
     extra_checks: Sequence[Callable[[Template, Schedule], bool]] = [
         # defaulting to pure output stationary schedules for now
-        is_pure_output_stationary
+        is_pure_output_stationary,
+        is_memory_flexible_enough,
     ],
 ) -> Schedule:
     # for now just return the first result of the backtracking

--- a/tests/ir/dart/test_scheduler.py
+++ b/tests/ir/dart/test_scheduler.py
@@ -7,6 +7,7 @@ from snaxc.ir.dart.access_pattern import (
     TemplatePattern,
 )
 from snaxc.ir.dart.scheduler import (
+    is_memory_flexible_enough,
     is_pure_output_stationary,
     scheduler,
     scheduler_backtrack,
@@ -20,7 +21,7 @@ def test_matching_1o():
     template = Template((TemplatePattern(bounds=(4, 4, 4), pattern=pattern),))
     schedule = Schedule((SchedulePattern(bounds=(4, 4, 4), pattern=pattern),))
 
-    resulting_schedule = scheduler(template, schedule)
+    resulting_schedule = scheduler(template, schedule, extra_checks=[])
 
     assert schedule == resulting_schedule.clear_unused_dims()
 
@@ -32,7 +33,7 @@ def test_matching_2o():
     template = Template((TemplatePattern(bounds=(4, 4, 4), pattern=pattern),) * 2)
     schedule = Schedule((SchedulePattern(bounds=(4, 4, 4), pattern=pattern),) * 2)
 
-    resulting_schedule = scheduler(template, schedule)
+    resulting_schedule = scheduler(template, schedule, extra_checks=[])
 
     assert schedule == resulting_schedule.clear_unused_dims()
 
@@ -48,7 +49,7 @@ def test_tiling_1o1_1d():
     schedule = Schedule((SchedulePattern(bounds=(4,), pattern=pattern_schedule),))
     expected = Schedule((SchedulePattern(bounds=(2, 2), pattern=pattern_expected),))
 
-    result = scheduler(template, schedule)
+    result = scheduler(template, schedule, extra_checks=[])
 
     assert result == expected
 
@@ -72,7 +73,7 @@ def test_tiling_1o1_2d():
         (SchedulePattern(bounds=(2, 2, 2, 2), pattern=pattern_expected),)
     )
 
-    result = scheduler(template, schedule)
+    result = scheduler(template, schedule, extra_checks=[])
 
     assert result == expected
 
@@ -103,7 +104,7 @@ def test_tiling_2o1_2d():
         SchedulePattern((2, 2, 2, 2), pattern) for pattern in pattern_expected
     )
 
-    result = scheduler(template, schedule)
+    result = scheduler(template, schedule, extra_checks=[])
 
     assert result == expected
 
@@ -225,3 +226,21 @@ def test_pure_output_stationary_scheduler():
     assert len(result) == 1
     # that one result being the output stationary one
     assert result[0] == schedule_output_stationary
+
+
+def test_memory_flexibility_scheduler():
+    template_pattern = AffineMap.from_callable(lambda y: (y,))
+    template = Template([TemplatePattern([4], template_pattern)])
+
+    schedule_pattern = AffineMap.from_callable(lambda x, y: (x + y,))
+    schedule = Schedule([SchedulePattern([3, 8], schedule_pattern)])
+
+    results_without = list(scheduler_backtrack(template, schedule, extra_checks=[]))
+    results_with = list(
+        scheduler_backtrack(
+            template, schedule, extra_checks=[is_memory_flexible_enough]
+        )
+    )
+
+    assert len(results_without) == 2
+    assert len(results_with) == 0


### PR DESCRIPTION
this PR adds a check to the scheduler wheter a given schedule can be achieved, given the limited flexibility of the tcdm system. there will always have to be 8 int8 values packed together, and this check checks wether the schedule will access them at a finer granularity than this 8.