### PR TITLE
kernels: (streamer_matmul) make use of new transform pass

### DIFF
--- a/kernels/streamer_matmul/Snakefile
+++ b/kernels/streamer_matmul/Snakefile
@@ -30,10 +30,6 @@ config["snaxoptflags"] = ",".join(
     ]
 )
 
-config["mlirtransformflags"] = [
-    "--pass-pipeline='builtin.module(transform-interpreter{debug-bind-trailing-args=linalg.quantized_matmul}, test-transform-dialect-erase-schedule)'"
-]
-
 
 module snax_rules:
     snakefile:
@@ -81,7 +77,7 @@ rule apply_transforms_mlir:
     output:
         "{file}.mlir",
     shell:
-        "{config[mlir-opt]} {config[mlirtransformflags]} --mlir-print-op-generic --mlir-print-local-scope -o {output} {input}"
+        "{config[snax-opt]} -p frontend-transform -o {output} {input}"
 
 
 def get_main_obj(wildcards):


### PR DESCRIPTION
embedding the functionality in snax-opt rather than having to call mlir-opt seperately

we can't use the transform binding args anymore though, so we need to add the match statement to the transform script