### PR TITLE
transforms: (alloc-to-global) only globalize allocs used in terminator ops

### DIFF
--- a/snaxc/tools/snaxc_main.py
+++ b/snaxc/tools/snaxc_main.py
@@ -199,12 +199,12 @@ class SNAXCMain(CommandLineTool):
             pass_pipeline.append(SnaxBufferize())
         if self.args.debug:
             pass_pipeline.append(InsertDebugPass())
+        pass_pipeline.append(AllocToGlobalPass())
         pass_pipeline.append(SetMemorySpace())
         pass_pipeline.append(DartSchedulerPass())
         pass_pipeline.append(SetMemoryLayout())
         if self.args.debug:
             pass_pipeline.append(InsertDebugPass())
-        pass_pipeline.append(AllocToGlobalPass())
         pass_pipeline.append(RealizeMemrefCastsPass())
         pass_pipeline.append(ReuseMemrefAllocs())
         pass_pipeline.append(MemrefToSNAX())

--- a/snaxc/tools/snaxc_main.py
+++ b/snaxc/tools/snaxc_main.py
@@ -204,6 +204,7 @@ class SNAXCMain(CommandLineTool):
         pass_pipeline.append(SetMemoryLayout())
         if self.args.debug:
             pass_pipeline.append(InsertDebugPass())
+        pass_pipeline.append(AllocToGlobalPass())
         pass_pipeline.append(RealizeMemrefCastsPass())
         pass_pipeline.append(ReuseMemrefAllocs())
         pass_pipeline.append(MemrefToSNAX())
@@ -217,7 +218,6 @@ class SNAXCMain(CommandLineTool):
         pass_pipeline.append(ConvertAccfgToCsrPass())
         pass_pipeline.append(SNAXCopyToDMA())
         pass_pipeline.append(SNAXToFunc())
-        pass_pipeline.append(AllocToGlobalPass())
         if self.args.debug:
             pass_pipeline.append(DebugToFuncPass())
         pass_pipeline.append(ClearMemorySpace())

--- a/snaxc/transforms/alloc_to_global.py
+++ b/snaxc/transforms/alloc_to_global.py
@@ -14,7 +14,10 @@ from xdsl.traits import IsTerminator, SymbolTable
 
 class AllocToGlobal(RewritePattern):
     """
-    Convert all static allocs to empty statically scheduled memref globals
+    Convert memref allocs to empty statically scheduled memref globals
+
+    Will only apply to allocs without a specified memory space that
+    are used in a terminator operation such as a func.return.
 
     Warning: using this pattern multiple times in a lowering flow may lead
     to over
@@ -27,6 +30,9 @@ class AllocToGlobal(RewritePattern):
     def match_and_rewrite(self, op: memref.AllocOp, rewriter: PatternRewriter):
         # check if it is used in a terminator operation
         if not any(use.operation.has_trait(IsTerminator) for use in op.memref.uses):
+            return
+        # check if layout attribute is not set
+        if op.memref.type.memory_space != builtin.NoneAttr():
             return
 
         # get module op

--- a/snaxc/transforms/alloc_to_global.py
+++ b/snaxc/transforms/alloc_to_global.py
@@ -9,7 +9,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
-from xdsl.traits import SymbolTable
+from xdsl.traits import IsTerminator, SymbolTable
 
 
 class AllocToGlobal(RewritePattern):
@@ -25,6 +25,10 @@ class AllocToGlobal(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref.AllocOp, rewriter: PatternRewriter):
+        # check if it is used in a terminator operation
+        if not any(use.operation.has_trait(IsTerminator) for use in op.memref.uses):
+            return
+
         # get module op
         module_op = op
         while not isinstance(module_op, builtin.ModuleOp):

--- a/tests/filecheck/transforms/alloc-to-global.mlir
+++ b/tests/filecheck/transforms/alloc-to-global.mlir
@@ -1,6 +1,9 @@
 // RUN: snax-opt %s -p alloc-to-global | filecheck %s
 
-%0 = memref.alloc() {"alignment" = 64 : i64} : memref<16x16xi8>
+func.func @main() -> memref<16x16xi8> {
+  %0 = memref.alloc() : memref<16x16xi8>
+  func.return %0 : memref<16x16xi8>
+}
 
 // CHECK:      %0 = memref.get_global @_static_const_0 : memref<16x16xi8>
-// CHECK-NEXT: "memref.global"() <{sym_name = "_static_const_0", type = memref<16x16xi8>, initial_value, sym_visibility = "private"}> : () -> ()
+// CHECK: "memref.global"() <{sym_name = "_static_const_0", type = memref<16x16xi8>, initial_value, sym_visibility = "private"}> : () -> ()


### PR DESCRIPTION
Allocs that are returned in a function, must be initialized as a global such that they can be read from the function caller in any scenario. Intermediate allocs can remain as we can later determine where they ought to be allocated.
Additionally, memref.allocs with a specified memory space are also ignored.

This allows us to move up the alloc-to-global pass way back up, where it is supposed to be.