### PR TITLE
bump xdsl and llvm

### DIFF
--- a/.github/workflows/build-run-mlperf-tiny.yml
+++ b/.github/workflows/build-run-mlperf-tiny.yml
@@ -1,9 +1,9 @@
 name: Build MLPerf Tiny Networks
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  # push:
+  #   branches:
+  #     - main
+  # pull_request:
   workflow_dispatch:
 jobs:
   build-and-run-networks:

--- a/pixi.lock
+++ b/pixi.lock
@@ -82,7 +82,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-19.1.7-h024ca30_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py312h178313f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2024.2.2-ha957f24_16.conda
-      - conda: https://conda.anaconda.org/kuleuven-micas/linux-64/mlir-19.1.1.c.d401987fe349a87c53fe25829215b80b70c0c1a-hb0f4dca_0.conda
+      - conda: https://conda.anaconda.org/kuleuven-micas/linux-64/mlir-20.1.1-hb0f4dca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
@@ -183,7 +183,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/89/9b/599bcfc7064fbe5740919e78c5df18e5dceb0887e676256a1061bb5ae232/virtualenv-20.29.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl
-      - pypi: git+https://github.com/xdslproject/xdsl.git?rev=e9b1efb65d0873ee21442515e78f3a449b01bedb#e9b1efb65d0873ee21442515e78f3a449b01bedb
+      - pypi: git+https://github.com/xdslproject/xdsl.git?rev=60e3b7970a3eb7fc16ab7e57c2928357bc5d0180#60e3b7970a3eb7fc16ab7e57c2928357bc5d0180
       - pypi: .
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1405,11 +1405,11 @@ packages:
   - pylint>=2.6.0 ; extra == 'dev'
   - pyink ; extra == 'dev'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/kuleuven-micas/linux-64/mlir-19.1.1.c.d401987fe349a87c53fe25829215b80b70c0c1a-hb0f4dca_0.conda
-  sha256: ae082f0b8d9c39916a81e083b89d7577ed377048f41cc339eaa0e982e8a03cfa
-  md5: 46bc97854617f9df01e47c5505f0f7bc
-  size: 43010488
-  timestamp: 1741358904582
+- conda: https://conda.anaconda.org/kuleuven-micas/linux-64/mlir-20.1.1-hb0f4dca_0.conda
+  sha256: 866448c2ca069ea3a7fa2212499e97d2268735e949fddd7d3a531f86262b12b0
+  md5: ede2888be3834046176b8839fb777f2a
+  size: 46230168
+  timestamp: 1747124207173
 - pypi: https://files.pythonhosted.org/packages/73/59/7854fbfb59f8ae35483ce93493708be5942ebb6328cd85b3a609df629736/namex-0.0.8-py3-none-any.whl
   name: namex
   version: 0.0.8
@@ -2042,6 +2042,8 @@ packages:
   - python >=3.8.0,<4.0.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/snakemake-interface-common?source=hash-mapping
   size: 18489
   timestamp: 1728055352534
 - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-executor-plugins-9.3.3-pyhdfd78af_0.tar.bz2
@@ -2065,6 +2067,8 @@ packages:
   - python >=3.11.0,<4.0.0
   - snakemake-interface-common >=1.16.0,<2.0.0
   license: MIT
+  purls:
+  - pkg:pypi/snakemake-interface-report-plugins?source=hash-mapping
   size: 13269
   timestamp: 1728055589409
 - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-3.3.0-pyhdfd78af_0.tar.bz2
@@ -2131,9 +2135,9 @@ packages:
 - pypi: .
   name: snax-mlir
   version: 0.2.2
-  sha256: 5402383f7cdc854dd6e02bb34c069b126eddc920d931652e508f12b78cf0c996
+  sha256: b136b7227c6b0de56fa69181f753963b29a54756be75e7f663c7a91078c48c20
   requires_dist:
-  - xdsl @ git+https://github.com/xdslproject/xdsl.git@e9b1efb65d0873ee21442515e78f3a449b01bedb
+  - xdsl @ git+https://github.com/xdslproject/xdsl.git@60e3b7970a3eb7fc16ab7e57c2928357bc5d0180
   - numpy
   - pre-commit ; extra == 'dev'
   - filecheck==1.0.0 ; extra == 'dev'
@@ -2389,12 +2393,12 @@ packages:
   - pkg:pypi/wrapt?source=hash-mapping
   size: 63590
   timestamp: 1736869574299
-- pypi: git+https://github.com/xdslproject/xdsl.git?rev=e9b1efb65d0873ee21442515e78f3a449b01bedb#e9b1efb65d0873ee21442515e78f3a449b01bedb
+- pypi: git+https://github.com/xdslproject/xdsl.git?rev=60e3b7970a3eb7fc16ab7e57c2928357bc5d0180#60e3b7970a3eb7fc16ab7e57c2928357bc5d0180
   name: xdsl
-  version: 0.28.0+35.ge9b1efb6
+  version: 0.37.1.dev6+g60e3b797
   requires_dist:
   - immutabledict<4.2.2
-  - typing-extensions>=4.7,<4.13
+  - typing-extensions>=4.7,<5
   - ordered-set==4.1.0
   - toml<0.11 ; extra == 'dev'
   - pytest-cov ; extra == 'dev'
@@ -2402,25 +2406,33 @@ packages:
   - ipykernel ; extra == 'dev'
   - pytest<8.4 ; extra == 'dev'
   - nbval<0.12 ; extra == 'dev'
-  - filecheck==1.0.1 ; extra == 'dev'
+  - filecheck==1.0.2 ; extra == 'dev'
   - lit<19.0.0 ; extra == 'dev'
