### PR TITLE
tsl: fix bug when not inserting created ops

### DIFF
--- a/snaxc/dialects/tsl.py
+++ b/snaxc/dialects/tsl.py
@@ -214,12 +214,13 @@ class TiledStridedLayoutAttr(MemRefLayoutAttr, Data[TiledStridedLayout]):
         # the max static stride multiplied by the bound of that Stride
         # can be used as a starting value for the dynamic strides
         max_stride_op = ConstantOp.from_int_and_width(max_value, IndexType())
+        result.append(max_stride_op)
         dynamic_step = MuliOp(
             bound_ops[max_key],
             max_stride_op,
             IndexType(),
         )
-        result.append(max_stride_op)
+        result.append(dynamic_step)
 
         # assign strides right to left
         for dim in reversed(range(tsl.dimension())):
@@ -244,7 +245,7 @@ class TiledStridedLayoutAttr(MemRefLayoutAttr, Data[TiledStridedLayout]):
                         # else, follow contiguity assumption
                         step_op = dynamic_step
                     dynamic_step = MuliOp(step_op, bound_ops[(dim, depth)], IndexType())
-                    result.append(step_op)
+                    result.append(dynamic_step)
                     result_mapping[(dim, depth)] = step_op
         return result, result_mapping
 


### PR DESCRIPTION
this fixes a bug where the TSL code created operations that weren't inserted into the IR, which causes some tricky issues later