### PR TITLE
 kernels: (alloc) use snax_alu specific config for use with snaxc tool 

### DIFF
--- a/kernels/alloc/Snakefile
+++ b/kernels/alloc/Snakefile
@@ -1,6 +1,6 @@
-from util.snake.configs import get_snax_mac_config
+from util.snake.configs import get_snax_alu_config
 
-config = get_snax_mac_config()
+config = get_snax_alu_config()
 
 
 module snax_rules:
@@ -23,7 +23,7 @@ rule compile_snax:
     output:
         temp("{file}_{alloc_mode}.ll.mlir"),
     shell:
-        "{config[snaxc]} --alloc-mode={wildcards.alloc_mode} -o {output} {input}"
+        "{config[snaxc]} --alloc-mode={wildcards.alloc_mode} -c {config[snaxc-config]} -o {output} {input}"
 
 
 # Rules

--- a/snaxc/accelerators/acc_context.py
+++ b/snaxc/accelerators/acc_context.py
@@ -3,12 +3,12 @@ from dataclasses import dataclass, field
 
 from xdsl.context import Context
 from xdsl.ir import Operation
-from xdsl.parser import ModuleOp, StringAttr
+from xdsl.parser import ModuleOp
 from xdsl.traits import SymbolTable
 
 from snaxc.accelerators.accelerator import Accelerator
 from snaxc.dialects.accfg import AcceleratorOp
-from snaxc.util.snax_memory import L1, L3, TEST, SnaxMemory
+from snaxc.util.snax_memory import SnaxMemory
 
 
 @dataclass
@@ -21,13 +21,7 @@ class AccContext(Context):
         default_factory=dict[str, Callable[[], Accelerator]]
     )
 
-    _memories: dict[StringAttr, SnaxMemory] = field(
-        default_factory=lambda: {
-            L3.attribute: L3,
-            L1.attribute: L1,
-            TEST.attribute: TEST,
-        }
-    )
+    _memories: dict[str, SnaxMemory] = field(default_factory=dict[str, SnaxMemory])
 
     def clone(self) -> "AccContext":
         return AccContext(
@@ -96,9 +90,9 @@ class AccContext(Context):
         return self._registered_accelerators.keys()
 
     def register_memory(self, memory: SnaxMemory) -> None:
-        self._memories[memory.attribute] = memory
+        self._memories[memory.attribute.data] = memory
 
-    def get_memory(self, name: StringAttr) -> SnaxMemory:
+    def get_memory(self, name: str) -> SnaxMemory:
         """
         Get a memory space by its name.
         Raises KeyError if the memory space is not registered.

--- a/snaxc/tools/snax_opt_main.py
+++ b/snaxc/tools/snax_opt_main.py
@@ -8,6 +8,7 @@ from xdsl.xdsl_opt_main import xDSLOptMain
 from snaxc.accelerators import AccContext, get_all_accelerators
 from snaxc.dialects import get_all_snax_dialects
 from snaxc.transforms import get_all_snax_passes
+from snaxc.util.snax_memory import L1, L3, TEST
 
 
 class SNAXOptMain(xDSLOptMain):
@@ -21,11 +22,13 @@ class SNAXOptMain(xDSLOptMain):
         self.available_targets = {}
 
         self.ctx: AccContext = AccContext()
+
         self.register_all_dialects()
         self.register_all_accelerators()
         self.register_all_frontends()
         self.register_all_passes()
         self.register_all_targets()
+        self.register_all_memories()
 
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)
@@ -55,6 +58,11 @@ class SNAXOptMain(xDSLOptMain):
     def register_all_accelerators(self):
         for accelerator_name, accelerator_factory in get_all_accelerators().items():
             self.ctx.register_accelerator(accelerator_name, accelerator_factory)
+
+    def register_all_memories(self):
+        self.ctx.register_memory(L1)
+        self.ctx.register_memory(L3)
+        self.ctx.register_memory(TEST)
 
 
 def main():

--- a/snaxc/transforms/snax_allocate.py
+++ b/snaxc/transforms/snax_allocate.py
@@ -158,7 +158,7 @@ class StaticAllocs(RewritePattern):
     No allocations are ever freed, so the address space is never reused.
     """
 
-    get_memory: Callable[[StringAttr], SnaxMemory]
+    get_memory: Callable[[str], SnaxMemory]
 
     current_addresses: dict[SnaxMemory, int] = field(
         default_factory=dict[SnaxMemory, int]
@@ -189,7 +189,7 @@ class StaticAllocs(RewritePattern):
 
         # get the memory space
         assert isinstance(op.memory_space, builtin.StringAttr)
-        memory = self.get_memory(op.memory_space)
+        memory = self.get_memory(op.memory_space.data)
 
         if memory not in self.current_addresses:
             self.current_addresses[memory] = memory.start
@@ -229,7 +229,7 @@ class MiniMallocate(RewritePattern):
     Lifetime is determined by the index of the first and last op it is used in.
     """
 
-    get_memory: Callable[[StringAttr], SnaxMemory]
+    get_memory: Callable[[str], SnaxMemory]
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, func_op: func.FuncOp, rewriter: PatternRewriter):
@@ -293,7 +293,7 @@ class MiniMallocate(RewritePattern):
         # Lifetime of the buffers is now determined, run the minimalloc algorithm for every memory space
         pointer_result: dict[str, int] = {}
         memory_spaces = set(
-            self.get_memory(cast(StringAttr, buffer_ops[buffer.id].memory_space))
+            self.get_memory(cast(StringAttr, buffer_ops[buffer.id].memory_space).data)
             for buffer in buffers
         )
         for memory in memory_spaces:

--- a/util/snake/configs.py
+++ b/util/snake/configs.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import Any
 
 from util.snake.flags import (
@@ -48,6 +49,7 @@ def get_snax_gemmx_config(snax_mlir_path: str | None = None) -> dict[str, Any]:
 def get_snax_alu_config(snax_mlir_path: str | None = None) -> dict[str, Any]:
     # use CONDA_PREFIX to access pixi env
     snax_utils_path = os.environ["CONDA_PREFIX"] + "/snax-utils"
+    utils_dir = Path(__file__).resolve().parent.parent
     snitch_sw_path = snax_utils_path + "/snax-alu"
     config: dict[str, Any] = {}
     config.update(get_default_paths())
@@ -56,6 +58,7 @@ def get_snax_alu_config(snax_mlir_path: str | None = None) -> dict[str, Any]:
     config["num_chips"] = 1
     config["num_harts"] = 2
     config["vltsim"] = snax_utils_path + "/snax-alu-rtl/bin/snitch_cluster.vlt"
+    config["snaxc-config"] = utils_dir / "ssot" / "snax_alu.yaml"
     return config
 
 


### PR DESCRIPTION
For this, the accelerator context changes somewhat so that not all memories are registered by default.
For snax-opt we explicitly then register all of them such that testing passes remain functional.