-  - marimo==0.11.6 ; extra == 'dev'
-  - pre-commit==4.1.0 ; extra == 'dev'
-  - ruff==0.9.6 ; extra == 'dev'
+  - marimo==0.13.7 ; extra == 'dev'
+  - pre-commit>=4.0.0,<5.0.0 ; extra == 'dev'
+  - ruff==0.11.9 ; extra == 'dev'
   - nbconvert>=7.7.2,<8.0.0 ; extra == 'dev'
   - textual-dev==1.7.0 ; extra == 'dev'
-  - pytest-asyncio==0.25.3 ; extra == 'dev'
-  - pyright==1.1.394 ; extra == 'dev'
-  - sympy==1.13.3 ; extra == 'dev'
+  - pytest-asyncio==0.26.0 ; extra == 'dev'
+  - pyright==1.1.400 ; extra == 'dev'
+  - sympy==1.14.0 ; extra == 'dev'
   - mkdocs-gen-files>=0.5.0 ; extra == 'docs'
   - mkdocs-material>=9.5.49 ; extra == 'docs'
   - mkdocs>=1.6.1 ; extra == 'docs'
   - mkdocstrings[python]>=0.27.0 ; extra == 'docs'
-  - textual==2.0.4 ; extra == 'gui'
+  - pymdown-extensions>=10.7 ; extra == 'docs'
+  - lzstring2 ; extra == 'docs'
+  - textual==3.2.0 ; extra == 'gui'
   - pyclip==0.7 ; extra == 'gui'
-  - jax==0.5.0 ; extra == 'jax'
-  - numpy==2.2.3 ; extra == 'jax'
+  - jax==0.6.0 ; extra == 'jax'
+  - numpy==2.2.5 ; extra == 'jax'
   - riscemu==2.2.7 ; extra == 'riscv'
+  - asv>=0.6.4 ; extra == 'bench'
+  - snakeviz>=2.2.2 ; extra == 'bench'
+  - viztracer>=1.0.1 ; extra == 'bench'
+  - flameprof>=0.4 ; extra == 'bench'
+  - orjson>=3.10.15 ; extra == 'bench'
+  - pyinstrument>=5.0.1 ; extra == 'bench'
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
   sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535

--- a/pixi.lock
+++ b/pixi.lock
@@ -22,8 +22,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py312h06ac9bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-19-19.1.1-default_hb5137d0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-19.1.1-default_h9e3a008_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-20-20.1.1-default_hb5137d0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-20.1.1-default_h9e3a008_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-cbc-2.10.12-h8b142ea_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-cgl-0.60.9-h1d3f3f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-clp-1.17.10-h07f2a63_0.conda
@@ -54,7 +54,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-28_h2556b6b_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-28_h372d94f_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.1-default_hb5137d0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.1-default_hb5137d0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
@@ -64,11 +64,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.2-default_h0d58e46_1001.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-28_hc41d3b0_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-28_hbc6e62b_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.7-ha7bfdaf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.3-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.4-he9d0ab4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.48.0-hee588c1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
@@ -76,9 +76,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.50.0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-h8d12d68_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.8-h4bc477f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lld-19.1.1-ha85224e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lld-20.1.1-ha85224e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-19.1.7-h024ca30_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py312h178313f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2024.2.2-ha957f24_16.conda
@@ -131,8 +131,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/yte-1.5.6-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312hef9b889_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312h66e93f0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - pypi: https://files.pythonhosted.org/packages/a2/ad/e0d3c824784ff121c03cc031f944bc7e139a8f1870ffd2845cc2dd76f6c4/absl_py-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b4557eb792fbcf0c653af6076b81e5941d36ec61f7ce6028/astunparse-1.6.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl
@@ -158,7 +158,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/d872fc3d753516870d520595ddd8ce4dd44fa797a240999f125f58521ad7/matplotlib-3.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e5/f1/93219c44bae4017e6e43391fa4433592de08e05def9d885227d3596f21a5/ml_dtypes-0.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/08/57/5d58fad4124192b1be42f68bd0c0ddaa26e44a730ff8c9337adade2f5632/ml_dtypes-0.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/73/59/7854fbfb59f8ae35483ce93493708be5942ebb6328cd85b3a609df629736/namex-0.0.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/50/de23fde84e45f5c4fda2488c759b69990fd4512387a8632860f3ac9cd225/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
@@ -175,9 +175,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/eb/38/ac33370d784287baa1c3d538978b5e2ea064d4c1b93ffbd12826c190dd10/pytz-2025.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3a/d0/b97889ffa769e2d1fdebb632084d5e8b53fc299d43a537acee7ec0c021a3/tensorboard-2.16.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/12/4f70e8e2ba0dbe72ea978429d8530b0333f0ed2140cc571a48802878ef99/tensorboard-2.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/99/9e/f3d851053b8a356f8093043c7f92771a9372e6fc40f28d276c702b7a3111/tensorflow_cpu-2.16.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e9/52/06113de858c340e9dca5279a370e6742bbe7791c80d4627433e2463903f3/tensorflow_cpu-2.19.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/7f/be/df630c387a0a054815d60be6a97eb4e8f17385d5d6fe660e1c02750062b4/termcolor-2.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/9b/599bcfc7064fbe5740919e78c5df18e5dceb0887e676256a1061bb5ae232/virtualenv-20.29.1-py3-none-any.whl
@@ -350,33 +350,33 @@ packages:
   - pkg:pypi/charset-normalizer?source=hash-mapping
   size: 47438
   timestamp: 1735929811779
-- conda: https://conda.anaconda.org/conda-forge/linux-64/clang-19.1.1-default_h9e3a008_0.conda
-  sha256: 2f9998fad593fd3df5da604af5a722b0ddba6806e405b408d2d83c83e481e648
-  md5: f0a93bba3b2501ef865e955cc1f26c5c
+- conda: https://conda.anaconda.org/conda-forge/linux-64/clang-20.1.1-default_h9e3a008_0.conda
+  sha256: 0bbcc6eb77f2597af1b2d0ffc6f7b48db09f1b716c769af350388235c2614fab
+  md5: 88ad01cded2b46ab4a77aafeac17cb3e
   depends:
   - binutils_impl_linux-64
