### PR TITLE
transforms: (convert-dart-to-snax-stream) clean up with get_streamers…

### DIFF
--- a/snaxc/accelerators/snax.py
+++ b/snaxc/accelerators/snax.py
@@ -9,7 +9,7 @@ from xdsl.ir import Operation, OpResult, SSAValue
 
 from snaxc.accelerators.accelerator import Accelerator
 from snaxc.accelerators.streamers import StreamerConfiguration
-from snaxc.accelerators.streamers.streamers import StreamerFlag, StreamerOpts
+from snaxc.accelerators.streamers.streamers import Streamer, StreamerFlag, StreamerOpts
 from snaxc.dialects import accfg
 from snaxc.dialects.dart import StreamingRegionOpBase
 from snaxc.dialects.snax_stream import StreamerConfigurationAttr, StreamingRegionOp
@@ -271,6 +271,12 @@ class SNAXStreamer(ABC):
         Returns template, template_bounds
         """
         raise NotImplementedError()
+
+    def get_streamers(self, op: StreamingRegionOpBase) -> Sequence[Streamer]:
+        """
+        Return the set of streamers used for a given op.
+        """
+        return self.streamer_config.data.streamers
 
 
 class SNAXPollingBarrier(Accelerator, ABC):

--- a/snaxc/accelerators/snax_gemmx.py
+++ b/snaxc/accelerators/snax_gemmx.py
@@ -490,3 +490,24 @@ class SNAXGEMMXAccelerator(SNAXAccelerator, SNAXStreamer, DispatchTemplate, SNAX
             raise RuntimeError("unsupported kernel")
 
         return Template(TemplatePattern(template_bounds, tp) for tp in template)
+
+    def get_streamers(self, op: dart.StreamingRegionOpBase) -> Sequence[Streamer]:
+        if len(op.patterns) == 3:
+            # matmul, no add
+            if op.body.block.arg_types[-1] == dart.StreamType(builtin.IntegerType(32)):
+                streamers = [self.streamer_config.data.streamers[i] for i in (0, 1, 4)]
+            elif op.body.block.arg_types[-1] == dart.StreamType(builtin.IntegerType(8)):
+                streamers = [self.streamer_config.data.streamers[i] for i in (0, 1, 2)]
+            else:
+                raise NotImplementedError("Unsupported type for snax_gemmx accelerator")
+        elif len(op.patterns) == 4:
+            # gemm with add
+            if op.body.block.arg_types[-1] == dart.StreamType(builtin.IntegerType(32)):
+                streamers = [self.streamer_config.data.streamers[i] for i in (0, 1, 3, 4)]
+            elif op.body.block.arg_types[-1] == dart.StreamType(builtin.IntegerType(8)):
+                streamers = [self.streamer_config.data.streamers[i] for i in (0, 1, 3, 2)]
+            else:
+                raise NotImplementedError("Unsupported type for snax_gemmx accelerator")
+        else:
+            raise NotImplementedError("Unsupported number of patterns for snax_gemmx accelerator")
+        return streamers


### PR DESCRIPTION
… function

instead of figuring out which streamerst to use for a given operation in the transformation itself, we move this logic to a function get_streamers of the SNAXStreamer class, to modify in a custom way which streamers are used for each accelerator type and operation