### PR TITLE
transforms: add construct-pipeline pass

### DIFF
--- a/snaxc/dialects/pipeline.py
+++ b/snaxc/dialects/pipeline.py
@@ -61,7 +61,7 @@ class IndexOp(IRDLOperation):
     input = operand_def(IndexType)
     outputs = var_result_def()
 
-    body = region_def()
+    body = region_def("single_block")
 
     traits = traits_def(HasParent(PipelineOp))
 

--- a/snaxc/transforms/__init__.py
+++ b/snaxc/transforms/__init__.py
@@ -36,6 +36,13 @@ def get_all_snax_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return ClearMemorySpace
 
+    def construct_pipeline():
+        from snaxc.transforms.pipeline.construct_pipeline import (
+            ConstructPipelinePass,
+        )
+
+        return ConstructPipelinePass
+
     def get_convert_accfg_to_csr():
         from snaxc.transforms.convert_accfg_to_csr import ConvertAccfgToCsrPass
 
@@ -215,6 +222,7 @@ def get_all_snax_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "accfg-trace-states": get_accfg_trace_states,
         "alloc-to-global": get_alloc_to_global,
         "clear-memory-space": get_clear_memory_space,
+        "construct-pipeline": construct_pipeline,
         "convert-accfg-to-csr": get_convert_accfg_to_csr,
         "convert-dart-to-snax-stream": get_convert_dart_to_snax_stream,
         "convert-kernel-to-linalg": get_convert_kernel_to_linalg,

--- a/snaxc/transforms/pipeline/construct_pipeline.py
+++ b/snaxc/transforms/pipeline/construct_pipeline.py
@@ -1,0 +1,164 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from xdsl.context import Context
+from xdsl.dialects import builtin, scf
+from xdsl.dialects.builtin import IndexType, MemRefType
+from xdsl.dialects.linalg import GenericOp
+from xdsl.dialects.memref import CopyOp
+from xdsl.dialects.scf import ForOp
+from xdsl.ir import Block, Operation, Region, SSAValue
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.rewriter import InsertPoint
+
+from snaxc.dialects.dart import StreamingRegionOpBase
+from snaxc.dialects.pipeline import IndexOp, PipelineOp, StageOp, YieldOp
+from snaxc.dialects.snax import ClusterSyncOp
+from snaxc.util.dispatching_rules import dispatch_to_compute, dispatch_to_dm
+
+
+@dataclass
+class ConstructPipeline(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: ForOp, rewriter: PatternRewriter):
+        # TODO: only apply for for loops with lb 0 and step 1
+
+        # no nested for loop allowed
+        for operation in op.walk():
+            if operation is not op and isinstance(operation, ForOp):
+                return
+
+        # create pipeline op inside
+        pipeline_op = PipelineOp(Region(Block()))
+
+        # create pipeline index op with for loop iter value as index
+        index_ops: Sequence[Operation] = []
+
+        next_op: Operation | None = op.body.block.first_op
+        assert next_op is not None
+
+        def is_index_op(op: Operation) -> bool:
+            if dispatch_to_compute(op) or dispatch_to_dm(op):
+                return False
+            if isinstance(op, ClusterSyncOp):
+                return False
+            return True
+
+        # first get all indexing ops
+        while is_index_op(next_op):
+            index_ops.append(next_op)
+            if isinstance(next_op := next_op.next_op, scf.YieldOp):
+                # no valid pipeline detected
+                return
+            assert next_op is not None
+
+        # now fetch the stages
+        stages: list[list[Operation]] = []
+        current_stage: list[Operation] = []
+        cluster_sync_ops: list[ClusterSyncOp] = []
+
+        def is_stage_op(op: Operation) -> bool:
+            return isinstance(op, CopyOp | StreamingRegionOpBase)
+
+        while is_stage_op(next_op):
+            current_stage.append(next_op)
+            next_op = next_op.next_op
+            if isinstance(next_op, ClusterSyncOp):
+                stages.append(current_stage)
+                current_stage = []
+                # save cluster sync
+                cluster_sync_ops.append(next_op)
+                next_op = next_op.next_op
+            if isinstance(next_op, scf.YieldOp):
+                # valid pipeline ends with sync, so current
+                # stage should be empty
+                if len(current_stage) > 0:
+                    return
+                break
+            assert next_op is not None
+
+        # a valid pipeline has at least two stages
+        if len(stages) < 2:
+            return
+
+        # at this point, the correct pipeline is detected, now we should create the
+        # operations for it
+
+        pipeline_op = PipelineOp(Region(Block()))
+
+        # create index op
+        index_args = [i_op.results[0] for i_op in index_ops if len(i_op.results) > 0]
+        index_yield = YieldOp(*index_args)
+        for o in index_ops:
+            o.detach()
+        index_op = IndexOp(
+            input=op.body.block.args[0],
+            result_types=[x.type for x in index_args],
+            body=Region(Block([*index_ops, index_yield], arg_types=[IndexType()])),
+        )
+
+        # insert index op
+        rewriter.insert_op(index_op, InsertPoint.at_end(pipeline_op.body.block))
+
+        # create stages
+        for i, stage in enumerate(stages):
+            input_buffers: list[SSAValue] = []
+            output_buffers: list[SSAValue] = []
+
+            for operation in stage:
+                if isinstance(next_op, CopyOp):
+                    input_buffers.append(next_op.source)
+                    output_buffers.append(next_op.destination)
+
+                if isinstance(next_op, GenericOp):
+                    input_buffers.extend(
+                        [o for o in next_op.inputs if isinstance(o.type, MemRefType)]
+                    )
+                    output_buffers.extend(
+                        [o for o in next_op.outputs if isinstance(o.type, MemRefType)]
+                    )
+
+                if isinstance(next_op, StreamingRegionOpBase):
+                    input_buffers.extend(
+                        [o for o in next_op.inputs if isinstance(o.type, MemRefType)]
+                    )
+                    output_buffers.extend(
+                        [o for o in next_op.outputs if isinstance(o.type, MemRefType)]
+                    )
+                operation.detach()
+
+            stage_op = StageOp(
+                input_buffers,
+                output_buffers,
+                i,
+                body=Region(
+                    Block(
+                        stage,
+                        arg_types=[o.type for o in (*input_buffers, *output_buffers)],
+                    )
+                ),
+            )
+
+            rewriter.insert_op(stage_op, InsertPoint.at_end(pipeline_op.body.block))
+
+        # insert pipeline op
+        rewriter.insert_op(pipeline_op, InsertPoint.at_start(op.body.block))
+
+        # remove the remaining cluster syncs
+        for cluster_sync in cluster_sync_ops:
+            rewriter.erase_op(cluster_sync)
+
+
+class ConstructPipelinePass(ModulePass):
+    name = "construct-pipeline"
+
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(
+            ConstructPipeline(), apply_recursively=False
+        ).rewrite_module(op)

