### PR TITLE
transforms: (frontend-transform) add frontend transform pass

### DIFF
--- a/snaxc/transforms/__init__.py
+++ b/snaxc/transforms/__init__.py
@@ -112,6 +112,11 @@ def get_all_snax_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return DispatchRegions
 
+    def get_frontend_transform():
+        from snaxc.transforms.frontend.frontend_transform import FrontendTransformPass
+
+        return FrontendTransformPass
+
     def get_insert_accfg_op():
         from snaxc.transforms.insert_accfg_op import InsertAccOp
 
@@ -258,6 +263,7 @@ def get_all_snax_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "dart-scheduler": get_dart_scheduler,
         "dispatch-kernels": get_dispatch_kernels,
         "dispatch-regions": get_dispatch_regions,
+        "frontend-transform": get_frontend_transform,
         "insert-accfg-op": get_insert_accfg_op,
         "insert-sync-barrier": get_insert_sync_barrier,
         "memref-to-snax": get_memref_to_snax,

--- a/snaxc/transforms/frontend/frontend_transform.py
+++ b/snaxc/transforms/frontend/frontend_transform.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass, field
+
+from xdsl.context import Context
+from xdsl.dialects import builtin
+from xdsl.passes import ModulePass
+from xdsl.transforms.mlir_opt import MLIROptPass
+
+MLIR_FLAGS: tuple[tuple[str, ...], ...] = (
+    (
+        "--transform-interpreter",
+        "--test-transform-dialect-erase-schedule",
+        "--mlir-print-op-generic",
+        "--mlir-print-local-scope",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class FrontendTransformPass(ModulePass):
+    name = "frontend-transform"
+
+    executable: str = field(default="mlir-opt")
+
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        for flags in MLIR_FLAGS:
+            MLIROptPass(generic=True, arguments=flags).apply(ctx, op)


### PR DESCRIPTION
to replace the calling of transform interpreter now present in the snakefiles

this doesn't allow for the use of binding trailing args, so transform scripts should use match operations instead of block arguments