### PR TITLE
transforms: (realize-memref-casts) refactor op rewriting 

### DIFF
--- a/snaxc/transforms/realize_memref_casts.py
+++ b/snaxc/transforms/realize_memref_casts.py
@@ -126,7 +126,6 @@ class RealizeMemrefCasts(RewritePattern):
                 new_constant_op = arith.ConstantOp(new_constant, new_constant.type)
                 rewriter.replace_op(const_source, new_constant_op)
 
-
         # now perform casting by inserting memref copies and allocs
         source_type = source_op.source.type
         assert isa(source_type, builtin.MemRefType[Attribute])


### PR DESCRIPTION
to enable more constant transformations with code reuse (not only arith.constant, but also memref.global)