### PR TITLE
transforms: (convert-kernel-to-linalg) add simple rescale lowering

### DIFF
--- a/snaxc/transforms/convert_kernel_to_linalg.py
+++ b/snaxc/transforms/convert_kernel_to_linalg.py
@@ -1,5 +1,6 @@
 from xdsl.context import Context
 from xdsl.dialects import builtin, linalg
+from xdsl.dialects.arith import AddiOp, ConstantOp, ExtSIOp, MaxSIOp, MinSIOp, MuliOp, ShRSIOp, SubiOp, TruncIOp
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     PatternRewriter,
@@ -7,8 +8,44 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 
-from snaxc.dialects.kernel import Parsable
+from snaxc.dialects.kernel import Parsable, RescaleOp
+
+
+class LowerRescale(RewritePattern):
+    """
+    Limited lowering of rescale to linalg,
+    ignoring separate channels and double rounding.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: RescaleOp, rewriter: PatternRewriter):
+        if not isinstance(linalg_op := op.parent_op(), linalg.GenericOp):
+            return
+
+        # create constant ops:
+        zp_in = ConstantOp.from_int_and_width(op.input_zp.value.data, builtin.IntegerType(32))
+        zp_out = ConstantOp.from_int_and_width(op.output_zp.value.data, builtin.IntegerType(32))
+        shift = ConstantOp.from_int_and_width(int(op.shift.get_values()[0]), builtin.IntegerType(64))
+        mult = ConstantOp.from_int_and_width(int(op.multiplier.get_values()[0]), builtin.IntegerType(64))
+        min = ConstantOp.from_int_and_width(op.min_int.value.data, builtin.IntegerType(32))
+        max = ConstantOp.from_int_and_width(op.max_int.value.data, builtin.IntegerType(32))
+        rewriter.insert_op([zp_in, zp_out, shift, mult, min, max], InsertPoint.before(linalg_op))
+
+        # create body ops:
+        with_zp_in = SubiOp(op.input, zp_in)
+        extended = ExtSIOp(with_zp_in, builtin.i64)
+        multed = MuliOp(extended, mult)
+        shifted = ShRSIOp(multed, shift)
+        trunced = TruncIOp(shifted, builtin.i32)
+        with_zp_out = AddiOp(trunced, zp_out)
+        clamped_max = MinSIOp(with_zp_out, max)
+        clamped_min = MaxSIOp(clamped_max, min)
+        trunced_final = TruncIOp(clamped_min, builtin.i8)
+        rewriter.replace_matched_op(
+            [with_zp_in, extended, multed, shifted, trunced, with_zp_out, clamped_max, clamped_min, trunced_final]
+        )
 
 
 class LowerLinalgBody(RewritePattern):
@@ -48,3 +85,4 @@ class ConvertKernelToLinalg(ModulePass):
 
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
         PatternRewriteWalker(LowerLinalgBody()).rewrite_module(op)
+        PatternRewriteWalker(LowerRescale()).rewrite_module(op)


### PR DESCRIPTION
to be used when deploying neural networks, when dispatching a rescale op has failed, such that we still generate valid linalg that can be ran on the risc-v cores in the cluster