-  - clang-19 19.1.1 default_hb5137d0_0
+  - clang-20 20.1.1 default_hb5137d0_0
   - libgcc-devel_linux-64
   - sysroot_linux-64
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 22906
-  timestamp: 1728456867364
-- conda: https://conda.anaconda.org/conda-forge/linux-64/clang-19-19.1.1-default_hb5137d0_0.conda
-  sha256: ce2d4de7fb24518ef91aff5f0527a106e72816c6a28c862c2b31449b4da895e1
-  md5: a74eb4576082ead2e4f589f02078bd45
+  size: 23982
+  timestamp: 1742506317665
+- conda: https://conda.anaconda.org/conda-forge/linux-64/clang-20-20.1.1-default_hb5137d0_0.conda
+  sha256: d293037dcd8377011dad0cc822e88335d0a10f0d504e4649e57dbdb72690809f
+  md5: cef16ac880dc2fa050bdfb15fe1d2a8b
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libclang-cpp19.1 19.1.1 default_hb5137d0_0
+  - libclang-cpp20.1 20.1.1 default_hb5137d0_0
   - libgcc >=13
-  - libllvm19 >=19.1.1,<19.2.0a0
+  - libllvm20 >=20.1.1,<20.2.0a0
   - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 776553
-  timestamp: 1728456794213
+  size: 820809
+  timestamp: 1742506260799
 - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-cbc-2.10.12-h8b142ea_1.conda
   sha256: d06d5911c0153aa4b1549ff6eda413409c40f6ba4f68fdb53791ec792d827f16
   md5: 1d7f5461c42aba35340cd31d0f72d85f
@@ -971,19 +971,19 @@ packages:
   name: libclang
   version: 18.1.1
   sha256: c533091d8a3bbf7460a00cb6c1a71da93bffe148f172c7d03b1c31fbf8aa2a0b
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.1-default_hb5137d0_0.conda
-  sha256: a2fb20bdcbebf94d654a4e770ddc910b0e1fcefe2b5acbd5dec04cb19129df2c
-  md5: a5feadc4a296e2d31ab5a642498ff85e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.1-default_hb5137d0_0.conda
+  sha256: 3b79cdf6bb6d5f42a73f5db5f3dd9fb5563b44f24e761d02faeb52b9506019f4
+  md5: 331dee424fabc0c26331767acc93a074
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libllvm19 >=19.1.1,<19.2.0a0
+  - libllvm20 >=20.1.1,<20.2.0a0
   - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 20542477
-  timestamp: 1728456712882
+  size: 20878931
+  timestamp: 1742506161165
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
   sha256: 56541b98447b58e52d824bd59d6382d609e11de1f8adf20b23143e353d2b8d26
   md5: db833e03127376d461e1e13e76f09b6c
@@ -1088,15 +1088,16 @@ packages:
   purls: []
   size: 2423200
   timestamp: 1731374922090
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
-  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
-  md5: d66573916ffcf376178462f1b61c941e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
+  sha256: 18a4afe14f731bfb9cf388659994263904d20111e42f841e9eea1bb6f91f4ab4
+  md5: e796ff8ddc598affdf7c173d6145f087
   depends:
-  - libgcc-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   license: LGPL-2.1-only
   purls: []
-  size: 705775
-  timestamp: 1702682170569
+  size: 713084
+  timestamp: 1740128065462
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-28_hc41d3b0_mkl.conda
   build_number: 28
   sha256: 41722505678641075eb3937d1a785e7ef75161b98c339e5d49c55ca3e63b4ee7
@@ -1131,33 +1132,34 @@ packages:
   purls: []
   size: 16480
   timestamp: 1738114007938
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.7-ha7bfdaf_0.conda
-  sha256: 13d6e687e111832902a70e49b28cda3a9927c8b50eb22e3a5c828e4a0dd5304b
-  md5: 683d876292316d64a1aa26fb79b21f8e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.4-he9d0ab4_0.conda
+  sha256: 56a375dc36df1a4e2061e30ebbacbc9599a11277422a9a3145fd228f772bab53
+  md5: 96c33bbd084ef2b2463503fb7f1482ae
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libstdcxx >=13
-  - libxml2 >=2.13.5,<3.0a0
+  - libxml2 >=2.13.7,<2.14.0a0
   - libzlib >=1.3.1,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
+  - zstd >=1.5.7,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 40132862
-  timestamp: 1736894001744
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.6.3-hb9d3cd8_1.conda
-  sha256: e6e425252f3839e2756e4af1ea2074dffd3396c161bf460629f9dfd6a65f15c6
-  md5: 2ecf2f1c7e4e21fcfe6423a51a992d84
+  size: 43004201
+  timestamp: 1746052658083
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_1.conda
+  sha256: eeff241bddc8f1b87567dd6507c9f441f7f472c27f0860a07628260c000ef27c
+  md5: a76fd702c93cd2dfd89eff30a5fd45a8
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   constrains:
-  - xz ==5.6.3=*_1
+  - xz 5.8.1.*
+  - xz ==5.8.1=*_1
   license: 0BSD
   purls: []
-  size: 111132
-  timestamp: 1733407410083
+  size: 112845
+  timestamp: 1746531470399
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
   sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
   md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
@@ -1229,21 +1231,21 @@ packages:
   purls: []
   size: 100393
   timestamp: 1702724383534
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.5-h8d12d68_1.conda
-  sha256: c3b05bdc40d27a9249f0bb60f3f71718f94104b8bcd200163a6c9d4ade7aa052
-  md5: 1a21e49e190d1ffe58531a81b6e400e1
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.8-h4bc477f_0.conda
+  sha256: b0b3a96791fa8bb4ec030295e8c8bf2d3278f33c0f9ad540e73b5e538e6268e7
+  md5: 14dbe05b929e329dbaa6f2d0aa19466d
   depends:
   - __glibc >=2.17,<3.0.a0
   - icu >=75.1,<76.0a0
   - libgcc >=13
