### PR TITLE
transforms: (frontend-transform) only apply mlir pass if module contains transform script

### DIFF
--- a/kernels/streamer_matmul/Snakefile
+++ b/kernels/streamer_matmul/Snakefile
@@ -3,6 +3,7 @@ from util.snake.configs import get_snax_gemmx_config
 config = get_snax_gemmx_config()
 config["snaxoptflags"] = ",".join(
     [
+        "frontend-transform",
         "preprocess",
         "convert-linalg-to-kernel",
         "insert-accfg-op{accelerator=snax_gemmx}",
@@ -66,18 +67,9 @@ rule generate_matmul_i8_out:
 
 rule generate_tiled_quantized_matmul:
     output:
-        "tiled_quantized_matmul.transform.mlir",
+        "tiled_quantized_matmul.mlir",
     script:
         "tiled_quantized_matmul.py"
-
-
-rule apply_transforms_mlir:
-    input:
-        "{file}.transform.mlir",
-    output:
-        "{file}.mlir",
-    shell:
-        "{config[snax-opt]} -p frontend-transform -o {output} {input}"
 
 
 def get_main_obj(wildcards):

--- a/kernels/streamer_matmul/tiled_quantized_matmul.py
+++ b/kernels/streamer_matmul/tiled_quantized_matmul.py
@@ -92,7 +92,7 @@ def matmul(m=16, n=16, k=16):
 if __name__ == "__main__":
     # Get the name of the current Python script and replace its extension with .mlir
     script_name = os.path.basename(__file__)
-    mlir_filename = os.path.splitext(script_name)[0] + ".transform.mlir"
+    mlir_filename = os.path.splitext(script_name)[0] + ".mlir"
 
     # Generate IR and write it to the specified MLIR file
     output = StringIO()

--- a/snaxc/transforms/frontend/frontend_transform.py
+++ b/snaxc/transforms/frontend/frontend_transform.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 
 from xdsl.context import Context
 from xdsl.dialects import builtin
+from xdsl.dialects.transform import NamedSequenceOp
 from xdsl.passes import ModulePass
 from xdsl.transforms.mlir_opt import MLIROptPass
 
@@ -22,5 +23,8 @@ class FrontendTransformPass(ModulePass):
     executable: str = field(default="mlir-opt")
 
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        # only apply the pass if the module contians a transform script
+        if not any(isinstance(operation, NamedSequenceOp) for operation in op.ops):
+            return
         for flags in MLIR_FLAGS:
             MLIROptPass(generic=True, arguments=flags).apply(ctx, op)


### PR DESCRIPTION
such that the pass can be applied to any ir (even those without transform script) without erroring out

this gets rid of the seperate rule in the streamer matmul kernel