### PR TITLE
add initial configuration parsing scripts

### DIFF
--- a/snaxc/accelerators/acc_context.py
+++ b/snaxc/accelerators/acc_context.py
@@ -95,6 +95,9 @@ class AccContext(Context):
         """
         return self._registered_accelerators.keys()
 
+    def register_memory(self, memory: SnaxMemory) -> None:
+        self._memories[memory.attribute] = memory
+
     def get_memory(self, name: StringAttr) -> SnaxMemory:
         """
         Get a memory space by its name.

--- a/snaxc/tools/config_parser.py
+++ b/snaxc/tools/config_parser.py
@@ -1,0 +1,58 @@
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from xdsl.dialects.builtin import StringAttr
+from xdsl.utils.hints import isa
+
+from snaxc.accelerators.acc_context import AccContext
+from snaxc.accelerators.snax_gemmx import SNAXGEMMXAccelerator
+from snaxc.util.snax_memory import SnaxMemory
+
+
+@dataclass
+class Core:
+    accelerators: list[str]
+
+
+@dataclass
+class Cluster:
+    memory: SnaxMemory
+    cores: list[Core]
+
+
+def parse_config(config: Any) -> AccContext:
+    context = AccContext()
+    assert isa(config, dict[str, Any])
+
+    for key, value in config.items():
+        if key == "memory":
+            assert isa(value, dict[str, Any])
+            memory = parse_memory(value)
+            context.register_memory(memory)
+        elif re.fullmatch(r"cluster_(\d+)", key):
+            assert isa(value, dict[str, Any])
+            cluster = parse_cluster(value)
+            context.register_memory(cluster.memory)
+            for core in cluster.cores:
+                for accelerator in core.accelerators:
+                    if accelerator == "gemmx":
+                        context.register_accelerator(
+                            SNAXGEMMXAccelerator.name, lambda: SNAXGEMMXAccelerator()
+                        )
+        else:
+            raise ValueError(f"Unknown config key: {key}")
+
+    return context
+
+
+def parse_memory(config: dict[str, Any]) -> SnaxMemory:
+    assert set(config.keys()) == set(["name", "start", "size"])
+    return SnaxMemory(StringAttr(config["name"]), config["size"], config["start"])
+
+
+def parse_cluster(config: dict[str, Any]) -> Cluster:
+    return Cluster(
+        memory=parse_memory(config["memory"]),
+        cores=[Core(accelerators=list(core.keys())) for core in config["cores"]],
+    )


### PR DESCRIPTION
this PR adds initial functionality to parse a snax cluster configuration yaml file and build up an AccContext with it.
This can be used with `snaxc --config [file]`