### PR TITLE
accelerators: (SNAXStreamer) get_template is not static

### DIFF
--- a/snaxc/accelerators/snax.py
+++ b/snaxc/accelerators/snax.py
@@ -262,9 +262,8 @@ class SNAXStreamer(ABC):
 
         return base_addr, streamer_launch
 
-    @staticmethod
     @abstractmethod
-    def get_template(op: StreamingRegionOpBase) -> Template:
+    def get_template(self, op: StreamingRegionOpBase) -> Template:
         """
         Get the template for this acelerator to schedule a given
         stream.streaming_region operation.

--- a/snaxc/accelerators/snax_alu.py
+++ b/snaxc/accelerators/snax_alu.py
@@ -181,8 +181,7 @@ class SNAXAluAccelerator(SNAXAccelerator, SNAXPollingBarrier3, SNAXStreamer, Dis
 
         return op
 
-    @staticmethod
-    def get_template(op: dart.StreamingRegionOpBase):
+    def get_template(self, op: dart.StreamingRegionOpBase):
         template = [AffineMap.from_callable(lambda y: (y,))] * 3
         template_bounds = (4,)
         return Template(TemplatePattern(template_bounds, tp) for tp in template)

--- a/snaxc/accelerators/snax_gemmx.py
+++ b/snaxc/accelerators/snax_gemmx.py
@@ -448,8 +448,7 @@ class SNAXGEMMXAccelerator(SNAXAccelerator, SNAXStreamer, DispatchTemplate, SNAX
 
         return ops
 
-    @staticmethod
-    def get_template(op: dart.StreamingRegionOpBase) -> Template:
+    def get_template(self, op: dart.StreamingRegionOpBase) -> Template:
         assert isinstance(generic_op := op.body.block.first_op, dart.GenericOp)
         if isinstance(generic_op.body.block.first_op, kernel.QMacOp | kernel.MacOp):
             # matmul


### PR DESCRIPTION
The template can depend on for example gemmx dimensions