### PR TITLE
add pipeline dialect

### DIFF
--- a/snaxc/dialects/__init__.py
+++ b/snaxc/dialects/__init__.py
@@ -26,6 +26,11 @@ def get_all_snax_dialects() -> dict[str, Callable[[], Dialect]]:
 
         return Kernel
 
+    def get_pipeline():
+        from snaxc.dialects.pipeline import Pipeline
+
+        return Pipeline
+
     def get_snax():
         from snaxc.dialects.snax import Snax
 
@@ -46,6 +51,7 @@ def get_all_snax_dialects() -> dict[str, Callable[[], Dialect]]:
         "dart": get_dart,
         "debug": get_debug,
         "kernel": get_kernel,
+        "pipeline": get_pipeline,
         "snax": get_snax,
         "snax_stream": get_snax_stream,
         "tsl": get_tsl,

--- a/snaxc/dialects/pipeline.py
+++ b/snaxc/dialects/pipeline.py
@@ -121,10 +121,16 @@ class StageOp(IRDLOperation):
 
     def __init__(
         self,
-        buffers: Sequence[SSAValue | Operation],
+        ins: Sequence[SSAValue | Operation],
+        outs: Sequence[SSAValue | Operation],
+        index: int | IntegerAttr[IndexType],
         body: Region,
     ) -> None:
