### PR TITLE
transforms: (convert-linalg-to-dart) turn arith.constant init into explicit add

### DIFF
--- a/snaxc/transforms/dart/convert_linalg_to_dart.py
+++ b/snaxc/transforms/dart/convert_linalg_to_dart.py
@@ -12,7 +12,7 @@ from xdsl.dialects.builtin import (
     StringAttr,
     TensorType,
 )
-from xdsl.dialects.tensor import EmptyOp
+from xdsl.dialects.tensor import EmptyOp, ExtractSliceOp
 from xdsl.ir import Block, BlockArgument, OpResult, Region, SSAValue
 from xdsl.ir.affine import AffineMap
 from xdsl.passes import ModulePass
@@ -70,6 +70,10 @@ class StreamifyGenericOpPattern(RewritePattern):
         outputs_to_add: list[SSAValue] = []
         for output in (op.operands[index] for index, _ in streamable_output_indices):
             if isinstance(output, OpResult) and isinstance(output.op, EmptyOp):
+                outputs.append(output)
+            elif isinstance(output, OpResult) and isinstance(output.op, ExtractSliceOp):
+                # TODO: this case isn't entirely correct, for tiled execution, i think
+                # depending on the tiling we sould add / not add
                 outputs.append(output)
             else:
                 # replace with an empty tensor

--- a/snaxc/transforms/dart/convert_linalg_to_dart.py
+++ b/snaxc/transforms/dart/convert_linalg_to_dart.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass
 
 from xdsl.builder import Builder
@@ -15,6 +16,7 @@ from xdsl.dialects.builtin import (
 from xdsl.dialects.tensor import EmptyOp, ExtractSliceOp
 from xdsl.ir import Block, BlockArgument, OpResult, Region, SSAValue
 from xdsl.ir.affine import AffineMap
+from xdsl.parser import MemRefType
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     PatternRewriter,
@@ -74,6 +76,9 @@ class StreamifyGenericOpPattern(RewritePattern):
             elif isinstance(output, OpResult) and isinstance(output.op, ExtractSliceOp):
                 # TODO: this case isn't entirely correct, for tiled execution, i think
                 # depending on the tiling we sould add / not add
+                outputs.append(output)
+            elif isinstance(output.type, MemRefType):
+                warnings.warn("You really shoulnd't be using memrefs at this point")
                 outputs.append(output)
             else:
                 # replace with an empty tensor

--- a/snaxc/transforms/dart/convert_linalg_to_dart.py
+++ b/snaxc/transforms/dart/convert_linalg_to_dart.py
@@ -71,11 +71,12 @@ class StreamifyGenericOpPattern(RewritePattern):
         for output in (op.operands[index] for index, _ in streamable_output_indices):
             if isinstance(output, OpResult) and isinstance(output.op, EmptyOp):
                 outputs.append(output)
-            # replace with an empty tensor
-            empty = EmptyOp([], tensor_type=output.type)
-            rewriter.insert_op(empty, InsertPoint.before(op))
-            outputs.append(empty.tensor)
-            outputs_to_add.append(output)
+            else:
+                # replace with an empty tensor
+                empty = EmptyOp([], tensor_type=output.type)
+                rewriter.insert_op(empty, InsertPoint.before(op))
+                outputs.append(empty.tensor)
+                outputs_to_add.append(output)
 
         # create the streaming region to wrap around the stream.generic
         streaming_region_op = dart.OperationOp(


### PR DESCRIPTION
when converting a linalg that starts from certain initial values, explicitly transform that into an add operation for a simple case of an arith.constant