-  - libiconv >=1.17,<2.0a0
-  - liblzma >=5.6.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
   - libzlib >=1.3.1,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 690589
-  timestamp: 1733443667823
+  size: 690864
+  timestamp: 1746634244154
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
   sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
   md5: edb0dca6bc32e4f4789199455a1dbeb8
@@ -1261,23 +1263,23 @@ packages:
   name: lit
   version: 18.1.8
   sha256: a873ff7acd76e746368da32eb7355625e2e55a2baaab884c9cc130f2ee0300f7
-- conda: https://conda.anaconda.org/conda-forge/linux-64/lld-19.1.1-ha85224e_0.conda
-  sha256: 85422856ef2e016cee62a3e2b3cc71b975dadd2c4254b4fcaa3af2f51822743b
-  md5: d8236e4934c63286d0d11b564382b1ef
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lld-20.1.1-ha85224e_0.conda
+  sha256: 9bb3597baa96524d649c2080daa65e4aa0fb88c009c01975e1036c81d32077ef
+  md5: 16400df173f9882609a23fa1c938ebd2
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libllvm19 >=19.1.1,<19.2.0a0
+  - libllvm20 >=20.1.1,<20.2.0a0
   - libstdcxx >=13
   - libzlib >=1.3.1,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
+  - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - llvm ==19.1.1
+  - llvm ==20.1.1
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   purls: []
-  size: 7419742
-  timestamp: 1727917032907
+  size: 6104914
+  timestamp: 1742476833964
 - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-19.1.7-h024ca30_0.conda
   sha256: 5383e32604e03814b6011fa01a5332057934181a7ea0e90abba7890c17cabce6
   md5: 9915f85a72472011550550623cce2d53
@@ -1390,15 +1392,16 @@ packages:
   purls: []
   size: 124718448
   timestamp: 1730231808335
-- pypi: https://files.pythonhosted.org/packages/e5/f1/93219c44bae4017e6e43391fa4433592de08e05def9d885227d3596f21a5/ml_dtypes-0.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/08/57/5d58fad4124192b1be42f68bd0c0ddaa26e44a730ff8c9337adade2f5632/ml_dtypes-0.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: ml-dtypes
-  version: 0.3.2
-  sha256: e8505946df1665db01332d885c2020b4cb9e84a8b1241eb4ba69d59591f65855
+  version: 0.5.1
+  sha256: ad4953c5eb9c25a56d11a913c2011d7e580a435ef5145f804d98efa14477d390
   requires_dist:
-  - numpy>1.20
+  - numpy>=1.21
   - numpy>=1.21.2 ; python_full_version >= '3.10'
   - numpy>=1.23.3 ; python_full_version >= '3.11'
   - numpy>=1.26.0 ; python_full_version >= '3.12'
+  - numpy>=2.1.0 ; python_full_version >= '3.13'
   - absl-py ; extra == 'dev'
   - pytest ; extra == 'dev'
   - pytest-xdist ; extra == 'dev'
@@ -2135,7 +2138,7 @@ packages:
 - pypi: .
   name: snax-mlir
   version: 0.2.2
-  sha256: b136b7227c6b0de56fa69181f753963b29a54756be75e7f663c7a91078c48c20
+  sha256: d8c22634b903257bfa26e4403904d0b7395df85ea15c128c469f03bc7d8cc889
   requires_dist:
   - xdsl @ git+https://github.com/xdslproject/xdsl.git@60e3b7970a3eb7fc16ab7e57c2928357bc5d0180
   - numpy
@@ -2145,7 +2148,7 @@ packages:
   - pytest ; extra == 'dev'
   - pandas ; extra == 'viz'
   - matplotlib ; extra == 'viz'
-  - tensorflow-cpu==2.16.2 ; extra == 'nn'
+  - tensorflow-cpu==2.19.0 ; extra == 'nn'
   requires_python: ==3.12.*
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h0157908_18.conda
@@ -2183,15 +2186,16 @@ packages:
   purls: []
   size: 175954
   timestamp: 1732982638805
-- pypi: https://files.pythonhosted.org/packages/3a/d0/b97889ffa769e2d1fdebb632084d5e8b53fc299d43a537acee7ec0c021a3/tensorboard-2.16.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/5d/12/4f70e8e2ba0dbe72ea978429d8530b0333f0ed2140cc571a48802878ef99/tensorboard-2.19.0-py3-none-any.whl
   name: tensorboard
-  version: 2.16.2
-  sha256: 9f2b4e7dad86667615c0e5cd072f1ea8403fc032a299f0072d6f74855775cc45
+  version: 2.19.0
+  sha256: 5e71b98663a641a7ce8a6e70b0be8e1a4c0c45d48760b076383ac4755c35b9a0
   requires_dist:
   - absl-py>=0.4
   - grpcio>=1.48.2
   - markdown>=2.6.8
   - numpy>=1.12.0
+  - packaging
   - protobuf>=3.19.6,!=4.24.0
   - setuptools>=41.0.0
   - six>1.9
@@ -2203,22 +2207,20 @@ packages:
   version: 0.7.2
   sha256: 7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/99/9e/f3d851053b8a356f8093043c7f92771a9372e6fc40f28d276c702b7a3111/tensorflow_cpu-2.16.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/e9/52/06113de858c340e9dca5279a370e6742bbe7791c80d4627433e2463903f3/tensorflow_cpu-2.19.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: tensorflow-cpu
