### PR TITLE
transforms: (convert-dart-to-snax-stream) add support for broadcasting

### DIFF
--- a/snaxc/dialects/snax_stream.py
+++ b/snaxc/dialects/snax_stream.py
@@ -77,6 +77,8 @@ class StridePattern(ParametrizedAttribute):
             printer.print_string("]")
 
     def canonicalize(self) -> Self:
+        if IntAttr(0) in self.spatial_strides.data:
+            return self
         upper_bounds = [x.data for x in self.upper_bounds.data]
         temporal_strides = [x.data for x in self.temporal_strides.data]
 


### PR DESCRIPTION
There is an exception to the non-contiguity check if broadcasting is used, as only the first streamer is active and then contiguity is no longer a restriction.