### PR TITLE
Adding an MLP program

### DIFF
--- a/.github/workflows/build-run-kernel-snake.yml
+++ b/.github/workflows/build-run-kernel-snake.yml
@@ -20,4 +20,4 @@ jobs:
         working-directory: kernels/${{ matrix.kernel }}
     strategy:
       matrix:
-        kernel: [alloc, conv, simple_copy, transform_copy, gemm, rescale, gemmini, streamer_alu, streamer_matmul, tiled_add]
+        kernel: [alloc, conv, simple_copy, transform_copy, gemm, rescale, gemmini, streamer_alu, streamer_matmul, tiled_add, mlp]

--- a/kernels/mlp/Snakefile
+++ b/kernels/mlp/Snakefile
@@ -1,0 +1,67 @@
+from util.snake.configs import get_snax_gemmx_config
+
+config = get_snax_gemmx_config()
+config["snaxoptflags"] = ",".join(
+    [
+        "preprocess",
+        "convert-linalg-to-kernel",
+        "insert-accfg-op{accelerator=snax_gemmx}",
+        "dispatch-kernels",
+        "convert-linalg-to-dart",
+        "dart-fuse-operations",
+        "snax-bufferize",
+        "alloc-to-global",
+        "set-memory-space",
+        "dart-scheduler",
+        "set-memory-layout",
+        "realize-memref-casts",
+        "insert-sync-barrier",
+        "dispatch-regions{nb_cores=2}",
+        "dart-layout-resolution",
+        "convert-dart-to-snax-stream",
+        "convert-linalg-to-accfg",
+        "convert-accfg-to-csr",
+        "snax-copy-to-dma",
+        "memref-to-snax",
+        "snax-to-func",
+        "clear-memory-space",
+        "postprocess",
+    ]
+)
+
+
+
+module snax_rules:
+    snakefile:
+        "../../util/snake/snax.smk"
+    config:
+        config
+
+
+use rule * from snax_rules as snax_*
+
+
+files = ["mlp"]
+
+
+# Rules
+rule all:
+    input:
+        expand("{file}_traces.json", file=files),
+
+
+rule generate_mlp:
+    output:
+        "mlp.mlir",
+    script:
+        "mlp.py"
+
+
+rule link_snax_binary:
+    input:
+        "{file}.o",
+        "main.o",
+    output:
+        "{file}.x",
+    shell:
+        "{config[ld]} {config[ldflags]} {input} -o {output}"

--- a/kernels/mlp/Snakefile
+++ b/kernels/mlp/Snakefile
@@ -30,7 +30,6 @@ config["snaxoptflags"] = ",".join(
 )
 
 
-
 module snax_rules:
     snakefile:
         "../../util/snake/snax.smk"

--- a/kernels/mlp/main.c
+++ b/kernels/mlp/main.c
@@ -5,8 +5,8 @@
 
 void _mlir_ciface_snax_main(TwoDMemrefI8_t *results);
 