-  version: 2.16.2
-  sha256: 8ec09acc09534017e02318456f77e96947b2ab4d24d2eb580541405c45ea3b70
+  version: 2.19.0
+  sha256: 0b9dbed26ca64194cdadee6a471b916825be803c4608f0f6a68b8336f47fb7f3
   requires_dist:
   - absl-py>=1.0.0
   - astunparse>=1.6.0
-  - flatbuffers>=23.5.26
+  - flatbuffers>=24.3.25
   - gast>=0.2.1,!=0.5.0,!=0.5.1,!=0.5.2
   - google-pasta>=0.1.1
-  - h5py>=3.10.0
   - libclang>=13.0.0
-  - ml-dtypes~=0.3.1
   - opt-einsum>=2.3.2
   - packaging
-  - protobuf>=3.20.3,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0.dev0
+  - protobuf>=3.20.3,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<6.0.0.dev0
   - requests>=2.21.0,<3
   - setuptools
   - six>=1.12.0
@@ -2226,24 +2228,25 @@ packages:
   - typing-extensions>=3.6.6
   - wrapt>=1.11.0
   - grpcio>=1.24.3,<2.0
-  - tensorboard>=2.16,<2.17
-  - keras>=3.0.0
-  - tensorflow-intel==2.16.2 ; sys_platform == 'win32'
+  - tensorboard~=2.19.0
+  - keras>=3.5.0
+  - numpy>=1.26.0,<2.2.0
+  - h5py>=3.11.0
+  - ml-dtypes>=0.5.1,<1.0.0
+  - tensorflow-intel==2.19.0 ; sys_platform == 'win32'
   - tensorflow-io-gcs-filesystem>=0.23.1 ; python_full_version < '3.12'
-  - numpy>=1.23.5,<2.0.0 ; python_full_version < '3.12'
-  - numpy>=1.26.0,<2.0.0 ; python_full_version >= '3.12'
-  - nvidia-cublas-cu12==12.3.4.1 ; extra == 'and-cuda'
-  - nvidia-cuda-cupti-cu12==12.3.101 ; extra == 'and-cuda'
-  - nvidia-cuda-nvcc-cu12==12.3.107 ; extra == 'and-cuda'
-  - nvidia-cuda-nvrtc-cu12==12.3.107 ; extra == 'and-cuda'
-  - nvidia-cuda-runtime-cu12==12.3.101 ; extra == 'and-cuda'
-  - nvidia-cudnn-cu12==8.9.7.29 ; extra == 'and-cuda'
-  - nvidia-cufft-cu12==11.0.12.1 ; extra == 'and-cuda'
-  - nvidia-curand-cu12==10.3.4.107 ; extra == 'and-cuda'
-  - nvidia-cusolver-cu12==11.5.4.101 ; extra == 'and-cuda'
-  - nvidia-cusparse-cu12==12.2.0.103 ; extra == 'and-cuda'
-  - nvidia-nccl-cu12==2.19.3 ; extra == 'and-cuda'
-  - nvidia-nvjitlink-cu12==12.3.101 ; extra == 'and-cuda'
+  - nvidia-cublas-cu12==12.5.3.2 ; extra == 'and-cuda'
+  - nvidia-cuda-cupti-cu12==12.5.82 ; extra == 'and-cuda'
+  - nvidia-cuda-nvcc-cu12==12.5.82 ; extra == 'and-cuda'
+  - nvidia-cuda-nvrtc-cu12==12.5.82 ; extra == 'and-cuda'
+  - nvidia-cuda-runtime-cu12==12.5.82 ; extra == 'and-cuda'
+  - nvidia-cudnn-cu12==9.3.0.75 ; extra == 'and-cuda'
+  - nvidia-cufft-cu12==11.2.3.61 ; extra == 'and-cuda'
+  - nvidia-curand-cu12==10.3.6.82 ; extra == 'and-cuda'
+  - nvidia-cusolver-cu12==11.6.3.83 ; extra == 'and-cuda'
+  - nvidia-cusparse-cu12==12.5.1.3 ; extra == 'and-cuda'
+  - nvidia-nccl-cu12==2.23.4 ; extra == 'and-cuda'
+  - nvidia-nvjitlink-cu12==12.5.82 ; extra == 'and-cuda'
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/7f/be/df630c387a0a054815d60be6a97eb4e8f17385d5d6fe660e1c02750062b4/termcolor-2.5.0-py3-none-any.whl
   name: termcolor
@@ -2481,32 +2484,31 @@ packages:
   purls: []
   size: 92286
   timestamp: 1727963153079
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312hef9b889_1.conda
-  sha256: b97015e146437283f2213ff0e95abdc8e2480150634d81fbae6b96ee09f5e50b
-  md5: 8b7069e9792ee4e5b4919a7a306d2e67
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312h66e93f0_2.conda
+  sha256: ff62d2e1ed98a3ec18de7e5cf26c0634fd338cb87304cf03ad8cbafe6fe674ba
+  md5: 630db208bc7bbb96725ce9832c7423bb
   depends:
   - __glibc >=2.17,<3.0.a0
   - cffi >=1.11
   - libgcc >=13
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  - zstd >=1.5.6,<1.5.7.0a0
-  - zstd >=1.5.6,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/zstandard?source=hash-mapping
-  size: 419552
-  timestamp: 1725305670210
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
-  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
-  md5: 4d056880988120e29d75bfff282e0f45
+  - pkg:pypi/zstandard?source=compressed-mapping
+  size: 732224
+  timestamp: 1745869780524
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+  sha256: a4166e3d8ff4e35932510aaff7aa90772f84b4d07e9f6f83c614cba7ceefe0eb
+  md5: 6432cb5d4ac0046c3ac0a8a0f95842f9
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 554846
-  timestamp: 1714722996770
+  size: 567578
+  timestamp: 1742433379869

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ version = "0.2.2"
 requires-python = "== 3.12.*"
 
 dependencies = [
-    "xdsl @ git+https://github.com/xdslproject/xdsl.git@e9b1efb65d0873ee21442515e78f3a449b01bedb",
+    "xdsl @ git+https://github.com/xdslproject/xdsl.git@60e3b7970a3eb7fc16ab7e57c2928357bc5d0180",
     "numpy",
 ]
 
