### PR TITLE
add gemmx streamer matmul test for default i8 output

### DIFF
--- a/kernels/streamer_matmul/Snakefile
+++ b/kernels/streamer_matmul/Snakefile
@@ -44,7 +44,7 @@ module snax_rules:
 use rule * from snax_rules as snax_*
 
 
-files = ["quantized_matmul", "tiled_quantized_matmul"]
+files = ["quantized_matmul", "tiled_quantized_matmul", "matmul_i8_out"]
 
 
 # Rules

--- a/kernels/streamer_matmul/Snakefile
+++ b/kernels/streamer_matmul/Snakefile
@@ -60,6 +60,13 @@ rule generate_quantized_matmul:
         "quantized_matmul.py"
 
 
+rule generate_matmul_i8_out:
+    output:
+        "matmul_i8_out.mlir",
+    script:
+        "matmul_i8_out.py"
+
+
 rule generate_tiled_quantized_matmul:
     output:
         "tiled_quantized_matmul.transform.mlir",
@@ -76,11 +83,18 @@ rule apply_transforms_mlir:
         "{config[mlir-opt]} {config[mlirtransformflags]} --mlir-print-op-generic --mlir-print-local-scope -o {output} {input}"
 
 
+def get_main_obj(wildcards):
+    if "i8" in wildcards.file:
+        return "main_i8.o"
+    else:
+        return "main.o"
+
+
 rule link_snax_binary:
     input:
         "{file}.o",
-        "main.o",
+        main=lambda wildcards: get_main_obj(wildcards),
     output:
         "{file}.x",
     shell:
-        "{config[ld]} {config[ldflags]} {input} -o {output}"
+        "{config[ld]} {config[ldflags]} {input[0]} {input.main} -o {output}"

--- a/kernels/streamer_matmul/main_i8.c
+++ b/kernels/streamer_matmul/main_i8.c
@@ -1,0 +1,54 @@
+#include "memref.h"
+#include "snax_rt.h"
+#include "stdint.h"
+#include <snrt.h>
+
+void _mlir_ciface_snax_main(TwoDMemrefI8_t *results);
+
+int main() {
+
+  TwoDMemrefI8_t results[2];
+
+  TwoDMemrefI8_t *golden, *computed;
+
+  golden = &results[0];
+  computed = &results[1];
+
+  (void)snrt_mcycle();
+  snrt_cluster_hw_barrier();
+
+  _mlir_ciface_snax_main(results);
+
+  snrt_cluster_hw_barrier();
+  (void)snrt_mcycle();
+
+  // Correctness check
+  // from this point on only core 0 is required to be alive.
+  int thiscore = snrt_cluster_core_idx();
+  if (thiscore != 0)
+    return 0;
+
+  int total_results = 1;
+  for (int i = 0; i < 2; i++)
+    total_results *= computed->shape[i];
+
+  printf("Checking %d results...\n", total_results);
+
+  int nerr = 0;
+
+  for (int i = 0; i < total_results; i++) {
+
+    if (golden->aligned_data[i] != computed->aligned_data[i]) {
+      // printf("(%d) %d -> %d\n", i, golden->aligned_data[i],
+      // computed->aligned_data[i]);
+      nerr++;
+    }
+  }
+
+  printf("Finished, nb errors: %d\n", nerr);
+
+  if (nerr > 0)
+    return 1;
+  else
+    return 0;
+}

--- a/kernels/streamer_matmul/matmul_i8_out.py
+++ b/kernels/streamer_matmul/matmul_i8_out.py
@@ -1,0 +1,94 @@
+import os
+from io import StringIO
+
+import numpy as np
+from xdsl.builder import Builder
+from xdsl.dialects.arith import ConstantOp
+from xdsl.dialects.builtin import (
+    DenseIntOrFPElementsAttr,
+    ModuleOp,
+    TensorType,
+    i8,
+)
+from xdsl.dialects.func import FuncOp, ReturnOp
+from xdsl.dialects.linalg import MatmulOp
+from xdsl.dialects.tensor import EmptyOp
+from xdsl.printer import Printer
+
+"""
+This file contains the implementation of a cascade matrix multiplication function
+
+The arguments are:
+    batch_size: int
+    input_dim: int
+    hidden_layers_dim: List[int]
+    output_dim: int
+"""
+
+
+# TODO: This is just a simple scaling mechanism
+# Just for the sake of making the matrices within int8
+def scale_to_int8(arr):
+    scaled = np.right_shift(arr, 9)
+    scaled = np.clip(scaled, -128, 127)
+    return scaled.astype(np.int8)
+
+
+def matmul(m=16, n=16, k=16):
+    # Define Variables For Program:
+
+    np.random.seed(2)  # For reproducibility
+
+    a_type = TensorType(i8, (m, k))
+    a_vals = np.random.randint(-128, 127, (m, k))
+
+    b_type = TensorType(i8, (k, n))
+    b_vals = np.random.randint(-128, 127, (k, n))
+
+    output_type = TensorType(i8, (m, n))
+    golden_vals = a_vals @ b_vals
+    golden_vals = scale_to_int8(golden_vals)
+
+    res_types = [output_type] * 2
+
+    # Define Program:
+
+    @Builder.implicit_region([])
+    def func_body(_) -> None:
+        # Declare constants
+        a = ConstantOp(
+            DenseIntOrFPElementsAttr.from_list(a_type, a_vals.flatten().tolist())
+        )
+        b = ConstantOp(
+            DenseIntOrFPElementsAttr.from_list(b_type, b_vals.flatten().tolist())
+        )
+        golden = ConstantOp(
+            DenseIntOrFPElementsAttr.from_list(
+                output_type, golden_vals.flatten().tolist()
+            )
+        )
+
+        # Declare result tensor type
+        empty_tensor = EmptyOp([], output_type)
+
+        # Specify the operation
+        result = MatmulOp([a.result, b.result], empty_tensor.results)
+
+        # Return both the computed result and the golden output
+        ReturnOp(result, golden)
+
+    function = FuncOp.from_region("snax_main", [], res_types, func_body)
+    return ModuleOp([function])
+
+
+if __name__ == "__main__":
+    # Get the name of the current Python script and replace its extension with .mlir
+    script_name = os.path.basename(__file__)
+    mlir_filename = os.path.splitext(script_name)[0] + ".mlir"
+
+    # Generate IR and write it to the specified MLIR file
+    output = StringIO()
+    printer = Printer(stream=output)
+    printer.print(matmul())
+    with open(mlir_filename, "w") as output_file:
+        output_file.write(output.getvalue())


### PR DESCRIPTION
this adds a unit test for deploying macs (i8, i8 -> i8) to the gemmx. if no specific rescaling is specified,
a default right shift of >> 9 is applied.

Mostly useful for testing and quick benchmarking purposes.

Support for this was added in #404 and #406