--- a/snaxc/transforms/pipeline/construct_pipeline.py
+++ b/snaxc/transforms/pipeline/construct_pipeline.py
@@ -112,24 +112,24 @@ class ConstructPipeline(RewritePattern):
             output_buffers: list[SSAValue] = []
 
             for operation in stage:
-                if isinstance(next_op, CopyOp):
-                    input_buffers.append(next_op.source)
-                    output_buffers.append(next_op.destination)
+                if isinstance(operation, CopyOp):
+                    input_buffers.append(operation.source)
+                    output_buffers.append(operation.destination)
 
-                if isinstance(next_op, GenericOp):
+                if isinstance(operation, GenericOp):
                     input_buffers.extend(
-                        [o for o in next_op.inputs if isinstance(o.type, MemRefType)]
+                        [o for o in operation.inputs if isinstance(o.type, MemRefType)]
                     )
                     output_buffers.extend(
-                        [o for o in next_op.outputs if isinstance(o.type, MemRefType)]
+                        [o for o in operation.outputs if isinstance(o.type, MemRefType)]
                     )
 
-                if isinstance(next_op, StreamingRegionOpBase):
+                if isinstance(operation, StreamingRegionOpBase):
                     input_buffers.extend(
-                        [o for o in next_op.inputs if isinstance(o.type, MemRefType)]
+                        [o for o in operation.inputs if isinstance(o.type, MemRefType)]
                     )
                     output_buffers.extend(
-                        [o for o in next_op.outputs if isinstance(o.type, MemRefType)]
+                        [o for o in operation.outputs if isinstance(o.type, MemRefType)]
                     )
                 operation.detach()
 

