### PR TITLE
transforms: (unroll-pipeline) postamble ends with ub - 1

### DIFF
--- a/snaxc/transforms/pipeline/unroll_pipeline.py
+++ b/snaxc/transforms/pipeline/unroll_pipeline.py
@@ -52,7 +52,7 @@ class UnrollPipeline(RewritePattern):
         for i in range(pipeline.nb_stages - 1):
             ops_to_add: list[Operation] = []
             # create new index op
-            index = arith.ConstantOp.from_int_and_width(i, builtin.IndexType())
+            index = arith.ConstantOp.from_int_and_width(i + 1, builtin.IndexType())
             index_val = arith.SubiOp(for_op.ub, index)
             index_clone = index_op.clone()
             index_clone.operands[0] = index_val.result

--- a/tests/filecheck/transforms/pipeline/unroll-pipeline.mlir
+++ b/tests/filecheck/transforms/pipeline/unroll-pipeline.mlir
@@ -32,7 +32,7 @@ scf.for %i = %lb to %ub step %step {
 // CHECK-NEXT:   "test.op"(%2) {world} : (index) -> ()
 // CHECK-NEXT:   "snax.cluster_sync_op"() : () -> ()
 // CHECK-NEXT: }
-// CHECK-NEXT: %3 = arith.constant 0 : index
+// CHECK-NEXT: %3 = arith.constant 1 : index
 // CHECK-NEXT: %4 = arith.subi %ub, %3 : index
 // CHECK-NEXT: "test.op"(%4) {world} : (index) -> ()
 // CHECK-NEXT: "snax.cluster_sync_op"() : () -> ()
@@ -81,9 +81,9 @@ scf.for %i = %lb to %ub step %step {
 // CHECK-NEXT    "test.op"(%3) {wizard} : (index) -> ()
 // CHECK-NEXT    "snax.cluster_sync_op"() : () -> ()
 // CHECK-NEXT  }
-// CHECK-NEXT  %6 = arith.constant 0 : index
+// CHECK-NEXT  %6 = arith.constant 1 : index
 // CHECK-NEXT  %7 = arith.subi %ub, %6 : index
-// CHECK-NEXT  %8 = arith.constant 1 : index
+// CHECK-NEXT  %8 = arith.constant 2 : index
 // CHECK-NEXT  %9 = arith.subi %ub, %8 : index
 // CHECK-NEXT  "test.op"(%7) {a} : (index) -> ()
 // CHECK-NEXT  "test.op"(%9) {wizard} : (index) -> ()


### PR DESCRIPTION
the final iteration of the pipeline was done with index = ub, but the last one should be done with ub - 1 instead. This PR fixes this bug.