-        super().__init__(operands=[buffers], regions=[body])
+        if isinstance(index, int):
+            index = IntegerAttr.from_index_int_value(index)
+        super().__init__(
+            operands=[ins, outs], regions=[body], properties={"index": index}
+        )
 
 
 Pipeline = Dialect(

--- a/snaxc/dialects/pipeline.py
+++ b/snaxc/dialects/pipeline.py
@@ -1,0 +1,139 @@
+from collections.abc import Sequence
+from typing import Self
+
+from xdsl.dialects.builtin import IndexType, IntegerAttr
+from xdsl.dialects.scf import ForOp
+from xdsl.dialects.utils import AbstractYieldOperation
+from xdsl.ir import (
+    Attribute,
+    Block,
+    Dialect,
+    Operation,
+    Region,
+    SSAValue,
+)
+from xdsl.irdl import (
+    AttrSizedOperandSegments,
+    IRDLOperation,
+    irdl_op_definition,
+    operand_def,
+    prop_def,
+    region_def,
+    traits_def,
+    var_operand_def,
+    var_result_def,
+)
+from xdsl.traits import HasParent, IsTerminator, NoTerminator, Pure
+
+
+@irdl_op_definition
+class PipelineOp(IRDLOperation):
+    """
+    An operation whose region is a sequence of one
+    index op and or more pipeline stages.
+    """
+
+    name = "pipeline.pipeline"
+
+    body = region_def("single_block")
+
+    traits = traits_def(NoTerminator(), HasParent(ForOp))
+
+    assembly_format = "$body attr-dict"
+
+    def __init__(self, body: Region) -> None:
+        super().__init__(regions=[body])
+
+
+@irdl_op_definition
+class IndexOp(IRDLOperation):
+    """
+    An index op is the collection of operations without explicit side-effects
+    and not dispatchable to a given accelerator.
+    For example, arith ops, memref subviews, ...
+    These are often computed using the for loop variable `i`.
+    By wrapping them in a pipeline.index op, it is easy to get these values
+    for other values than `i`, such as `i+1`, `i+2`, etc.
+    """
+
+    name = "pipeline.index"
+
+    input = operand_def(IndexType)
+    outputs = var_result_def()
+
+    body = region_def()
+
+    traits = traits_def(HasParent(PipelineOp))
+
+    assembly_format = "$input `->` type($outputs) $body attr-dict"
+
+    def __init__(
+        self,
+        input: SSAValue | Operation,
+        result_types: Sequence[Attribute],
+        body: Region,
+    ):
+        super().__init__(operands=[input], result_types=[result_types], regions=[body])
+
+    @classmethod
+    def empty(cls, input: SSAValue | Operation) -> Self:
+        """
+        Create an empty index op with the given input.
+        """
+        return cls(input=input, result_types=[], body=Region(Block([YieldOp()])))
+
+
+@irdl_op_definition
+class YieldOp(AbstractYieldOperation[Attribute]):
+    """
+    A yield operation for the pipeline index op.
+    """
+
+    name = "pipeline.yield"
+
+    traits = traits_def(IsTerminator(), HasParent(IndexOp), Pure())
+
+
+@irdl_op_definition
+class StageOp(IRDLOperation):
+    """
+    A single pipeline stage. The operation tracks which input / output buffers defined
+    outside of the pipleine op the operations in its region works on.
+    """
+
+    name = "pipeline.stage"
+
+    ins = var_operand_def()
+    outs = var_operand_def()
+
+    body = region_def("single_block")
+
+    index = prop_def(IntegerAttr[IndexType])
+
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
+    assembly_format = (
+        "$index (` ins` `(` $ins^ `:` type($ins) `)`)?"
+        + "(` outs` `(` $outs^ `:` type($outs) `)`)? $body attr-dict"
+    )
+
+    traits = traits_def(NoTerminator(), HasParent(PipelineOp))
+
+    def __init__(
+        self,
+        buffers: Sequence[SSAValue | Operation],
+        body: Region,
+    ) -> None:
+        super().__init__(operands=[buffers], regions=[body])
+
+
+Pipeline = Dialect(
+    "pipeline",
+    [
+        PipelineOp,
+        IndexOp,
+        YieldOp,
+        StageOp,
+    ],
+    [],
+)

--- a/tests/filecheck/dialects/pipeline/ops.mlir
+++ b/tests/filecheck/dialects/pipeline/ops.mlir
@@ -1,0 +1,80 @@
+// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_GENERIC_ROUNDTRIP
+
+
+builtin.module {
+  %0 = memref.alloc() : memref<1x2xi32>
+  %1 = memref.alloc() : memref<1x2xi32>
+  %lb = arith.constant 0 : index
+  %ub = arith.constant 10 : index
+  %step = arith.constant 1 : index
+  scf.for %i = %lb to %ub step %step {
+    pipeline.pipeline {
+      %2, %3 = pipeline.index %i -> i32, memref<1x2xi32> {
+      ^0(%4 : index):
+        %5 = arith.constant 0 : i32
+        %6 = memref.alloc() : memref<1x2xi32>
+        pipeline.yield %5, %6 : i32, memref<1x2xi32>
+      }
+      pipeline.stage 0 {
+        "memref.copy"(%3, %3) : (memref<1x2xi32>, memref<1x2xi32>) -> ()
+      }
+      pipeline.stage 1 ins(%0 : memref<1x2xi32>) outs(%1 : memref<1x2xi32>) {
+      ^1(%7 : memref<1x2xi32>, %8 : memref<1x2xi32>):
+        "memref.copy"(%7, %8) : (memref<1x2xi32>, memref<1x2xi32>) -> ()
+      }
+    }
+  }
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %0 = memref.alloc() : memref<1x2xi32>
+// CHECK-NEXT:   %1 = memref.alloc() : memref<1x2xi32>
+// CHECK-NEXT:   %lb = arith.constant 0 : index
+// CHECK-NEXT:   %ub = arith.constant 10 : index
+// CHECK-NEXT:   %step = arith.constant 1 : index
+// CHECK-NEXT:   scf.for %i = %lb to %ub step %step {
+// CHECK-NEXT:     pipeline.pipeline {
+// CHECK-NEXT:       %2, %3 = pipeline.index %i -> i32, memref<1x2xi32> {
+// CHECK-NEXT:       ^0(%4 : index):
+// CHECK-NEXT:         %5 = arith.constant 0 : i32
+// CHECK-NEXT:         %6 = memref.alloc() : memref<1x2xi32>
+// CHECK-NEXT:         pipeline.yield %5, %6 : i32, memref<1x2xi32>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       pipeline.stage 0 {
+// CHECK-NEXT:         "memref.copy"(%3, %3) : (memref<1x2xi32>, memref<1x2xi32>) -> ()
+// CHECK-NEXT:       }
+// CHECK-NEXT:       pipeline.stage 1 ins(%0 : memref<1x2xi32>) outs(%1 : memref<1x2xi32>) {
+// CHECK-NEXT:       ^1(%7 : memref<1x2xi32>, %8 : memref<1x2xi32>):
+// CHECK-NEXT:         "memref.copy"(%7, %8) : (memref<1x2xi32>, memref<1x2xi32>) -> ()
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// CHECK-GENERIC:      "builtin.module"() ({
+// CHECK-GENERIC-NEXT:   %0 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> : () -> memref<1x2xi32>
+// CHECK-GENERIC-NEXT:   %1 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> : () -> memref<1x2xi32>
+// CHECK-GENERIC-NEXT:   %lb = "arith.constant"() <{value = 0 : index}> : () -> index
+// CHECK-GENERIC-NEXT:   %ub = "arith.constant"() <{value = 10 : index}> : () -> index
+// CHECK-GENERIC-NEXT:   %step = "arith.constant"() <{value = 1 : index}> : () -> index
+// CHECK-GENERIC-NEXT:   "scf.for"(%lb, %ub, %step) ({
+// CHECK-GENERIC-NEXT:   ^0(%i : index):
+// CHECK-GENERIC-NEXT:     "pipeline.pipeline"() ({
+// CHECK-GENERIC-NEXT:       %2, %3 = "pipeline.index"(%i) ({
+// CHECK-GENERIC-NEXT:       ^1(%4 : index):
+// CHECK-GENERIC-NEXT:         %5 = "arith.constant"() <{value = 0 : i32}> : () -> i32
+// CHECK-GENERIC-NEXT:         %6 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> : () -> memref<1x2xi32>
+// CHECK-GENERIC-NEXT:         "pipeline.yield"(%5, %6) : (i32, memref<1x2xi32>) -> ()
+// CHECK-GENERIC-NEXT:       }) : (index) -> (i32, memref<1x2xi32>)
+// CHECK-GENERIC-NEXT:       "pipeline.stage"() <{index = 0 : index, operandSegmentSizes = array<i32: 0, 0>}> ({
+// CHECK-GENERIC-NEXT:         "memref.copy"(%3, %3) : (memref<1x2xi32>, memref<1x2xi32>) -> ()
+// CHECK-GENERIC-NEXT:       }) : () -> ()
+// CHECK-GENERIC-NEXT:       "pipeline.stage"(%0, %1) <{index = 1 : index, operandSegmentSizes = array<i32: 1, 1>}> ({
+// CHECK-GENERIC-NEXT:       ^2(%7 : memref<1x2xi32>, %8 : memref<1x2xi32>):
+// CHECK-GENERIC-NEXT:         "memref.copy"(%7, %8) : (memref<1x2xi32>, memref<1x2xi32>) -> ()
+// CHECK-GENERIC-NEXT:       }) : (memref<1x2xi32>, memref<1x2xi32>) -> ()
+// CHECK-GENERIC-NEXT:     }) : () -> ()
+// CHECK-GENERIC-NEXT:     "scf.yield"() : () -> ()
+// CHECK-GENERIC-NEXT:   }) : (index, index, index) -> ()
+// CHECK-GENERIC-NEXT: }) : () -> ()


### PR DESCRIPTION
this PR adds an initial version of the pipeline dialect

this will be used in transformations to construct pipelines from for loop blocks, that can then later be unrolled to achieve double buffering and multi-core pipelined scenarios