### PR TITLE
 transforms: (snax-allocate) insert dealloc ops at buffer death 

### DIFF
--- a/snaxc/transforms/insert_sync_barrier.py
+++ b/snaxc/transforms/insert_sync_barrier.py
@@ -1,5 +1,6 @@
 from xdsl.context import Context
 from xdsl.dialects import builtin
+from xdsl.dialects.memref import DeallocOp
 from xdsl.ir import Operation
 from xdsl.passes import ModulePass
 from xdsl.rewriter import InsertPoint, Rewriter
@@ -52,4 +53,8 @@ class InsertSyncBarrier(ModulePass):
                     if dispatch_to_compute(op_in_module) and not dispatch_to_compute(
                         op_use.operation
                     ):
+                        ops_to_sync.append(op_use.operation)
+
+                    if isinstance(op_use.operation, DeallocOp):
+                        # if the operation is a sync op, clear the list
                         ops_to_sync.append(op_use.operation)

--- a/snaxc/transforms/snax_allocate.py
+++ b/snaxc/transforms/snax_allocate.py
@@ -6,6 +6,7 @@ from typing import cast
 from minimalloc import Buffer, Problem  # pyright: ignore[reportMissingTypeStubs]
 from xdsl.context import Context
 from xdsl.dialects import arith, builtin, func, llvm
+from xdsl.dialects.memref import DeallocOp
 from xdsl.ir import Operation, OpResult, Sequence, SSAValue
 from xdsl.parser import IndexType, IntegerAttr, StringAttr
 from xdsl.passes import ModulePass
@@ -15,6 +16,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 from xdsl.traits import SymbolTable
 from xdsl.utils.hints import isa
 
@@ -289,6 +291,16 @@ class MiniMallocate(RewritePattern):
                 # udpate lifetime of buffer
                 for buffer in uses[op]:
                     buffer.end_time = i
+
+        # Insert Dealloc Ops
+        last_uses: list[tuple[SSAValue, Operation]] = []
+        func_ops = [x for x in func_op.body.block.ops]
+        for buffer in buffers:
+            memref_op = next(iter(buffer_ops[buffer.id].results[0].uses)).operation
+            assert isinstance(memref_op, builtin.UnrealizedConversionCastOp)
+            last_uses.append((memref_op.results[0], func_ops[buffer.end_time]))
+        for value, op in last_uses:
+            rewriter.insert_op(DeallocOp.get(value), InsertPoint.after(op))
 
         # Lifetime of the buffers is now determined, run the minimalloc algorithm for every memory space
         pointer_result: dict[str, int] = {}

--- a/snaxc/transforms/snax_to_func.py
+++ b/snaxc/transforms/snax_to_func.py
@@ -1,5 +1,6 @@
 from xdsl.context import Context
 from xdsl.dialects import builtin, func
+from xdsl.dialects.memref import DeallocOp
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     PatternRewriter,
@@ -37,6 +38,12 @@ class ClearL1ToFunc(RewritePattern):
         rewriter.replace_matched_op(func_call)
 
 
+class EraseDeallocs(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: DeallocOp, rewriter: PatternRewriter):
+        rewriter.erase_matched_op()
+
+
 class SNAXToFunc(ModulePass):
     name = "snax-to-func"
 
@@ -51,3 +58,4 @@ class SNAXToFunc(ModulePass):
             SymbolTable.insert_or_update(op, func_op)
 
         PatternRewriteWalker(ClearL1ToFunc()).rewrite_module(op)
+        PatternRewriteWalker(EraseDeallocs()).rewrite_module(op)


### PR DESCRIPTION
To maintain correct synchronization, the snax-allocate pass is adapted to insert dealloc operations when the lifetime of a buffer ends, such that proper synchronization can still take place. 
This will take effect when dealing with multi-layer netwroks such as the mlp example