### PR TITLE
kernels: (rescale) use snaxc tool

### DIFF
--- a/kernels/rescale/Snakefile
+++ b/kernels/rescale/Snakefile
@@ -1,29 +1,29 @@
 from util.snake.configs import get_snax_gemmx_config
 
 config = get_snax_gemmx_config()
-config["snaxoptflags"] = ",".join(
-    [
-        "insert-accfg-op{accelerator=snax_gemmx}",
-        "dispatch-kernels",
-        "set-memory-space",
-        "convert-linalg-to-dart",
-        "dart-scheduler",
-        "set-memory-layout",
-        "realize-memref-casts",
-        "insert-sync-barrier",
-        "dispatch-regions{nb_cores=2}",
-        "dart-layout-resolution",
-        "convert-dart-to-snax-stream",
-        "convert-linalg-to-accfg",
-        "convert-accfg-to-csr",
-        "snax-copy-to-dma",
-        "memref-to-snax",
-        "snax-to-func",
-        "snax-allocate",
-        "clear-memory-space",
-        "postprocess",
-    ]
-)
+# config["snaxoptflags"] = ",".join(
+#     [
+#         "insert-accfg-op{accelerator=snax_gemmx}",
+#         "dispatch-kernels",
+#         "set-memory-space",
+#         "convert-linalg-to-dart",
+#         "dart-scheduler",
+#         "set-memory-layout",
+#         "realize-memref-casts",
+#         "insert-sync-barrier",
+#         "dispatch-regions{nb_cores=2}",
+#         "dart-layout-resolution",
+#         "convert-dart-to-snax-stream",
+#         "convert-linalg-to-accfg",
+#         "convert-accfg-to-csr",
+#         "snax-copy-to-dma",
+#         "memref-to-snax",
+#         "snax-to-func",
+#         "snax-allocate",
+#         "clear-memory-space",
+#         "postprocess",
+#     ]
+# )
 
 
 module snax_rules:
@@ -33,7 +33,20 @@ module snax_rules:
         config
 
 
-use rule * from snax_rules as snax_*
+use rule * from snax_rules exclude snax_opt_mlir as snax_*
+
+
+rule compile_snax:
+    """
+    Apply various transformations snax-opt on mlir files.
+    Options controlled with `snaxoptflags` defined in config.
+    """
+    input:
+        "{file}.mlir",
+    output:
+        temp("{file}.ll.mlir"),
+    shell:
+        "{config[snaxc]} --no-frontend -c {config[snaxc-config]} -o {output} {input}"
 
 
 rule link_snax_binary:

--- a/kernels/rescale/Snakefile
+++ b/kernels/rescale/Snakefile
@@ -1,29 +1,6 @@
 from util.snake.configs import get_snax_gemmx_config
 
 config = get_snax_gemmx_config()
-# config["snaxoptflags"] = ",".join(
-#     [
-#         "insert-accfg-op{accelerator=snax_gemmx}",
-#         "dispatch-kernels",
-#         "set-memory-space",
-#         "convert-linalg-to-dart",
-#         "dart-scheduler",
-#         "set-memory-layout",
-#         "realize-memref-casts",
-#         "insert-sync-barrier",
-#         "dispatch-regions{nb_cores=2}",
-#         "dart-layout-resolution",
-#         "convert-dart-to-snax-stream",
-#         "convert-linalg-to-accfg",
-#         "convert-accfg-to-csr",
-#         "snax-copy-to-dma",
-#         "memref-to-snax",
-#         "snax-to-func",
-#         "snax-allocate",
-#         "clear-memory-space",
-#         "postprocess",
-#     ]
-# )
 
 
 module snax_rules:

--- a/kernels/rescale/main.c
+++ b/kernels/rescale/main.c
@@ -28,9 +28,6 @@ int main() {
   memrefO.stride[0] = DATA_LEN;
   memrefO.stride[1] = 1;
 
-  // allocate zero row in tcdm
-  snrt_l1alloc(256);
-
   (void)snrt_mcycle();
 
   _mlir_ciface_rescale(&memrefA, &memrefO);

--- a/kernels/rescale/rescale.mlir
+++ b/kernels/rescale/rescale.mlir
@@ -1,11 +1,16 @@
 "builtin.module"() ({
   "func.func"() <{function_type = (memref<16x16xi32>, memref<16x16xi8>) -> (), sym_name = "rescale", sym_visibility = "public"}> ({
   ^bb0(%arg0: memref<16x16xi32>, %arg1: memref<16x16xi8>):
+    %c_256 = arith.constant 256 : index
+    %c_16 = arith.constant 16 : index
+    %zero_row = "snax.alloc"(%c_256, %c_16, %c_16) <{memory_space = "L1", alignment = 64 : i64}> : (index, index, index) -> !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)>
+    %zero_memref = builtin.unrealized_conversion_cast %zero_row : !llvm.struct<(!llvm.ptr, !llvm.ptr, i32, !llvm.array<2 x i32>, !llvm.array<2 x i32>)> to memref<16x16xi32>
     "linalg.generic"(%arg0, %arg1) <{indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>], operandSegmentSizes = array<i32: 1, 1>}> ({
     ^bb0(%arg2: i32, %arg3: i8):
       %0 = "kernel.rescale"(%arg2) {double_round = true, input_zp = 23 : i8, max_int = 100 : i8, min_int = -110 : i8, multiplier = 1234567890 : i32, output_zp = -15 : i8, shift = 39 : i8} : (i32) -> i8
       "linalg.yield"(%0) : (i8) -> ()
     }) : (memref<16x16xi32>, memref<16x16xi8>) -> ()
+    "memref.copy" (%zero_memref, %zero_memref) : (memref<16x16xi32>, memref<16x16xi32>) -> ()
     "func.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()


### PR DESCRIPTION
because allocation now happens in snax-mlir, the zero row hack to be able to run this test is now ported to mlir instead of the main.c