### PR TITLE
transforms: (set-memory-layout) add access granularity constraints

### DIFF
--- a/tests/filecheck/transforms/set-memory-layout.mlir
+++ b/tests/filecheck/transforms/set-memory-layout.mlir
@@ -49,3 +49,30 @@ func.func @snax_main() -> () {
 // CHECK:      %3 = "snax.layout_cast"(%0) : (memref<1x16x18x18xi8, "L1">) -> memref<1x16x18x18xi8, #tsl.tsl<[1] -> (5184), [16] -> (1), [18] -> (288), [18] -> (16)>, "L1">
 // CHECK-NEXT: %4 = "snax.layout_cast"(%1) : (memref<16x16x3x3xi8, "L1">) -> memref<16x16x3x3xi8, #tsl.tsl<[16] -> (16), [16] -> (1), [3] -> (768), [3] -> (256)>, "L1">
 // CHECK-NEXT: %5 = "snax.layout_cast"(%2) : (memref<1x16x16x16xi32, "L1">) -> memref<1x16x16x16xi32, #tsl.tsl<[1] -> (4096), [16] -> (1), [16] -> (256), [16] -> (16)>, "L1">
+
+// -----
+
+func.func @snax_main() -> () {
+  %0 = memref.alloc() : memref<16x16xi8, "L1">
+  %1 = memref.alloc() : memref<16x16xi8, "L1">
+  %2 = memref.alloc() : memref<16xi32, "L1">
+  %3 = memref.alloc() : memref<16x16xi32, "L1">
+  "dart.schedule"(%0, %1, %2, %3) <{patterns = [affine_map<(d0, d1, d2, d3, d4, d5) -> (((d1 * 8) + d3), ((d2 * 8) + d5))>, affine_map<(d0, d1, d2, d3, d4, d5) -> (((d2 * 8) + d5), ((d0 * 8) + d4))>, affine_map<(d0, d1, d2, d3, d4, d5) -> (((d0 * 8) + d4))>, affine_map<(d0, d1, d2, d3, d4, d5) -> (((d1 * 8) + d3), ((d0 * 8) + d4))>], accelerator = "snax_gemmx", tiles = [[]], bounds = [2 : index, 2 : index, 2 : index, 8 : index, 8 : index, 8 : index], operandSegmentSizes = array<i32: 3, 1>}> ({
+  ^0(%arg0 : !dart.stream<i8>, %arg1 : !dart.stream<i8>, %arg2 : !dart.stream<i32>, %arg3 : !dart.stream<i32>):
+    %9 = "dart.generic"(%arg0, %arg1) <{library_call = "snax_gemmx"}> ({
+    ^1(%arg7 : i8, %arg8 : i8, %arg9 : i32):
+      %10 = kernel.mac %arg7, %arg8 : i8, i8 -> i32
+      dart.yield %10 : i32
+    }) : (!dart.stream<i8>, !dart.stream<i8>) -> !dart.stream<i32>
+    %11 = "dart.generic"(%9, %arg2) <{library_call = "snax_gemmx"}> ({
+    ^2(%arg4 : i32, %arg5 : i32, %arg6 : i32):
+      %12 = kernel.add %arg4, %arg5 : i32, i32 -> i32
+      dart.yield %12 : i32
+    }) : (!dart.stream<i32>, !dart.stream<i32>) -> !dart.stream<i32>
+    dart.yield %11 : !dart.stream<i32>
+  }) : (memref<16x16xi8, "L1">, memref<16x16xi8, "L1">, memref<16xi32, "L1">, memref<16x16xi32, "L1">) -> ()
+  func.return
+}
+
+// non-contiguous layout for access granularity constraint:
+// CHECK:     %6 = "snax.layout_cast"(%2) : (memref<16xi32, "L1">) -> memref<16xi32, #tsl.tsl<[2, 8] -> (16, 1)>, "L1">

--- a/tests/filecheck/transforms/set-memory-layout.mlir
+++ b/tests/filecheck/transforms/set-memory-layout.mlir
@@ -75,4 +75,6 @@ func.func @snax_main() -> () {
 }
 
 // non-contiguous layout for access granularity constraint:
-// CHECK:     %6 = "snax.layout_cast"(%2) : (memref<16xi32, "L1">) -> memref<16xi32, #tsl.tsl<[2, 8] -> (16, 1)>, "L1">
+// TILED:     %6 = "snax.layout_cast"(%2) : (memref<16xi32, "L1">) -> memref<16xi32, #tsl.tsl<[2, 8] -> (16, 1)>, "L1">
+// not possible if we cannot tile
+// CHECK:     %6 = "snax.layout_cast"(%2) : (memref<16xi32, "L1">) -> memref<16xi32, #tsl.tsl<[16] -> (1)>, "L1">


### PR DESCRIPTION
just the start of a better system, set layouts such that access
granularity of the streamers towards the tcdm is compliant with
connectivity