### PR TITLE
tsl: fix bug when not inserting created ops

### DIFF
--- a/snaxc/dialects/tsl.py
+++ b/snaxc/dialects/tsl.py
@@ -187,6 +187,7 @@ class TiledStridedLayoutAttr(MemRefLayoutAttr, Data[TiledStridedLayout]):
                 if tsl.get_stride(dim, depth).step is None:
                     # dynamic stride, assign to result of metadata op
                     stride = MuliOp(metadata_op.strides[dim], element_size_op)
+                    result.append(stride)
                     result_mapping[(dim, depth)] = stride
 
         # optional bytes correction
@@ -214,12 +215,13 @@ class TiledStridedLayoutAttr(MemRefLayoutAttr, Data[TiledStridedLayout]):
         # the max static stride multiplied by the bound of that Stride
         # can be used as a starting value for the dynamic strides
         max_stride_op = ConstantOp.from_int_and_width(max_value, IndexType())
+        result.append(max_stride_op)
         dynamic_step = MuliOp(
             bound_ops[max_key],
             max_stride_op,
             IndexType(),
         )
-        result.append(max_stride_op)
+        result.append(dynamic_step)
 
         # assign strides right to left
         for dim in reversed(range(tsl.dimension())):
@@ -244,7 +246,7 @@ class TiledStridedLayoutAttr(MemRefLayoutAttr, Data[TiledStridedLayout]):
                         # else, follow contiguity assumption
                         step_op = dynamic_step
                     dynamic_step = MuliOp(step_op, bound_ops[(dim, depth)], IndexType())
-                    result.append(step_op)
+                    result.append(dynamic_step)
                     result_mapping[(dim, depth)] = step_op
         return result, result_mapping
 

--- a/tests/filecheck/transforms/copy-to-dma-ignore-transform.mlir
+++ b/tests/filecheck/transforms/copy-to-dma-ignore-transform.mlir
@@ -11,4 +11,4 @@
 
 // but a very simple 1d transfer applied:
 
-// CHECK: func.call @snax_dma_1d_transfer(%0, %1, %26) : (index, index, index) -> ()
+// CHECK: func.call @snax_dma_1d_transfer(%0, %1, %{{.*}}) : (index, index, index) -> ()