--- a/snaxc/transforms/pipeline/construct_pipeline.py
+++ b/snaxc/transforms/pipeline/construct_pipeline.py
@@ -64,7 +64,7 @@ class ConstructPipeline(RewritePattern):
         cluster_sync_ops: list[ClusterSyncOp] = []
 
         def is_stage_op(op: Operation) -> bool:
-            return isinstance(op, CopyOp | StreamingRegionOpBase)
+            return isinstance(op, CopyOp | GenericOp | StreamingRegionOpBase)
 
         while is_stage_op(next_op):
             current_stage.append(next_op)

--- a/tests/filecheck/transforms/pipeline/construct-pipeline.mlir
+++ b/tests/filecheck/transforms/pipeline/construct-pipeline.mlir
@@ -1,0 +1,48 @@
+// RUN: snax-opt -p construct-pipeline %s | filecheck %s
+
+%0 = memref.alloc() : memref<1x2xi8>
+%1 = memref.alloc() : memref<1x2xi8>
+%2 = memref.alloc() : memref<1x2xi8>
+%3 = memref.alloc() : memref<1x2xi8>
+%lb = arith.constant 0 : index
+%ub = arith.constant 10 : index
+%step = arith.constant 1 : index
+scf.for %i = %lb to %ub step %step {
+  "test.op"(%i) : (index) -> ()
+  "memref.copy"(%0, %1) : (memref<1x2xi8>, memref<1x2xi8>) -> ()
+  "snax.cluster_sync_op"() : () -> ()
+  "dart.operation"(%1, %2) <{patterns = [], operandSegmentSizes = array<i32: 1, 1>}> ({
+    dart.yield
+  }) : (memref<1x2xi8>, memref<1x2xi8>) -> ()
+  "snax.cluster_sync_op"() : () -> ()
+  "memref.copy"(%2, %3) : (memref<1x2xi8>, memref<1x2xi8>) -> ()
+  "snax.cluster_sync_op"() : () -> ()
+}
+
+// CHECK:      %0 = memref.alloc() : memref<1x2xi8>
+// CHECK-NEXT: %1 = memref.alloc() : memref<1x2xi8>
+// CHECK-NEXT: %2 = memref.alloc() : memref<1x2xi8>
+// CHECK-NEXT: %3 = memref.alloc() : memref<1x2xi8>
+// CHECK-NEXT: %lb = arith.constant 0 : index
+// CHECK-NEXT: %ub = arith.constant 10 : index
+// CHECK-NEXT: %step = arith.constant 1 : index
+// CHECK-NEXT: scf.for %i = %lb to %ub step %step {
+// CHECK-NEXT:   pipeline.pipeline {
+// CHECK-NEXT:     pipeline.index %i -> {
+// CHECK-NEXT:     ^0(%4 : index):
+// CHECK-NEXT:       "test.op"(%i) : (index) -> ()
+// CHECK-NEXT:       pipeline.yield
+// CHECK-NEXT:     }
+// CHECK-NEXT:     pipeline.stage 0 {
+// CHECK-NEXT:       "memref.copy"(%0, %1) : (memref<1x2xi8>, memref<1x2xi8>) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:     pipeline.stage 1 {
+// CHECK-NEXT:       "dart.operation"(%1, %2) <{patterns = [], operandSegmentSizes = array<i32: 1, 1>}> ({
+// CHECK-NEXT:         dart.yield
+// CHECK-NEXT:       }) : (memref<1x2xi8>, memref<1x2xi8>) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:     pipeline.stage 2 {
+// CHECK-NEXT:       "memref.copy"(%2, %3) : (memref<1x2xi8>, memref<1x2xi8>) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/tests/filecheck/transforms/pipeline/construct-pipeline.mlir
+++ b/tests/filecheck/transforms/pipeline/construct-pipeline.mlir
@@ -35,17 +35,17 @@ scf.for %i = %lb to %ub step %step {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     pipeline.stage 0 ins(%0 : memref<1x2xi8>) outs(%1 : memref<1x2xi8>) {
 // CHECK-NEXT:     ^1(%5 : memref<1x2xi8>, %6 : memref<1x2xi8>):
-// CHECK-NEXT:       "memref.copy"(%0, %1) : (memref<1x2xi8>, memref<1x2xi8>) -> ()
+// CHECK-NEXT:       "memref.copy"(%5, %6) : (memref<1x2xi8>, memref<1x2xi8>) -> ()
 // CHECK-NEXT:     }
 // CHECK-NEXT:     pipeline.stage 1 ins(%1 : memref<1x2xi8>) outs(%2 : memref<1x2xi8>) {
 // CHECK-NEXT:     ^2(%7 : memref<1x2xi8>, %8 : memref<1x2xi8>):
-// CHECK-NEXT:       "dart.operation"(%1, %2) <{patterns = [], operandSegmentSizes = array<i32: 1, 1>}> ({
+// CHECK-NEXT:       "dart.operation"(%7, %8) <{patterns = [], operandSegmentSizes = array<i32: 1, 1>}> ({
 // CHECK-NEXT:         dart.yield
 // CHECK-NEXT:       }) : (memref<1x2xi8>, memref<1x2xi8>) -> ()
 // CHECK-NEXT:     }
 // CHECK-NEXT:     pipeline.stage 2 ins(%2 : memref<1x2xi8>) outs(%3 : memref<1x2xi8>) {
 // CHECK-NEXT:     ^3(%9 : memref<1x2xi8>, %10 : memref<1x2xi8>):
-// CHECK-NEXT:       "memref.copy"(%2, %3) : (memref<1x2xi8>, memref<1x2xi8>) -> ()
+// CHECK-NEXT:       "memref.copy"(%9, %10) : (memref<1x2xi8>, memref<1x2xi8>) -> ()
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/pipeline/construct-pipeline.mlir
+++ b/tests/filecheck/transforms/pipeline/construct-pipeline.mlir
@@ -33,15 +33,18 @@ scf.for %i = %lb to %ub step %step {
 // CHECK-NEXT:       "test.op"(%i) : (index) -> ()
 // CHECK-NEXT:       pipeline.yield
 // CHECK-NEXT:     }
-// CHECK-NEXT:     pipeline.stage 0 {
+// CHECK-NEXT:     pipeline.stage 0 ins(%0 : memref<1x2xi8>) outs(%1 : memref<1x2xi8>) {
+// CHECK-NEXT:     ^1(%5 : memref<1x2xi8>, %6 : memref<1x2xi8>):
 // CHECK-NEXT:       "memref.copy"(%0, %1) : (memref<1x2xi8>, memref<1x2xi8>) -> ()
 // CHECK-NEXT:     }
-// CHECK-NEXT:     pipeline.stage 1 {
+// CHECK-NEXT:     pipeline.stage 1 ins(%1 : memref<1x2xi8>) outs(%2 : memref<1x2xi8>) {
+// CHECK-NEXT:     ^2(%7 : memref<1x2xi8>, %8 : memref<1x2xi8>):
 // CHECK-NEXT:       "dart.operation"(%1, %2) <{patterns = [], operandSegmentSizes = array<i32: 1, 1>}> ({
 // CHECK-NEXT:         dart.yield
 // CHECK-NEXT:       }) : (memref<1x2xi8>, memref<1x2xi8>) -> ()
 // CHECK-NEXT:     }
-// CHECK-NEXT:     pipeline.stage 2 {
+// CHECK-NEXT:     pipeline.stage 2 ins(%2 : memref<1x2xi8>) outs(%3 : memref<1x2xi8>) {
+// CHECK-NEXT:     ^3(%9 : memref<1x2xi8>, %10 : memref<1x2xi8>):
 // CHECK-NEXT:       "memref.copy"(%2, %3) : (memref<1x2xi8>, memref<1x2xi8>) -> ()
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }


### PR DESCRIPTION
This pattern will construct a pipeline operation from a for loop.
It tries to detect a structure in the following manner:
```
for:
  (index_ops):
  # some ops doing basic math or taking memref subviews
  # generally no side-effects here
  (stage_1):
  # some dispatchable op (memref copy, generic, streaming region)
  (cluster_sync)
  (stage_2)
  (cluster_sync)
  ...
```
This structure is then converted to a pipeline op, such that it can
be urnolled in further transformations to achieve double buffering
and pipelined execution of asynchronous multi-core accelerators.