@@ -108,7 +108,7 @@ default = { features = ["dev", "nn", "viz"] }
 [tool.pixi.tasks]
 
 [tool.pixi.dependencies]
-mlir = { version = "==19.1.1.c.d401987fe349a87c53fe25829215b80b70c0c1a", channel = "kuleuven-micas" }
+mlir = { version = "==20.1.1", channel = "kuleuven-micas" }
 clang = "==19.1.1"
 lld = "==19.1.1"
 snax-cluster-prebuilt = "==0.2.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ viz = [
 
 # Dependencies for neural network compilation
 nn = [
-    "tensorflow-cpu==2.16.2",
+    "tensorflow-cpu==2.19.0",
 ]
 
 [project.scripts]
@@ -109,8 +109,8 @@ default = { features = ["dev", "nn", "viz"] }
 
 [tool.pixi.dependencies]
 mlir = { version = "==20.1.1", channel = "kuleuven-micas" }
-clang = "==19.1.1"
-lld = "==19.1.1"
+clang = "==20.1.1"
+lld = "==20.1.1"
 snax-cluster-prebuilt = "==0.2.12"
 snakemake-minimal="*"
 pyright = ">=1.1.390,<2"

--- a/runtime/Makefile.rules
+++ b/runtime/Makefile.rules
@@ -86,7 +86,6 @@ MLIRPREPROCFLAGS += --mlir-print-local-scope
 MLIRPREPROC2FLAGS = --tosa-to-arith="include-apply-rescale" 
 MLIRPREPROC2FLAGS += --empty-tensor-to-alloc-tensor
 
-MLIRPREPROC3FLAGS += --test-linalg-transform-patterns="test-generalize-pad-tensor"
 MLIRPREPROC3FLAGS += --linalg-generalize-named-ops
 MLIRPREPROC3FLAGS += --empty-tensor-to-alloc-tensor --one-shot-bufferize="bufferize-function-boundaries allow-return-allocs-from-loops function-boundary-type-conversion=identity-layout-map"
 MLIRPREPROC3FLAGS += --mlir-print-op-generic

