### PR TITLE
transforms: (dispatch-regions) erase ops that are not inserted

### DIFF
--- a/snaxc/transforms/dispatch_regions.py
+++ b/snaxc/transforms/dispatch_regions.py
@@ -101,6 +101,9 @@ class DispatchRegionsRewriter(RewritePattern):
             rewriter.insert_op(
                 call_and_condition_dm, InsertPoint.at_start(func_op.body.blocks[0])
             )
+        else:
+            comparison_dm.erase()
+            cst_1.erase()
 
         ## dispatch compute core ops, insert function call
         # in dominator block if changes made
@@ -122,6 +125,9 @@ class DispatchRegionsRewriter(RewritePattern):
                     [func_call, *condition_compute],
                     InsertPoint.at_start(func_op.body.blocks[0]),
                 )
+        else:
+            comparison_compute.erase()
+            cst_0.erase()
 
 
 class InsertFunctionDeclaration(RewritePattern):


### PR DESCRIPTION
creating ops that are not used can cause issues with xdsl