### PR TITLE
kernels: (gemm) modify gemm_broadcast to avoid linalg fuse pass

### DIFF
--- a/snaxc/accelerators/gemmini.py
+++ b/snaxc/accelerators/gemmini.py
@@ -129,7 +129,7 @@ class GemminiAccelerator(RoCCAccelerator):
         if not isinstance(op, linalg.GenericOp):
             return []
         else:
-            a, b, _, c = op.operands  # Don't use zero point adjustments
+            a, b, _, _, c = op.operands  # Don't use zero point adjustments
             ops_to_insert: Sequence[Operation] = []
             pointer_values: Sequence[SSAValue] = []
             stride_values: Sequence[SSAValue] = []

--- a/snaxc/transforms/frontend/preprocess_mlir.py
+++ b/snaxc/transforms/frontend/preprocess_mlir.py
@@ -27,7 +27,6 @@ MLIR_PREPOC_FLAGS: tuple[tuple[str, ...], ...] = (
     ),
     (
         "--linalg-generalize-named-ops",
-        "--linalg-fuse-elementwise-ops",
         "--mlir-print-op-generic",
         "--mlir-print-local-scope",
     ),


### PR DESCRIPTION
the linalg-fuse-elementwise-ops messes up further lowerings, so we should not depend on it. Therefore, the broadcast add is modified to be generated with a linalg.generic directly, rather than a broadcast + add we then fuse together.