--- a/snaxc/accelerators/acc_context.py
+++ b/snaxc/accelerators/acc_context.py
@@ -17,7 +17,7 @@ class AccContext(Context):
     """
 
     _registered_accelerators: dict[str, Callable[[], Accelerator]] = field(
-        default_factory=dict
+        default_factory=dict[str, Callable[[], Accelerator]]
     )
 
     def clone(self) -> "AccContext":
@@ -26,6 +26,7 @@ class AccContext(Context):
             self._loaded_dialects.copy(),
             self._loaded_ops.copy(),
             self._loaded_attrs.copy(),
+            self._loaded_types.copy(),
             self._registered_dialects.copy(),
             self._registered_accelerators.copy(),
         )

--- a/snaxc/dialects/accfg.py
+++ b/snaxc/dialects/accfg.py
@@ -366,7 +366,7 @@ class SetupOp(AccfgBaseOp):
             accelerator,
             in_state,
         )
-        setup_op.out_state.type = res_typ
+        setup_op.out_state._type = res_typ
         setup_op.attributes.update(attributes)
         return setup_op
 

--- a/snaxc/dialects/snax.py
+++ b/snaxc/dialects/snax.py
@@ -92,7 +92,7 @@ class LayoutCast(IRDLOperation):
 
     def verify_(self) -> None:
         source = cast(MemRefType[Attribute], self.source.type)
-        dest = cast(MemRefType[Attribute], self.dest.type)
+        dest = self.dest.type
         if source.get_shape() != dest.get_shape():
             raise VerifyException(
                 "Expected source and destination to have the same shape."

--- a/snaxc/transforms/accfg_dedup.py
+++ b/snaxc/transforms/accfg_dedup.py
@@ -11,6 +11,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 from xdsl.traits import is_side_effect_free
 
 from snaxc.dialects import accfg
@@ -153,7 +154,7 @@ class PullSetupOpsOutOfLoops(RewritePattern):
             in_state=get_initial_value_for_scf_for_lcv(loop_op, op.in_state),
         )
         # insert the new setup op before the loop
-        rewriter.insert_op_before(loop_invariant_setups, loop_op)
+        rewriter.insert_op(loop_invariant_setups, InsertPoint.before(loop_op))
 
         # replace loop_invariant_setups.in_state with loop_invariant_setups.out_state in the iter_args of loop_op
         # loop_invariant_setups.in_state is the previous input state to the for loop (as determined by a call
@@ -226,9 +227,9 @@ class HoistSetupCallsIntoConditionals(RewritePattern):
 
             # insert a copy of the setup op but replace the
             # original in_state with the yielded state of the region
-            rewriter.insert_op_before(
+            rewriter.insert_op(
                 new_setup := op.clone(value_mapper={op.in_state: new_in_state}),
-                yield_op,
+                InsertPoint.before(yield_op),
             )
             # replace the yield op with a new yield op that yields the
             # newly produced state

--- a/snaxc/transforms/clear_memory_space.py
+++ b/snaxc/transforms/clear_memory_space.py
@@ -33,9 +33,9 @@ class ClearMemorySpace(ModulePass):
 
         for op_in_module in op.walk():
             for operand in op_in_module.operands:
-                operand.type = clear_memory_space(operand.type)
+                operand._type = clear_memory_space(operand.type)  # pyright: ignore
             for result in op_in_module.results:
-                result.type = clear_memory_space(result.type)
+                result._type = clear_memory_space(result.type)  # pyright: ignore
 
             if isinstance(op_in_module, func.FuncOp):
                 # special case for func ops because func ops do not have

--- a/snaxc/transforms/convert_linalg_to_accfg.py
+++ b/snaxc/transforms/convert_linalg_to_accfg.py
@@ -10,6 +10,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 
 from snaxc.accelerators import AccContext
 from snaxc.dialects import accfg
@@ -204,7 +205,7 @@ def _weave_states_in_region(
                             # create empty setup op
                             empty_setup = accfg.SetupOp([], [], acc_name)
                             # insert op before the scf.for
-                            rewriter.insert_op_before(empty_setup, op)
+                            rewriter.insert_op(empty_setup, InsertPoint.before(op))
                             # register it as an input
                             state[acc_name] = empty_setup.out_state
 

--- a/snaxc/transforms/dart/dart_fuse_operations.py
+++ b/snaxc/transforms/dart/dart_fuse_operations.py
@@ -116,9 +116,7 @@ class FuseElementwisePattern(RewritePattern):
                     InsertPoint.at_end(streaming_region_op.body.block),
                 )
                 for old_result, new_result in zip(o.results, producer_generic.results):
-                    rewriter._replace_all_uses_with(  # pyright: ignore
-                        old_result, new_result
-                    )
+                    old_result.replace_by(new_result)
             # do not use yield op from producer region
             elif isinstance(o, dart.YieldOp):
                 continue

--- a/snaxc/transforms/frontend/preprocess_mlir.py
+++ b/snaxc/transforms/frontend/preprocess_mlir.py
@@ -26,7 +26,6 @@ MLIR_PREPOC_FLAGS: tuple[tuple[str, ...], ...] = (
         "--mlir-print-local-scope",
     ),
     (
-        "--test-linalg-transform-patterns=test-generalize-pad-tensor",
         "--linalg-generalize-named-ops",
         "--mlir-print-op-generic",
         "--mlir-print-local-scope",

--- a/snaxc/transforms/frontend/preprocess_mlperf_tiny.py
+++ b/snaxc/transforms/frontend/preprocess_mlperf_tiny.py
@@ -227,7 +227,6 @@ class PreprocessMLPerfTiny(ModulePass):
 
     mlir_bufferization_pass = MLIROptPass(
         arguments=(
-            "--test-linalg-transform-patterns=test-generalize-pad-tensor",
             "--linalg-generalize-named-ops",
             "--empty-tensor-to-alloc-tensor",
             "--one-shot-bufferize=bufferize-function-boundaries allow-return-allocs-from-loops"

--- a/tests/dialects/test_snax.py
+++ b/tests/dialects/test_snax.py
@@ -6,7 +6,7 @@ from xdsl.ir import Attribute
 from xdsl.parser import StringAttr
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 from snaxc.dialects.snax import Alloc, LayoutCast
 from snaxc.util.memref_descriptor import LLVMMemrefDescriptor
@@ -19,7 +19,7 @@ def test_memref_memory_space_cast():
     source_type = MemRefType(
         i32, [10, 2], layout=layout_1, memory_space=builtin.StringAttr("L1")
     )
-    source_ssa = TestSSAValue(source_type)
+    source_ssa = create_ssa_value(source_type)
 
     dest_type = MemRefType(i32, [10, 2], memory_space=builtin.StringAttr("L1"))
 
@@ -58,7 +58,7 @@ def test_memref_memory_space_cast():
         LayoutCast(source_ssa, dest_type_other_space).verify()
 
     type_nolayout = MemRefType(i32, [10, 2], memory_space=builtin.StringAttr("L1"))
-    TestSSAValue(type_nolayout)
+    create_ssa_value(type_nolayout)
 
     # Test helper function
     memory_layout_cast = LayoutCast.from_type_and_target_layout(source_ssa, layout_2)
@@ -69,8 +69,8 @@ def test_memref_memory_space_cast():
 
 
 def test_snax_alloc():
-    size = TestSSAValue(i32)
-    shape = [TestSSAValue(i32), TestSSAValue(i32)]
+    size = create_ssa_value(i32)
+    shape = [create_ssa_value(i32), create_ssa_value(i32)]
     dim = 2
     alloc_a = Alloc(dim, size, shape, memory_space=builtin.StringAttr("L1"))
 

--- a/tests/filecheck/transforms/insert-sync-barrier.mlir
+++ b/tests/filecheck/transforms/insert-sync-barrier.mlir
@@ -7,7 +7,7 @@
 }) : () -> ()
 
 //CHECK: "builtin.module"() ({
-//CHECK-NEXT:   %0 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> {alignment = 64 : i64} : () -> memref<64xi32>
+//CHECK-NEXT:   %0 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>, alignment = 64 : i64}> : () -> memref<64xi32>
 //CHECK-NEXT:   "test.op"(%0) : (memref<64xi32>) -> ()
 //CHECK-NEXT: }) : () -> ()
 
@@ -65,9 +65,9 @@
 //CHECK: "builtin.module"() ({
 //CHECK-NEXT:   "func.func"() <{sym_name = "simple_mult", function_type = (memref<64xi32, "L3">, memref<64xi32, "L3">, memref<64xi32, "L3">) -> (), sym_visibility = "public"}> ({
 //CHECK-NEXT:   ^0(%arg0 : memref<64xi32, "L3">, %arg1 : memref<64xi32, "L3">, %arg2 : memref<64xi32, "L3">):
-//CHECK-NEXT:     %0 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> {alignment = 64 : i64} : () -> memref<64xi32, "L1">
-//CHECK-NEXT:     %1 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> {alignment = 64 : i64} : () -> memref<64xi32, "L1">
-//CHECK-NEXT:     %2 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> {alignment = 64 : i64} : () -> memref<64xi32, "L1">
+//CHECK-NEXT:     %0 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>, alignment = 64 : i64}> : () -> memref<64xi32, "L1">
+//CHECK-NEXT:     %1 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>, alignment = 64 : i64}> : () -> memref<64xi32, "L1">
+//CHECK-NEXT:     %2 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>, alignment = 64 : i64}> : () -> memref<64xi32, "L1">
 //CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, "L3">, memref<64xi32, "L1">) -> ()
 //CHECK-NEXT:     "memref.copy"(%arg1, %1) : (memref<64xi32, "L3">, memref<64xi32, "L1">) -> ()
 //CHECK-NEXT:     "snax.cluster_sync_op"() : () -> ()
@@ -115,10 +115,10 @@
 //CHECK: "builtin.module"() ({
 //CHECK-NEXT:   "func.func"() <{sym_name = "simple_mult", function_type = (memref<64xi32, "L3">, memref<64xi32, "L3">, memref<64xi32, "L3">) -> (), sym_visibility = "public"}> ({
 //CHECK-NEXT:   ^0(%arg0 : memref<64xi32, "L3">, %arg1 : memref<64xi32, "L3">, %arg2 : memref<64xi32, "L3">):
-//CHECK-NEXT:     %0 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> {alignment = 64 : i64} : () -> memref<64xi32, "L1">
-//CHECK-NEXT:     %1 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> {alignment = 64 : i64} : () -> memref<64xi32, "L1">
-//CHECK-NEXT:     %2 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> {alignment = 64 : i64} : () -> memref<64xi32, "L1">
-//CHECK-NEXT:     %3 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> {alignment = 64 : i64} : () -> memref<64xi32, "L1">
+//CHECK-NEXT:     %0 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>, alignment = 64 : i64}> : () -> memref<64xi32, "L1">
+//CHECK-NEXT:     %1 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>, alignment = 64 : i64}> : () -> memref<64xi32, "L1">
+//CHECK-NEXT:     %2 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>, alignment = 64 : i64}> : () -> memref<64xi32, "L1">
+//CHECK-NEXT:     %3 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>, alignment = 64 : i64}> : () -> memref<64xi32, "L1">
 //CHECK-NEXT:     "memref.copy"(%arg0, %0) : (memref<64xi32, "L3">, memref<64xi32, "L1">) -> ()
 //CHECK-NEXT:     "memref.copy"(%arg1, %1) : (memref<64xi32, "L3">, memref<64xi32, "L1">) -> ()
 //CHECK-NEXT:     "memref.copy"(%arg1, %3) : (memref<64xi32, "L3">, memref<64xi32, "L1">) -> ()

--- a/tests/filecheck/transforms/realize-memref-casts.mlir
+++ b/tests/filecheck/transforms/realize-memref-casts.mlir
@@ -223,7 +223,7 @@
 // CHECK-NEXT:    %11 = "memref.alloc"(%10) <{alignment = 64 : i64, operandSegmentSizes = array<i32: 1, 0>}> : (index) -> memref<?x128xi32, #tsl.tsl<[?, 8] -> (256, 4), [?, 8] -> (?, 32)>, "L1">
 // CHECK-NEXT:    "memref.copy"(%arg1, %8) : (memref<128x128xi8, "L3">, memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8), offset: 64>, "L1">) -> ()
 // CHECK-NEXT:    "memref.copy"(%arg0, %7) : (memref<?x128xi8, "L3">, memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, "L1">) -> ()
-// CHECK-NEXT:    "linalg.generic"(%7, %8, %0, %1, %11) <{indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>], operandSegmentSizes = array<i32: 4, 1>}> ({
+// CHECK-NEXT:    "linalg.generic"(%7, %8, %0, %1, %11) <{indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>], operandSegmentSizes = array<i32: 4, 1>, library_call = "snax_gemm"}> ({
 // CHECK-NEXT:    ^1(%arg3 : i8, %arg4 : i8, %arg5 : i32, %arg6 : i32, %arg7 : i32):
 // CHECK-NEXT:      %12 = "arith.extsi"(%arg3) : (i8) -> i32
 // CHECK-NEXT:      %13 = "arith.subi"(%12, %arg5) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
@@ -232,7 +232,7 @@
 // CHECK-NEXT:      %16 = "arith.muli"(%13, %15) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
 // CHECK-NEXT:      %17 = "arith.addi"(%arg7, %16) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
 // CHECK-NEXT:      "linalg.yield"(%17) : (i32) -> ()
-// CHECK-NEXT:    }) {library_call = "snax_gemm"} : (memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, "L1">, memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8), offset: 64>, "L1">, i32, i32, memref<?x128xi32, #tsl.tsl<[?, 8] -> (256, 4), [?, 8] -> (?, 32)>, "L1">) -> ()
+// CHECK-NEXT:    }) : (memref<?x128xi8, #tsl.tsl<[?, 8] -> (?, 8), [?, 8] -> (256, 1)>, "L1">, memref<128x128xi8, #tsl.tsl<[?, 8] -> (256, 1), [?, 8] -> (?, 8), offset: 64>, "L1">, i32, i32, memref<?x128xi32, #tsl.tsl<[?, 8] -> (256, 4), [?, 8] -> (?, 32)>, "L1">) -> ()
 // CHECK-NEXT:    "memref.copy"(%11, %arg2) : (memref<?x128xi32, #tsl.tsl<[?, 8] -> (256, 4), [?, 8] -> (?, 32)>, "L1">, memref<?x128xi32, "L3">) -> ()
 // CHECK-NEXT:    "func.return"(%arg2) : (memref<?x128xi32, "L3">) -> ()
 // CHECK-NEXT:  }) : () -> ()


### PR DESCRIPTION
this disables the mlperf tiny workflow because tensorflow is not updating fast enough, see #419 