### PR TITLE
transforms: (set-memory-space) handle func.return for different memory spaces

### DIFF
--- a/snaxc/transforms/set_memory_space.py
+++ b/snaxc/transforms/set_memory_space.py
@@ -197,15 +197,12 @@ class HandleFuncReturns(RewritePattern):
 
             if not isa(func_op_output, builtin.MemRefType[Attribute]):
                 new_arguments.append(func_return_output)
-                continue
-            if not isa(
+            elif not isa(
                 func_return_output_type := func_return_output.type,
                 builtin.MemRefType[Attribute],
             ):
                 new_arguments.append(func_return_output)
-                continue
-
-            if func_op_output.memory_space != func_return_output_type.memory_space:
+            elif func_op_output.memory_space != func_return_output_type.memory_space:
                 # create cast op
                 cast_op = memref.MemorySpaceCastOp.from_type_and_target_space(
                     func_return_output,
@@ -217,6 +214,8 @@ class HandleFuncReturns(RewritePattern):
                 # replace return value with cast
                 new_arguments.append(cast_op)
                 changes_made = True
+            else:
+                new_arguments.append(func_return_output)
 
         if not changes_made:
             return

--- a/tests/filecheck/transforms/set-memory-space.mlir
+++ b/tests/filecheck/transforms/set-memory-space.mlir
@@ -28,6 +28,23 @@ func.func public @test(%arg0 : memref<64xi32>) -> memref<64xi32> {
 
 // -----
 
+func.func public @test() -> (memref<64xi32>, memref<64xi32>) {
+  %0 = memref.get_global @constant : memref<64xi32>
+  %1 = memref.alloc() {alignment = 64 : i64} : memref<64xi32>
+  func.return %0, %1: memref<64xi32>, memref<64xi32>
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   func.func public @test() -> (memref<64xi32, "L3">, memref<64xi32, "L3">) {
+// CHECK-NEXT:     %0 = memref.get_global @constant : memref<64xi32, "L3">
+// CHECK-NEXT:     %1 = memref.alloc() {alignment = 64 : i64} : memref<64xi32, "L1">
+// CHECK-NEXT:     %2 = "memref.memory_space_cast"(%1) : (memref<64xi32, "L1">) -> memref<64xi32, "L3">
+// CHECK-NEXT:     func.return %0, %2 : memref<64xi32, "L3">, memref<64xi32, "L3">
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// -----
+
 func.func public @simple_mult(%arg0 : memref<64xi32>, %arg1 : memref<64xi32>, %arg2 : memref<64xi32>) {
   linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%arg0, %arg1 : memref<64xi32>, memref<64xi32>) outs(%arg2 : memref<64xi32>) {
   ^0(%arg3 : i32, %arg4 : i32, %arg5 : i32):


### PR DESCRIPTION
an else case was missing in the transform logic to handle this case