--- a/tests/filecheck/transforms/copy_to_dma.mlir
+++ b/tests/filecheck/transforms/copy_to_dma.mlir
@@ -59,38 +59,40 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK:  builtin.module {
-// CHECK-NEXT:    func.func public @transform_copy(%arg0 : memref<5xi32, strided<[1], offset: ?>, "L3">, %arg1 : memref<5xi32, strided<[1], offset: ?>, "L1">) {
-// CHECK-NEXT:      %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<5xi32, strided<[1], offset: ?>, "L3">) -> index
-// CHECK-NEXT:      %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<5xi32, strided<[1], offset: ?>, "L1">) -> index
-// CHECK-NEXT:      %2, %3, %4, %5 = "memref.extract_strided_metadata"(%arg0) : (memref<5xi32, strided<[1], offset: ?>, "L3">) -> (memref<i32, "L3">, index, index, index)
-// CHECK-NEXT:      %6 = arith.constant 4 : index
-// CHECK-NEXT:      %7 = arith.muli %6, %3 : index
-// CHECK-NEXT:      %8 = arith.addi %0, %7 : index
-// CHECK-NEXT:      %9, %10, %11, %12 = "memref.extract_strided_metadata"(%arg1) : (memref<5xi32, strided<[1], offset: ?>, "L1">) -> (memref<i32, "L1">, index, index, index)
-// CHECK-NEXT:      %13 = arith.constant 4 : index
-// CHECK-NEXT:      %14 = arith.muli %13, %10 : index
-// CHECK-NEXT:      %15 = arith.addi %1, %14 : index
-// CHECK-NEXT:      %16 = arith.constant 0 : index
-// CHECK-NEXT:      %17 = "memref.dim"(%arg0, %16) : (memref<5xi32, strided<[1], offset: ?>, "L3">, index) -> index
-// CHECK-NEXT:      %18 = arith.constant 5 : index
-// CHECK-NEXT:      %19, %20, %21, %22 = "memref.extract_strided_metadata"(%arg0) : (memref<5xi32, strided<[1], offset: ?>, "L3">) -> (memref<i32, "L3">, index, index, index)
-// CHECK-NEXT:      %23 = arith.constant 4 : index
-// CHECK-NEXT:      %24 = arith.constant 4 : index
-// CHECK-NEXT:      %25 = arith.constant 4 : index
-// CHECK-NEXT:      %26, %27, %28, %29 = "memref.extract_strided_metadata"(%arg1) : (memref<5xi32, strided<[1], offset: ?>, "L1">) -> (memref<i32, "L1">, index, index, index)
-// CHECK-NEXT:      %30 = arith.constant 4 : index
-// CHECK-NEXT:      %31 = arith.constant 4 : index
-// CHECK-NEXT:      %32 = arith.constant 4 : index
-// CHECK-NEXT:      %33 = arith.constant 0 : index
-// CHECK-NEXT:      %34 = "memref.dim"(%arg0, %33) : (memref<5xi32, strided<[1], offset: ?>, "L3">, index) -> index
-// CHECK-NEXT:      %35 = arith.constant 4 : index
-// CHECK-NEXT:      %36 = arith.muli %34, %35 : index
-// CHECK-NEXT:      func.call @snax_dma_1d_transfer(%8, %15, %36) : (index, index, index) -> ()
-// CHECK-NEXT:      func.return
-// CHECK-NEXT:    }
-// CHECK-NEXT:    func.func private @snax_dma_1d_transfer(index, index, index) -> ()
-// CHECK-NEXT:  }
+// CHECK:      builtin.module {
+// CHECK-NEXT:   func.func public @transform_copy(%arg0 : memref<5xi32, strided<[1], offset: ?>, "L3">, %arg1 : memref<5xi32, strided<[1], offset: ?>, "L1">) {
+// CHECK-NEXT:     %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<5xi32, strided<[1], offset: ?>, "L3">) -> index
+// CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<5xi32, strided<[1], offset: ?>, "L1">) -> index
+// CHECK-NEXT:     %2, %3, %4, %5 = "memref.extract_strided_metadata"(%arg0) : (memref<5xi32, strided<[1], offset: ?>, "L3">) -> (memref<i32, "L3">, index, index, index)
+// CHECK-NEXT:     %6 = arith.constant 4 : index
+// CHECK-NEXT:     %7 = arith.muli %6, %3 : index
+// CHECK-NEXT:     %8 = arith.addi %0, %7 : index
+// CHECK-NEXT:     %9, %10, %11, %12 = "memref.extract_strided_metadata"(%arg1) : (memref<5xi32, strided<[1], offset: ?>, "L1">) -> (memref<i32, "L1">, index, index, index)
+// CHECK-NEXT:     %13 = arith.constant 4 : index
+// CHECK-NEXT:     %14 = arith.muli %13, %10 : index
+// CHECK-NEXT:     %15 = arith.addi %1, %14 : index
+// CHECK-NEXT:     %16 = arith.constant 0 : index
+// CHECK-NEXT:     %17 = "memref.dim"(%arg0, %16) : (memref<5xi32, strided<[1], offset: ?>, "L3">, index) -> index
+// CHECK-NEXT:     %18 = arith.constant 5 : index
+// CHECK-NEXT:     %19, %20, %21, %22 = "memref.extract_strided_metadata"(%arg0) : (memref<5xi32, strided<[1], offset: ?>, "L3">) -> (memref<i32, "L3">, index, index, index)
+// CHECK-NEXT:     %23 = arith.constant 4 : index
+// CHECK-NEXT:     %24 = arith.constant 4 : index
+// CHECK-NEXT:     %25 = arith.muli %18, %24 : index
+// CHECK-NEXT:     %26 = arith.constant 4 : index
+// CHECK-NEXT:     %27, %28, %29, %30 = "memref.extract_strided_metadata"(%arg1) : (memref<5xi32, strided<[1], offset: ?>, "L1">) -> (memref<i32, "L1">, index, index, index)
+// CHECK-NEXT:     %31 = arith.constant 4 : index
+// CHECK-NEXT:     %32 = arith.constant 4 : index
+// CHECK-NEXT:     %33 = arith.muli %18, %32 : index
+// CHECK-NEXT:     %34 = arith.constant 4 : index
+// CHECK-NEXT:     %35 = arith.constant 0 : index
+// CHECK-NEXT:     %36 = "memref.dim"(%arg0, %35) : (memref<5xi32, strided<[1], offset: ?>, "L3">, index) -> index
+// CHECK-NEXT:     %37 = arith.constant 4 : index
+// CHECK-NEXT:     %38 = arith.muli %36, %37 : index
+// CHECK-NEXT:     func.call @snax_dma_1d_transfer(%8, %15, %38) : (index, index, index) -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @snax_dma_1d_transfer(index, index, index) -> ()
+// CHECK-NEXT: }
 
 // -----
 
@@ -102,40 +104,44 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK:  builtin.module {
-// CHECK-NEXT:    func.func public @transform_copy(%arg0 : memref<?x?xi32, strided<[?, 1]>, "L3">, %arg1 : memref<?x?xi32, strided<[?, 1]>, "L1">) {
-// CHECK-NEXT:      %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?x?xi32, strided<[?, 1]>, "L3">) -> index
-// CHECK-NEXT:      %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?x?xi32, strided<[?, 1]>, "L1">) -> index
-// CHECK-NEXT:      %2 = arith.constant 0 : index
-// CHECK-NEXT:      %3 = "memref.dim"(%arg0, %2) : (memref<?x?xi32, strided<[?, 1]>, "L3">, index) -> index
-// CHECK-NEXT:      %4 = arith.constant 1 : index
-// CHECK-NEXT:      %5 = "memref.dim"(%arg0, %4) : (memref<?x?xi32, strided<[?, 1]>, "L3">, index) -> index
-// CHECK-NEXT:      %6 = arith.constant 1 : index
-// CHECK-NEXT:      %7 = arith.divui %3, %6 : index
-// CHECK-NEXT:      %8 = arith.constant 1 : index
-// CHECK-NEXT:      %9 = arith.divui %5, %8 : index
-// CHECK-NEXT:      %10, %11, %12, %13, %14, %15 = "memref.extract_strided_metadata"(%arg0) : (memref<?x?xi32, strided<[?, 1]>, "L3">) -> (memref<i32, "L3">, index, index, index, index, index)
-// CHECK-NEXT:      %16 = arith.constant 4 : index
-// CHECK-NEXT:      %17 = arith.constant 4 : index
-// CHECK-NEXT:      %18 = arith.constant 4 : index
-// CHECK-NEXT:      %19 = arith.muli %14, %16 : index
-// CHECK-NEXT:      %20, %21, %22, %23, %24, %25 = "memref.extract_strided_metadata"(%arg1) : (memref<?x?xi32, strided<[?, 1]>, "L1">) -> (memref<i32, "L1">, index, index, index, index, index)
-// CHECK-NEXT:      %26 = arith.constant 4 : index
-// CHECK-NEXT:      %27 = arith.constant 4 : index
-// CHECK-NEXT:      %28 = arith.constant 4 : index
-// CHECK-NEXT:      %29 = arith.muli %24, %26 : index
-// CHECK-NEXT:      %30 = arith.constant 0 : index
-// CHECK-NEXT:      %31 = "memref.dim"(%arg0, %30) : (memref<?x?xi32, strided<[?, 1]>, "L3">, index) -> index
-// CHECK-NEXT:      %32 = arith.constant 1 : index
-// CHECK-NEXT:      %33 = "memref.dim"(%arg0, %32) : (memref<?x?xi32, strided<[?, 1]>, "L3">, index) -> index
-// CHECK-NEXT:      %34 = arith.muli %31, %33 : index
-// CHECK-NEXT:      %35 = arith.constant 4 : index
-// CHECK-NEXT:      %36 = arith.muli %34, %35 : index
-// CHECK-NEXT:      func.call @snax_dma_1d_transfer(%0, %1, %36) : (index, index, index) -> ()
-// CHECK-NEXT:      func.return
-// CHECK-NEXT:    }
-// CHECK-NEXT:    func.func private @snax_dma_1d_transfer(index, index, index) -> ()
-// CHECK-NEXT:  }
+// CHECK:      builtin.module {
+// CHECK-NEXT:   func.func public @transform_copy(%arg0 : memref<?x?xi32, strided<[?, 1]>, "L3">, %arg1 : memref<?x?xi32, strided<[?, 1]>, "L1">) {
+// CHECK-NEXT:     %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?x?xi32, strided<[?, 1]>, "L3">) -> index
+// CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?x?xi32, strided<[?, 1]>, "L1">) -> index
+// CHECK-NEXT:     %2 = arith.constant 0 : index
+// CHECK-NEXT:     %3 = "memref.dim"(%arg0, %2) : (memref<?x?xi32, strided<[?, 1]>, "L3">, index) -> index
+// CHECK-NEXT:     %4 = arith.constant 1 : index
+// CHECK-NEXT:     %5 = "memref.dim"(%arg0, %4) : (memref<?x?xi32, strided<[?, 1]>, "L3">, index) -> index
+// CHECK-NEXT:     %6 = arith.constant 1 : index
+// CHECK-NEXT:     %7 = arith.divui %3, %6 : index
+// CHECK-NEXT:     %8 = arith.constant 1 : index
+// CHECK-NEXT:     %9 = arith.divui %5, %8 : index
+// CHECK-NEXT:     %10, %11, %12, %13, %14, %15 = "memref.extract_strided_metadata"(%arg0) : (memref<?x?xi32, strided<[?, 1]>, "L3">) -> (memref<i32, "L3">, index, index, index, index, index)
+// CHECK-NEXT:     %16 = arith.constant 4 : index
+// CHECK-NEXT:     %17 = arith.muli %14, %16 : index
+// CHECK-NEXT:     %18 = arith.constant 4 : index
+// CHECK-NEXT:     %19 = arith.muli %9, %18 : index
+// CHECK-NEXT:     %20 = arith.constant 4 : index
+// CHECK-NEXT:     %21 = arith.muli %17, %7 : index
+// CHECK-NEXT:     %22, %23, %24, %25, %26, %27 = "memref.extract_strided_metadata"(%arg1) : (memref<?x?xi32, strided<[?, 1]>, "L1">) -> (memref<i32, "L1">, index, index, index, index, index)
+// CHECK-NEXT:     %28 = arith.constant 4 : index
+// CHECK-NEXT:     %29 = arith.muli %26, %28 : index
+// CHECK-NEXT:     %30 = arith.constant 4 : index
+// CHECK-NEXT:     %31 = arith.muli %9, %30 : index
+// CHECK-NEXT:     %32 = arith.constant 4 : index
+// CHECK-NEXT:     %33 = arith.muli %29, %7 : index
+// CHECK-NEXT:     %34 = arith.constant 0 : index
+// CHECK-NEXT:     %35 = "memref.dim"(%arg0, %34) : (memref<?x?xi32, strided<[?, 1]>, "L3">, index) -> index
+// CHECK-NEXT:     %36 = arith.constant 1 : index
+// CHECK-NEXT:     %37 = "memref.dim"(%arg0, %36) : (memref<?x?xi32, strided<[?, 1]>, "L3">, index) -> index
+// CHECK-NEXT:     %38 = arith.muli %35, %37 : index
+// CHECK-NEXT:     %39 = arith.constant 4 : index
+// CHECK-NEXT:     %40 = arith.muli %38, %39 : index
+// CHECK-NEXT:     func.call @snax_dma_1d_transfer(%0, %1, %40) : (index, index, index) -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @snax_dma_1d_transfer(index, index, index) -> ()
+// CHECK-NEXT: }
 
 // -----
 
@@ -147,32 +153,34 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK:  builtin.module {
-// CHECK-NEXT:    func.func public @simple_mult(%arg0 : memref<5x5xi32, strided<[10, 1]>>, %arg1 : memref<5x5xi32, strided<[20, 1]>>) {
-// CHECK-NEXT:      %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<5x5xi32, strided<[10, 1]>>) -> index
-// CHECK-NEXT:      %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<5x5xi32, strided<[20, 1]>>) -> index
-// CHECK-NEXT:      %2 = arith.constant 0 : index
-// CHECK-NEXT:      %3 = "memref.dim"(%arg0, %2) : (memref<5x5xi32, strided<[10, 1]>>, index) -> index
-// CHECK-NEXT:      %4 = arith.constant 1 : index
-// CHECK-NEXT:      %5 = "memref.dim"(%arg0, %4) : (memref<5x5xi32, strided<[10, 1]>>, index) -> index
-// CHECK-NEXT:      %6 = arith.constant 5 : index
-// CHECK-NEXT:      %7 = arith.constant 5 : index
-// CHECK-NEXT:      %8, %9, %10, %11, %12, %13 = "memref.extract_strided_metadata"(%arg0) : (memref<5x5xi32, strided<[10, 1]>>) -> (memref<i32>, index, index, index, index, index)
-// CHECK-NEXT:      %14 = arith.constant 4 : index
-// CHECK-NEXT:      %15 = arith.constant 40 : index
-// CHECK-NEXT:      %16 = arith.constant 4 : index
-// CHECK-NEXT:      %17 = arith.constant 40 : index
-// CHECK-NEXT:      %18, %19, %20, %21, %22, %23 = "memref.extract_strided_metadata"(%arg1) : (memref<5x5xi32, strided<[20, 1]>>) -> (memref<i32>, index, index, index, index, index)
-// CHECK-NEXT:      %24 = arith.constant 4 : index
-// CHECK-NEXT:      %25 = arith.constant 80 : index
-// CHECK-NEXT:      %26 = arith.constant 4 : index
-// CHECK-NEXT:      %27 = arith.constant 80 : index
-// CHECK-NEXT:      %28 = arith.constant 20 : index
-// CHECK-NEXT:      func.call @snax_dma_2d_transfer(%0, %1, %28, %17, %27, %6) : (index, index, index, index, index, index) -> ()
-// CHECK-NEXT:      func.return
-// CHECK-NEXT:    }
-// CHECK-NEXT:    func.func private @snax_dma_2d_transfer(index, index, index, index, index, index) -> ()
-// CHECK-NEXT:  }
+// CHECK:      builtin.module {
+// CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<5x5xi32, strided<[10, 1]>>, %arg1 : memref<5x5xi32, strided<[20, 1]>>) {
+// CHECK-NEXT:     %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<5x5xi32, strided<[10, 1]>>) -> index
+// CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<5x5xi32, strided<[20, 1]>>) -> index
+// CHECK-NEXT:     %2 = arith.constant 0 : index
+// CHECK-NEXT:     %3 = "memref.dim"(%arg0, %2) : (memref<5x5xi32, strided<[10, 1]>>, index) -> index
+// CHECK-NEXT:     %4 = arith.constant 1 : index
+// CHECK-NEXT:     %5 = "memref.dim"(%arg0, %4) : (memref<5x5xi32, strided<[10, 1]>>, index) -> index
+// CHECK-NEXT:     %6 = arith.constant 5 : index
+// CHECK-NEXT:     %7 = arith.constant 5 : index
+// CHECK-NEXT:     %8, %9, %10, %11, %12, %13 = "memref.extract_strided_metadata"(%arg0) : (memref<5x5xi32, strided<[10, 1]>>) -> (memref<i32>, index, index, index, index, index)
+// CHECK-NEXT:     %14 = arith.constant 4 : index
+// CHECK-NEXT:     %15 = arith.constant 40 : index
+// CHECK-NEXT:     %16 = arith.muli %6, %15 : index
+// CHECK-NEXT:     %17 = arith.constant 4 : index
+// CHECK-NEXT:     %18 = arith.constant 40 : index
+// CHECK-NEXT:     %19, %20, %21, %22, %23, %24 = "memref.extract_strided_metadata"(%arg1) : (memref<5x5xi32, strided<[20, 1]>>) -> (memref<i32>, index, index, index, index, index)
+// CHECK-NEXT:     %25 = arith.constant 4 : index
+// CHECK-NEXT:     %26 = arith.constant 80 : index
+// CHECK-NEXT:     %27 = arith.muli %6, %26 : index
+// CHECK-NEXT:     %28 = arith.constant 4 : index
+// CHECK-NEXT:     %29 = arith.constant 80 : index
+// CHECK-NEXT:     %30 = arith.constant 20 : index
+// CHECK-NEXT:     func.call @snax_dma_2d_transfer(%0, %1, %30, %18, %29, %6) : (index, index, index, index, index, index) -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @snax_dma_2d_transfer(index, index, index, index, index, index) -> ()
+// CHECK-NEXT: }
 
 // -----
 
@@ -184,45 +192,47 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK:  builtin.module {
-// CHECK-NEXT:    func.func public @transform_copy(%arg0 : memref<8x8xi32, #tsl.tsl<[2, 4] -> (4, 1), [2, 4] -> (32, 8)>, "L3">, %arg1 : memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 1), [2, 4] -> (32, 4)>, "L1">) {
-// CHECK-NEXT:      %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<8x8xi32, #tsl.tsl<[2, 4] -> (4, 1), [2, 4] -> (32, 8)>, "L3">) -> index
-// CHECK-NEXT:      %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 1), [2, 4] -> (32, 4)>, "L1">) -> index
-// CHECK-NEXT:      %2 = arith.constant 0 : index
-// CHECK-NEXT:      %3 = "memref.dim"(%arg0, %2) : (memref<8x8xi32, #tsl.tsl<[2, 4] -> (4, 1), [2, 4] -> (32, 8)>, "L3">, index) -> index
-// CHECK-NEXT:      %4 = arith.constant 1 : index
-// CHECK-NEXT:      %5 = "memref.dim"(%arg0, %4) : (memref<8x8xi32, #tsl.tsl<[2, 4] -> (4, 1), [2, 4] -> (32, 8)>, "L3">, index) -> index
-// CHECK-NEXT:      %6 = arith.constant 2 : index
-// CHECK-NEXT:      %7 = arith.constant 4 : index
-// CHECK-NEXT:      %8 = arith.constant 2 : index
-// CHECK-NEXT:      %9 = arith.constant 4 : index
-// CHECK-NEXT:      %10 = arith.constant 128 : index
-// CHECK-NEXT:      %11 = arith.constant 32 : index
-// CHECK-NEXT:      %12 = arith.constant 128 : index
-// CHECK-NEXT:      %13 = arith.constant 4 : index
-// CHECK-NEXT:      %14 = arith.constant 16 : index
-// CHECK-NEXT:      %15 = arith.constant 128 : index
-// CHECK-NEXT:      %16 = arith.constant 16 : index
-// CHECK-NEXT:      %17 = arith.constant 128 : index
-// CHECK-NEXT:      %18 = arith.constant 4 : index
-// CHECK-NEXT:      %19 = arith.constant 64 : index
-// CHECK-NEXT:      %20 = arith.constant 16 : index
-// CHECK-NEXT:      %21 = arith.constant 0 : index
-// CHECK-NEXT:      %22 = arith.constant 1 : index
-// CHECK-NEXT:      scf.for %23 = %21 to %6 step %22 {
-// CHECK-NEXT:        %24 = arith.muli %23, %14 : index
-// CHECK-NEXT:        %25 = arith.addi %0, %24 : index
-// CHECK-NEXT:        %26 = arith.muli %23, %19 : index
-// CHECK-NEXT:        %27 = arith.addi %1, %26 : index
-// CHECK-NEXT:        scf.for %28 = %21 to %8 step %22 {
-// CHECK-NEXT:          %29 = arith.muli %28, %12 : index
-// CHECK-NEXT:          %30 = arith.addi %25, %29 : index
-// CHECK-NEXT:          %31 = arith.muli %28, %17 : index
-// CHECK-NEXT:          %32 = arith.addi %27, %31 : index
-// CHECK-NEXT:          func.call @snax_dma_2d_transfer(%30, %32, %20, %11, %16, %9) : (index, index, index, index, index, index) -> ()
-// CHECK-NEXT:        }
-// CHECK-NEXT:      }
-// CHECK-NEXT:      func.return
-// CHECK-NEXT:    }
-// CHECK-NEXT:    func.func private @snax_dma_2d_transfer(index, index, index, index, index, index) -> ()
-// CHECK-NEXT:  }
+// CHECK:      builtin.module {
+// CHECK-NEXT:   func.func public @transform_copy(%arg0 : memref<8x8xi32, #tsl.tsl<[2, 4] -> (4, 1), [2, 4] -> (32, 8)>, "L3">, %arg1 : memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 1), [2, 4] -> (32, 4)>, "L1">) {
+// CHECK-NEXT:     %0 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<8x8xi32, #tsl.tsl<[2, 4] -> (4, 1), [2, 4] -> (32, 8)>, "L3">) -> index
+// CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 1), [2, 4] -> (32, 4)>, "L1">) -> index
+// CHECK-NEXT:     %2 = arith.constant 0 : index
+// CHECK-NEXT:     %3 = "memref.dim"(%arg0, %2) : (memref<8x8xi32, #tsl.tsl<[2, 4] -> (4, 1), [2, 4] -> (32, 8)>, "L3">, index) -> index
+// CHECK-NEXT:     %4 = arith.constant 1 : index
+// CHECK-NEXT:     %5 = "memref.dim"(%arg0, %4) : (memref<8x8xi32, #tsl.tsl<[2, 4] -> (4, 1), [2, 4] -> (32, 8)>, "L3">, index) -> index
+// CHECK-NEXT:     %6 = arith.constant 2 : index
+// CHECK-NEXT:     %7 = arith.constant 4 : index
+// CHECK-NEXT:     %8 = arith.constant 2 : index
+// CHECK-NEXT:     %9 = arith.constant 4 : index
+// CHECK-NEXT:     %10 = arith.constant 128 : index
+// CHECK-NEXT:     %11 = arith.muli %8, %10 : index
+// CHECK-NEXT:     %12 = arith.constant 32 : index
+// CHECK-NEXT:     %13 = arith.constant 128 : index
+// CHECK-NEXT:     %14 = arith.constant 4 : index
+// CHECK-NEXT:     %15 = arith.constant 16 : index
+// CHECK-NEXT:     %16 = arith.constant 128 : index
+// CHECK-NEXT:     %17 = arith.muli %8, %16 : index
+// CHECK-NEXT:     %18 = arith.constant 16 : index
+// CHECK-NEXT:     %19 = arith.constant 128 : index
+// CHECK-NEXT:     %20 = arith.constant 4 : index
+// CHECK-NEXT:     %21 = arith.constant 64 : index
+// CHECK-NEXT:     %22 = arith.constant 16 : index
+// CHECK-NEXT:     %23 = arith.constant 0 : index
+// CHECK-NEXT:     %24 = arith.constant 1 : index
+// CHECK-NEXT:     scf.for %25 = %23 to %6 step %24 {
+// CHECK-NEXT:       %26 = arith.muli %25, %15 : index
+// CHECK-NEXT:       %27 = arith.addi %0, %26 : index
+// CHECK-NEXT:       %28 = arith.muli %25, %21 : index
+// CHECK-NEXT:       %29 = arith.addi %1, %28 : index
+// CHECK-NEXT:       scf.for %30 = %23 to %8 step %24 {
+// CHECK-NEXT:         %31 = arith.muli %30, %13 : index
+// CHECK-NEXT:         %32 = arith.addi %27, %31 : index
+// CHECK-NEXT:         %33 = arith.muli %30, %19 : index
+// CHECK-NEXT:         %34 = arith.addi %29, %33 : index
+// CHECK-NEXT:         func.call @snax_dma_2d_transfer(%32, %34, %22, %12, %18, %9) : (index, index, index, index, index, index) -> ()
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @snax_dma_2d_transfer(index, index, index, index, index, index) -> ()
+// CHECK-NEXT: }

--- a/tests/filecheck/transforms/memref_to_snax.mlir
+++ b/tests/filecheck/transforms/memref_to_snax.mlir
@@ -49,41 +49,42 @@
   %0 = "memref.alloc"() <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, "L1">
 }) : () -> ()
 
-// CHECK:  builtin.module {
-// CHECK-NEXT:    %0 = arith.constant 8 : index
-// CHECK-NEXT:    %1 = arith.constant 8 : index
-// CHECK-NEXT:    %2 = arith.constant 2 : index
-// CHECK-NEXT:    %3 = arith.constant 4 : index
-// CHECK-NEXT:    %4 = arith.constant 2 : index
-// CHECK-NEXT:    %5 = arith.constant 4 : index
-// CHECK-NEXT:    %6 = arith.constant 512 : index
-// CHECK-NEXT:    %7 = arith.constant 128 : index
-// CHECK-NEXT:    %8 = arith.constant 512 : index
-// CHECK-NEXT:    %9 = arith.constant 16 : index
-// CHECK-NEXT:    %10 = arith.constant 64 : index
-// CHECK-NEXT:    %11 = arith.constant 1 : index
-// CHECK-NEXT:    %12 = arith.constant 0 : index
-// CHECK-NEXT:    %13 = arith.subi %2, %11 : index
-// CHECK-NEXT:    %14 = arith.muli %13, %10 : index
-// CHECK-NEXT:    %15 = arith.addi %12, %14 : index
-// CHECK-NEXT:    %16 = arith.subi %3, %11 : index
-// CHECK-NEXT:    %17 = arith.muli %16, %9 : index
-// CHECK-NEXT:    %18 = arith.addi %15, %17 : index
-// CHECK-NEXT:    %19 = arith.subi %4, %11 : index
-// CHECK-NEXT:    %20 = arith.muli %19, %8 : index
-// CHECK-NEXT:    %21 = arith.addi %18, %20 : index
-// CHECK-NEXT:    %22 = arith.subi %5, %11 : index
-// CHECK-NEXT:    %23 = arith.muli %22, %7 : index
-// CHECK-NEXT:    %24 = arith.addi %21, %23 : index
-// CHECK-NEXT:    %25 = arith.constant 4 : index
-// CHECK-NEXT:    %26 = arith.addi %24, %25 : index
-// CHECK-NEXT:    %27 = arith.muli %11, %26 : index
-// CHECK-NEXT:    %28 = arith.constant 0 : index
-// CHECK-NEXT:    %29 = arith.muli %28, %25 : index
-// CHECK-NEXT:    %30 = arith.addi %27, %29 : index
-// CHECK-NEXT:    %31 = "snax.alloc"(%30, %0, %1) <{memory_space = "L1", alignment = 64 : i64}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
-// CHECK-NEXT:    %32 = builtin.unrealized_conversion_cast %31 : !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)> to memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, "L1">
-// CHECK-NEXT:  }
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %0 = arith.constant 8 : index
+// CHECK-NEXT:   %1 = arith.constant 8 : index
+// CHECK-NEXT:   %2 = arith.constant 2 : index
+// CHECK-NEXT:   %3 = arith.constant 4 : index
+// CHECK-NEXT:   %4 = arith.constant 2 : index
+// CHECK-NEXT:   %5 = arith.constant 4 : index
+// CHECK-NEXT:   %6 = arith.constant 512 : index
+// CHECK-NEXT:   %7 = arith.muli %4, %6 : index
+// CHECK-NEXT:   %8 = arith.constant 128 : index
+// CHECK-NEXT:   %9 = arith.constant 512 : index
+// CHECK-NEXT:   %10 = arith.constant 16 : index
+// CHECK-NEXT:   %11 = arith.constant 64 : index
+// CHECK-NEXT:   %12 = arith.constant 1 : index
+// CHECK-NEXT:   %13 = arith.constant 0 : index
+// CHECK-NEXT:   %14 = arith.subi %2, %12 : index
+// CHECK-NEXT:   %15 = arith.muli %14, %11 : index
+// CHECK-NEXT:   %16 = arith.addi %13, %15 : index
+// CHECK-NEXT:   %17 = arith.subi %3, %12 : index
+// CHECK-NEXT:   %18 = arith.muli %17, %10 : index
+// CHECK-NEXT:   %19 = arith.addi %16, %18 : index
+// CHECK-NEXT:   %20 = arith.subi %4, %12 : index
+// CHECK-NEXT:   %21 = arith.muli %20, %9 : index
+// CHECK-NEXT:   %22 = arith.addi %19, %21 : index
+// CHECK-NEXT:   %23 = arith.subi %5, %12 : index
+// CHECK-NEXT:   %24 = arith.muli %23, %8 : index
+// CHECK-NEXT:   %25 = arith.addi %22, %24 : index
+// CHECK-NEXT:   %26 = arith.constant 4 : index
+// CHECK-NEXT:   %27 = arith.addi %25, %26 : index
+// CHECK-NEXT:   %28 = arith.muli %12, %27 : index
+// CHECK-NEXT:   %29 = arith.constant 0 : index
+// CHECK-NEXT:   %30 = arith.muli %29, %26 : index
+// CHECK-NEXT:   %31 = arith.addi %28, %30 : index
+// CHECK-NEXT:   %32 = "snax.alloc"(%31, %0, %1) <{memory_space = "L1", alignment = 64 : i64}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %33 = builtin.unrealized_conversion_cast %32 : !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)> to memref<8x8xi32, #tsl.tsl<[2, 4] -> (16, 4), [2, 4] -> (128, 32)>, "L1">
+// CHECK-NEXT: }
 
 // -----
 
@@ -92,40 +93,40 @@
   %1 = "memref.alloc"(%0) <{"alignment" = 64 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (?, 32)>, "L1">
 }) : () -> ()
 
-
-// CHECK:  builtin.module {
-// CHECK-NEXT:    %0 = "test.op"() : () -> index
-// CHECK-NEXT:    %1 = arith.constant 8 : index
-// CHECK-NEXT:    %2 = arith.constant 2 : index
-// CHECK-NEXT:    %3 = arith.constant 4 : index
-// CHECK-NEXT:    %4 = arith.constant 4 : index
-// CHECK-NEXT:    %5 = arith.divui %0, %4 : index
-// CHECK-NEXT:    %6 = arith.constant 4 : index
-// CHECK-NEXT:    %7 = arith.constant 128 : index
-// CHECK-NEXT:    %8 = arith.constant 128 : index
-// CHECK-NEXT:    %9 = arith.muli %6, %7 : index
-// CHECK-NEXT:    %10 = arith.constant 16 : index
-// CHECK-NEXT:    %11 = arith.constant 64 : index
-// CHECK-NEXT:    %12 = arith.constant 1 : index
-// CHECK-NEXT:    %13 = arith.constant 0 : index
-// CHECK-NEXT:    %14 = arith.subi %2, %12 : index
-// CHECK-NEXT:    %15 = arith.muli %14, %11 : index
-// CHECK-NEXT:    %16 = arith.addi %13, %15 : index
-// CHECK-NEXT:    %17 = arith.subi %3, %12 : index
-// CHECK-NEXT:    %18 = arith.muli %17, %10 : index
-// CHECK-NEXT:    %19 = arith.addi %16, %18 : index
-// CHECK-NEXT:    %20 = arith.subi %5, %12 : index
-// CHECK-NEXT:    %21 = arith.muli %20, %9 : index
-// CHECK-NEXT:    %22 = arith.addi %19, %21 : index
-// CHECK-NEXT:    %23 = arith.subi %6, %12 : index
-// CHECK-NEXT:    %24 = arith.muli %23, %8 : index
-// CHECK-NEXT:    %25 = arith.addi %22, %24 : index
-// CHECK-NEXT:    %26 = arith.constant 4 : index
-// CHECK-NEXT:    %27 = arith.addi %25, %26 : index
-// CHECK-NEXT:    %28 = arith.muli %12, %27 : index
-// CHECK-NEXT:    %29 = arith.constant 0 : index
-// CHECK-NEXT:    %30 = arith.muli %29, %26 : index
-// CHECK-NEXT:    %31 = arith.addi %28, %30 : index
-// CHECK-NEXT:    %32 = "snax.alloc"(%31, %1, %0) <{memory_space = "L1", alignment = 64 : i64}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
-// CHECK-NEXT:    %33 = builtin.unrealized_conversion_cast %32 : !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)> to memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (?, 32)>, "L1">
-// CHECK-NEXT:  }
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %0 = "test.op"() : () -> index
+// CHECK-NEXT:   %1 = arith.constant 8 : index
+// CHECK-NEXT:   %2 = arith.constant 2 : index
+// CHECK-NEXT:   %3 = arith.constant 4 : index
+// CHECK-NEXT:   %4 = arith.constant 4 : index
+// CHECK-NEXT:   %5 = arith.divui %0, %4 : index
+// CHECK-NEXT:   %6 = arith.constant 4 : index
+// CHECK-NEXT:   %7 = arith.constant 128 : index
+// CHECK-NEXT:   %8 = arith.muli %6, %7 : index
+// CHECK-NEXT:   %9 = arith.constant 128 : index
+// CHECK-NEXT:   %10 = arith.muli %8, %5 : index
+// CHECK-NEXT:   %11 = arith.constant 16 : index
+// CHECK-NEXT:   %12 = arith.constant 64 : index
+// CHECK-NEXT:   %13 = arith.constant 1 : index
+// CHECK-NEXT:   %14 = arith.constant 0 : index
+// CHECK-NEXT:   %15 = arith.subi %2, %13 : index
+// CHECK-NEXT:   %16 = arith.muli %15, %12 : index
+// CHECK-NEXT:   %17 = arith.addi %14, %16 : index
+// CHECK-NEXT:   %18 = arith.subi %3, %13 : index
+// CHECK-NEXT:   %19 = arith.muli %18, %11 : index
+// CHECK-NEXT:   %20 = arith.addi %17, %19 : index
+// CHECK-NEXT:   %21 = arith.subi %5, %13 : index
+// CHECK-NEXT:   %22 = arith.muli %21, %8 : index
+// CHECK-NEXT:   %23 = arith.addi %20, %22 : index
+// CHECK-NEXT:   %24 = arith.subi %6, %13 : index
+// CHECK-NEXT:   %25 = arith.muli %24, %9 : index
+// CHECK-NEXT:   %26 = arith.addi %23, %25 : index
+// CHECK-NEXT:   %27 = arith.constant 4 : index
+// CHECK-NEXT:   %28 = arith.addi %26, %27 : index
+// CHECK-NEXT:   %29 = arith.muli %13, %28 : index
+// CHECK-NEXT:   %30 = arith.constant 0 : index
+// CHECK-NEXT:   %31 = arith.muli %30, %27 : index
+// CHECK-NEXT:   %32 = arith.addi %29, %31 : index
+// CHECK-NEXT:   %33 = "snax.alloc"(%32, %1, %0) <{memory_space = "L1", alignment = 64 : i64}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+// CHECK-NEXT:   %34 = builtin.unrealized_conversion_cast %33 : !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)> to memref<8x?xi32, #tsl.tsl<[2, 4] -> (16, 4), [?, 4] -> (?, 32)>, "L1">
+// CHECK-NEXT: }


### PR DESCRIPTION
this fixes a bug where the TSL code created operations that weren't inserted into the IR, which causes some tricky issues later