-void _mlir_ciface_debug_dart(int32_t _ptr_a, int32_t _ptr_b,
-                                   int32_t _ptr_c, int32_t when) {
+void _mlir_ciface_debug_dart(int32_t _ptr_a, int32_t _ptr_b, int32_t _ptr_c,
+                             int32_t when) {
   int8_t *ptr_a, *ptr_b, *ptr_c;
   ptr_a = (int8_t *)_ptr_a;
   ptr_b = (int8_t *)_ptr_b;
@@ -57,7 +57,8 @@ int main() {
   for (int i = 0; i < total_results; i++) {
 
     if (golden->aligned_data[i] != computed->aligned_data[i]) {
-      printf("(%d) %d -> %d\n", i, golden->aligned_data[i], computed->aligned_data[i]);
+      printf("(%d) %d -> %d\n", i, golden->aligned_data[i],
+             computed->aligned_data[i]);
       nerr++;
     }
   }

--- a/kernels/mlp/main.c
+++ b/kernels/mlp/main.c
@@ -1,0 +1,71 @@
+#include "memref.h"
+#include "snax_rt.h"
+#include "stdint.h"
+#include <snrt.h>
+
+void _mlir_ciface_snax_main(TwoDMemrefI8_t *results);
+
+void _mlir_ciface_debug_dart(int32_t _ptr_a, int32_t _ptr_b,
+                                   int32_t _ptr_c, int32_t when) {
+  int8_t *ptr_a, *ptr_b, *ptr_c;
+  ptr_a = (int8_t *)_ptr_a;
+  ptr_b = (int8_t *)_ptr_b;
+  ptr_c = (int8_t *)_ptr_c;
+
+  if (snrt_cluster_core_idx() == 0) {
+    printf("Debugging at t = %d with A at %p, B at %p, C at %p\n", when, ptr_a,
+           ptr_b, ptr_c);
+
+    for (int i = 0; i < 5; i++) {
+      printf("i%d -> A=%d, B=%d, C=%d\n", i, (int32_t)ptr_a[i],
+             (int32_t)ptr_b[i], (int32_t)ptr_c[i]);
+    }
+  }
+}
+
+int main() {
+
+  TwoDMemrefI8_t results[2];
+
+  TwoDMemrefI8_t *golden, *computed;
+
+  golden = &results[0];
+  computed = &results[1];
+
+  (void)snrt_mcycle();
+  snrt_cluster_hw_barrier();
+
+  _mlir_ciface_snax_main(results);
+
+  snrt_cluster_hw_barrier();
+  (void)snrt_mcycle();
+
+  // Correctness check
+  // from this point on only core 0 is required to be alive.
+  int thiscore = snrt_cluster_core_idx();
+  if (thiscore != 0)
+    return 0;
+
+  int total_results = 1;
+  for (int i = 0; i < 2; i++)
+    total_results *= computed->shape[i];
+
+  printf("Checking %d results...\n", total_results);
+
+  int nerr = 0;
+
+  for (int i = 0; i < total_results; i++) {
+
+    if (golden->aligned_data[i] != computed->aligned_data[i]) {
+      printf("(%d) %d -> %d\n", i, golden->aligned_data[i], computed->aligned_data[i]);
+      nerr++;
+    }
+  }
+
+  printf("Finished, nb errors: %d\n", nerr);
+
+  if (nerr > 0)
+    return 1;
+  else
+    return 0;
+}

--- a/kernels/mlp/mlp.py
+++ b/kernels/mlp/mlp.py
@@ -1,0 +1,206 @@
+import os
+from io import StringIO
+
+import numpy as np
+from xdsl.builder import Builder
+from xdsl.dialects.arith import ConstantOp
+from xdsl.dialects.builtin import (
+    DenseIntOrFPElementsAttr,
+    ModuleOp,
+    TensorType,
+    i8,
+    i32,
+)
+from xdsl.dialects.func import FuncOp, ReturnOp
+from xdsl.dialects.linalg import QuantizedMatmulOp
+from xdsl.dialects.tensor import EmptyOp
+from xdsl.printer import Printer
+
+"""
+This file contains the implementation of a cascade matrix multiplication function
+
+The arguments are:
+    batch_size: int
+    input_dim: int
+    hidden_layers_dim: List[int]
+    output_dim: int
+"""
+
+# TODO: This is just a simple scaling mechanism
+# Just for the sake of making the matrices within int8
+def scale_to_int8(arr):
+    arr_min = arr.min()
+    arr_max = arr.max()
+    if arr_max == arr_min:
+        return np.zeros_like(arr, dtype=np.int8)  # Avoid division by zero
+
+    # Scale to range [-128, 127]
+    scaled = 255 * (arr - arr_min) / (arr_max - arr_min) - 128
+    return scaled.astype(np.int8)
+
+# Cascade matrix multiplication function
+# Technically a multilayer perceptron (MLP) with multiple hidden layers
+def cascade_matmul(batch_size, input_dim, hidden_layers_dim, output_dim):
+    # Input tensor
+    input_vals = np.random.randint(-128, 127, (batch_size, input_dim))
+
+    # Iterate through different hidden layers
+    hidden_weights_list = []
+    intermediate_vals = []
+
+    for i in range(len(hidden_layers_dim)):
+        # Generate random weights for the current layer
+        # then perform matrix multiplication
+        # and scale the result to int8
+        if(i==0):
+
+            hidden_weights_list.append(np.random.randint(-128, 127, (input_dim, hidden_layers_dim[i])))
+            # Perform matrix multiplication for the first layer
+            vXM = input_vals @ hidden_weights_list[i]
+            intermediate_vals.append(scale_to_int8(vXM))
+        else:
+            hidden_weights_list.append(np.random.randint(-128, 127, (hidden_layers_dim[i-1], hidden_layers_dim[i])))
+            vXM = intermediate_vals[i-1] @ hidden_weights_list[i]
+            intermediate_vals.append(scale_to_int8(vXM))
+
+    # Generate random weights for the output layer
+    output_weights = np.random.randint(-128, 127, (hidden_layers_dim[-1], output_dim))
+    vXM = intermediate_vals[-1] @ output_weights
+    # Perform matrix multiplication for the output layer
+    output_vals = scale_to_int8(vXM)
+
+    return input_vals, hidden_weights_list, intermediate_vals, output_weights, output_vals
+
+# Defining types and paramters for the MLIR generation
+def mlir_cascade_matmul(input_vals, hidden_weights_list, output_weights, output_vals):
+    # Define types For Program:
+    # For the input weights
+    input_type = TensorType(i8, input_vals.shape)
+
+    # For the hidden weights
+    hidden_weights_types = []
+    for i in range(len(hidden_weights_list)):
+        hidden_weights_types.append(TensorType(i8, hidden_weights_list[i].shape))
+
+    # For the output weights
+    output_weights_type = TensorType(i32, output_weights.shape)
+
+    # For the output values
+    output_type = TensorType(i32, output_vals.shape)
+
+    # Result types
+    res_types = [output_type] * 2
+
+    # Define Program:
+
+    @Builder.implicit_region([])
+    def func_body(_) -> None:
+        # Declare constants
+        # For the input weights
+        input_const = ConstantOp(
+            DenseIntOrFPElementsAttr.from_list(input_type, input_vals.flatten().tolist())
+        )
+
+        # For the hidden weights
+        hidden_weight_const = []
+        for i in range(len(hidden_weights_list)):
+            hidden_weight_const.append(ConstantOp(
+                    DenseIntOrFPElementsAttr.from_list(hidden_weights_types[i], hidden_weights_list[i].flatten().tolist())
+                ))
+
+        # For the output weights
+        output_weight_const = ConstantOp(
+            DenseIntOrFPElementsAttr.from_list(output_weights_type, output_weights.flatten().tolist())
+        )
+
+        # For the output values
+        output_const = ConstantOp(
+            DenseIntOrFPElementsAttr.from_list(
+                output_type, output_vals.flatten().tolist()
+            )
+        )
+
+        # TODO: check me after but let's leave these to 0 first
+        # Some needed constants
+        constants = ConstantOp.from_int_and_width(0, 32)
+
+        intermediate_result = []
+        # Calculating the MLP process
+        for i in range(len(hidden_layers_dim)):
+            # Specify the operation
+            # empty_tensor = EmptyOp([], hidden_weights_types[i])
+            empty_tensor = EmptyOp([], output_type)
+            if(i==0):
+                # For the first layer
+                result = QuantizedMatmulOp(
+                    [input_const.result, hidden_weight_const[i].result, constants.result, constants.result], empty_tensor.results
+                )
+            else:
+                # For the other layers
+                result = QuantizedMatmulOp(
+                    [intermediate_result[i-1][0], hidden_weight_const[i].result, constants.result, constants.result], empty_tensor.results
+                )
+
+            # TODO: need to have a scaling function here
+            # Trying out the xdsl.dialects.quant but it does not seem to be added
+            intermediate_result.append(result.res)
+
+        # For the output layer
+        empty_tensor = EmptyOp([], output_weights_type)
+        final_result = QuantizedMatmulOp(
+            [intermediate_result[-1][0], output_weight_const.result, constants.result, constants.result], empty_tensor.results
+        )
+        # Return both the computed result and the golden output
+        ReturnOp(final_result, output_const)
+
+    function = FuncOp.from_region("snax_main", [], res_types, func_body)
+    return ModuleOp([function])
+
+if __name__ == "__main__":
+
+    # Debug mode
+    print_data = True
+
+    # Example usage
+    batch_size = 1
+    input_dim = 4
+    hidden_layers_dim = [4,8,8,4]
+    output_dim = 3
+
+    # Print parameters
+    print(f"Batch size: {batch_size}")
+    print(f"Input dimension: {input_dim}")
+    print(f"Hidden layers dimensions: {hidden_layers_dim}")
+    print(f"Output dimension: {output_dim}")
+
+    # Call the cascade_matmul function
+    input_vals, hidden_weights_list, intermediate_vals, output_weights, output_vals = cascade_matmul(batch_size, input_dim, hidden_layers_dim, output_dim)
+
+    # For debugging purposes
+    # Print the results
+    if print_data:
+        print("Input values:")
+        print(input_vals)
+        print("Hidden weights:")
+        for i, weights in enumerate(hidden_weights_list):
+            print(f"Layer {i} weights:")
+            print(weights)
+        print("Intermediate values:")
+        for i, intermediate in enumerate(intermediate_vals):
+            print(f"Layer {i} intermediate values:")
+            print(intermediate)
+        print("Output weights:")
+        print(output_weights)
+        print("Output values:")
+        print(output_vals)
+
+    # Get the name of the current Python script and replace its extension with .mlir
+    script_name = os.path.basename(__file__)
+    mlir_filename = os.path.splitext(script_name)[0] + ".mlir"
+
+    # Generate IR and write it to the specified MLIR file
+    output = StringIO()
+    printer = Printer(stream=output)
+    printer.print(mlir_cascade_matmul(input_vals, hidden_weights_list, output_weights, output_vals))
+    with open(mlir_filename, "w") as output_file:
+        output_file.write(output.getvalue())

--- a/kernels/mlp/mlp.py
+++ b/kernels/mlp/mlp.py
@@ -29,13 +29,7 @@ The arguments are:
 # TODO: This is just a simple scaling mechanism
 # Just for the sake of making the matrices within int8
 def scale_to_int8(arr):
-    arr_min = arr.min()
-    arr_max = arr.max()
-    if arr_max == arr_min:
-        return np.zeros_like(arr, dtype=np.int8)  # Avoid division by zero
-
-    # Scale to range [-128, 127]
-    scaled = 255 * (arr - arr_min) / (arr_max - arr_min) - 128
+    scaled = np.right_shift(arr, 9)
     return scaled.astype(np.int8)
 
 
@@ -43,6 +37,7 @@ def scale_to_int8(arr):
 # Technically a multilayer perceptron (MLP) with multiple hidden layers
 def cascade_matmul(batch_size, input_dim, hidden_layers_dim, output_dim):
     # Input tensor
+    np.random.seed(0)  # For reproducibility
     input_vals = np.random.randint(-128, 127, (batch_size, input_dim))
 
     # Iterate through different hidden layers


### PR DESCRIPTION

In this PR, let's try out an MLP where you can vary the input size, hidden layers, and output sizes. 

Things you will find:
⭐  A *golden* function to produce MLP outputs
⭐  The MLIR programming function
⭐ The other things required to run on a certain SNAX cluster architecture

🌋 : I purposely separated this so I can modularize and make comparisons. I know in other examples we can combine them into one, but I did this for my *learning* purposes.

⚠️ Right now this is not "perfect" as it complains about the sign extension due to the `i32` output of the matmul operation. We need a scaling capability.

For now, I assumed that the outputs are indeed 32 bit but setting the types to 8bits complains more. So I get this error after running `snax-opt`:

```bash
 tensor<1x3xi32>
    %21 = "tensor.empty"() : () -> tensor<1x3xi32>
    %22 = "linalg.quantized_matmul"(%9, %2, %7, %7, %21) <{operandSegmentSizes = array<i32: 4, 1>}> ({
    ^1(%23 : i32, %24 : i8, %25 : i32, %26 : i32, %27 : i32):
      %28 = "arith.extsi"(%23) : (i32) -> i32
      ^^^^^^^^^^^^^^^^^^^-----------------------------------------------------------------------
      | Operation does not verify: Destination bit-width must be larger than the input bit-width
      ------------------------------------------------------------------------------------------
      %29 = "arith.subi"(%28, %25) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
      %30 = "arith.extsi"(%24) : (i8) -> i32
      %31 = "arith.subi"(%30, %26) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
      %32 = "arith.muli"(%29, %31) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
      %33 = "arith.addi"(%27, %32) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
```

Something to try out is the `xdsl.dialects.quant`. I found it here: https://mlir.llvm.org/docs/Dialects/QuantDialect/
It looks like (from what I understood) it can do the requantization steps. 

🌌**Solution**
Solution was to simply use the matMulOp rather than the quantizedMatMulOp. This way we can get away without the need for scaling yet. Moreoever, we use the shift scaling available so far.


⚠️ ~~I know this isn't formatted yet haha~~
⚠️ I hope to learn from what you guys think 💯 