### PR TITLE
add broadcasting support to scheduler

### DIFF
--- a/snaxc/ir/dart/access_pattern.py
+++ b/snaxc/ir/dart/access_pattern.py
@@ -230,7 +230,14 @@ class TemplatePattern(AccessPattern):
         elif sp.num_dims < self.num_dims:
             return False
 
-        result = same_nonzero_singular_vectors(self.pattern.A, sp.pattern.A)
+        # Allow for broadcasting the schedule to outer dims of the result:
+        broadcast_results = len(self.pattern.A) - len(sp.pattern.A)
+        if broadcast_results > 0:
+            self_pattern = self.pattern.A[broadcast_results:, :]
+        else:
+            self_pattern = self.pattern.A
+
+        result = same_nonzero_singular_vectors(self_pattern, sp.pattern.A)
 
         return result
 


### PR DESCRIPTION
This adds broadcasting support to the scheduler for a relatively simple case:
when the dimensions of the resulting space of the schedule is less than the template, only the inner dimension is considered, in the assumption that other dimensions can be broadcasted to.