### PR TITLE
transforms: (alloc-to-global) initialize to default value to avoid .bss

### DIFF
--- a/tests/filecheck/transforms/alloc-to-global.mlir
+++ b/tests/filecheck/transforms/alloc-to-global.mlir
@@ -6,4 +6,4 @@ func.func @main() -> memref<16x16xi8> {
 }
 
 // CHECK:      %0 = memref.get_global @_static_const_0 : memref<16x16xi8>
-// CHECK: "memref.global"() <{sym_name = "_static_const_0", type = memref<16x16xi8>, initial_value, sym_visibility = "private"}> : () -> ()
+// CHECK: "memref.global"() <{sym_name = "_static_const_0", type = memref<16x16xi8>, initial_value = dense<77> : tensor<16x16xi8>, sym_visibility = "private"}> : () -> ()


### PR DESCRIPTION
Uninitialized variables are currently very slow, so this avoids them until they are fast again.
See kuleuven-micas/snax_cluster#532 for more details