### PR TITLE
networks: (mlperftiny-ad01) add output checking to network

### DIFF
--- a/kernels/mlperf_tiny/Snakefile
+++ b/kernels/mlperf_tiny/Snakefile
@@ -58,12 +58,22 @@ rule get_mlperf_tiny_model:
         "wget -O {output[0]} https://github.com/kuleuven-micas/mlir-networks/releases/latest/download/mlperf_tiny_{output[0]}"
 
 
+rule get_mlperf_tiny_data:
+    output:
+        "{network}_sample_data.json",
+    wildcard_constraints:
+        network="|".join(nets),
+    shell:
+        "wget -O {output[0]} https://github.com/kuleuven-micas/mlir-networks/releases/latest/download/mlperf_tiny_{output[0]}"
+
+
 rule generate_data:
+    input:
+        "anomaly_int8_sample_data.json",
     output:
         "data.h",
-        "data.c",
-    script:
-        "gendata.py"
+    shell:
+        "python gendata.py {input} --batch_size 8"
 
 
 rule create_static_anomaly_int8:
@@ -79,7 +89,6 @@ rule link_snax_binary:
     input:
         "{file}.o",
         "main.o",
-        "data.o",
     output:
         "{file}.x",
     shell:

--- a/kernels/mlperf_tiny/gendata.py
+++ b/kernels/mlperf_tiny/gendata.py
@@ -1,9 +1,21 @@
+import argparse
+import json
+
 import numpy as np
 
-from util.gendata import create_data, create_header
+from util.gendata import create_header_only
 
-np.random.seed(0)
-data = np.random.randint(-128, 128, size=(8, 640), dtype=np.int8)
-
-create_header("data", {"DATA_SIZE": data.size}, {"data": data})
-create_data("data", {"data": data})
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("data", type=str, help="Path to the .json sample data")
+    parser.add_argument("--batch_size", type=int, help="Batch size for the data")
+    parser.add_argument("--output", type=str, default="data.h", help="Output data file")
+    args = parser.parse_args()
+    data = json.load(open(args.data))
+    create_header_only(
+        args.output,
+        {
+            "input": np.array(data["input"]["data"] * args.batch_size, dtype=data["input"]["dtype"]),
+            "output": np.array(data["output"]["data"] * args.batch_size, dtype=data["output"]["dtype"]),
+        },
+    )

--- a/kernels/mlperf_tiny/main.c
+++ b/kernels/mlperf_tiny/main.c
@@ -71,7 +71,7 @@ int main() {
   printf("MSE: %d\n", mse);
 
   if (mse > 5) {
-    printf("Error: MSE is too high (%d)\n" mse);
+    printf("Error: MSE is too high (%d)\n", mse);
     return 1;
   }
 

--- a/util/gendata.py
+++ b/util/gendata.py
@@ -23,6 +23,25 @@ def create_header(file_name: str, sizes: dict[str, int], variables: dict[str, np
         f.write("\n")
 
 
+def create_header_only(file_name: str, vars: dict[str, int | npt.NDArray[np.int_]]) -> None:
+    if os.path.dirname(file_name):
+        os.makedirs(os.path.dirname(file_name), exist_ok=True)
+    with open(file_name, "w") as f:
+        f.write("#include <stdint.h>\n")
+        f.write("#pragma once\n")
+        f.write("\n")
+        for i, j in vars.items():
+            if isinstance(j, int):
+                f.write(f"\n#define {i} {j}")
+        f.write("\n")
+        for i, j in vars.items():
+            if not isinstance(j, int):
+                f.write(f"\n\nconst {j.dtype}_t {i}" + f"[{j.size}] = " + "{")
+                f.write(", ".join(str(j_val) for j_val in j))
+                f.write("};")
+        f.write("\n")
+
+
 def create_data(file_name: str, variables: dict[str, npt.NDArray]):
     includes = [f'#include "{os.path.basename(file_name)}.h"', "", ""]
     includes = "\n".join(includes)


### PR DESCRIPTION
Now, sample data is downloaded along with the mlir network. Sample data is broadcasted by the gendata.py script for batched execution, and turned into a proper data.h.
The main file calculates the mean square error between sample data and simulator output.
If the error is > 5, we throw an error.
Currently, the error is all 1 (golden[i] = output[i] + 1). I have no idea why