### PR TITLE
accfg: lower_acc_launch is not always static

### DIFF
--- a/snaxc/accelerators/accelerator.py
+++ b/snaxc/accelerators/accelerator.py
@@ -51,9 +51,8 @@ class Accelerator(ABC):
         """
         raise NotImplementedError()
 
-    @staticmethod
     @abstractmethod
-    def lower_acc_launch(launch_op: accfg.LaunchOp, acc_op: accfg.AcceleratorOp) -> Sequence[Operation]:
+    def lower_acc_launch(self, launch_op: accfg.LaunchOp, acc_op: accfg.AcceleratorOp) -> Sequence[Operation]:
         """
         Based on the accfg.accelerator op, return the necessary sequence of
         lower-level operations to perform an

--- a/snaxc/accelerators/rocc.py
+++ b/snaxc/accelerators/rocc.py
@@ -23,8 +23,7 @@ class RoCCAccelerator(Accelerator, ABC):
         """
         return []
 
-    @staticmethod
-    def lower_acc_launch(launch_op: accfg.LaunchOp, acc_op: accfg.AcceleratorOp) -> Sequence[Operation]:
+    def lower_acc_launch(self, launch_op: accfg.LaunchOp, acc_op: accfg.AcceleratorOp) -> Sequence[Operation]:
         xcustom_acc = 3  # hardcoded to 3 for now
         vals = create_pairs(launch_op)
         # Create the sequence of all operations that need to be emitted

--- a/snaxc/accelerators/snax.py
+++ b/snaxc/accelerators/snax.py
@@ -33,8 +33,7 @@ class SNAXAccelerator(Accelerator, ABC):
     with common SNAX lowerings.
     """
 
-    @staticmethod
-    def lower_acc_launch(launch_op: accfg.LaunchOp, acc_op: accfg.AcceleratorOp) -> Sequence[Operation]:
+    def lower_acc_launch(self, launch_op: accfg.LaunchOp, acc_op: accfg.AcceleratorOp) -> Sequence[Operation]:
         field_to_csr = dict(acc_op.launch_field_items())
         ops: Sequence[Operation] = []
         for field, val in launch_op.iter_params():

--- a/snaxc/accelerators/snax_gemmx.py
+++ b/snaxc/accelerators/snax_gemmx.py
@@ -380,7 +380,7 @@ class SNAXGEMMXAccelerator(SNAXAccelerator, SNAXStreamer, DispatchTemplate, SNAX
 
     def lower_acc_launch(self, launch_op: accfg.LaunchOp, acc_op: accfg.AcceleratorOp) -> Sequence[Operation]:
         if "mult_vals" not in launch_op.attributes:
-            return self.lower_acc_launch(launch_op, acc_op)
+            return super().lower_acc_launch(launch_op, acc_op)
 
         # special case for channel-specific quantization scales:
         # for this to work, the schedule must be output-channel stationary

--- a/snaxc/accelerators/snax_gemmx.py
+++ b/snaxc/accelerators/snax_gemmx.py
@@ -378,10 +378,9 @@ class SNAXGEMMXAccelerator(SNAXAccelerator, SNAXStreamer, DispatchTemplate, SNAX
             launch_attrs,
         )
 
-    @staticmethod
-    def lower_acc_launch(launch_op: accfg.LaunchOp, acc_op: accfg.AcceleratorOp) -> Sequence[Operation]:
+    def lower_acc_launch(self, launch_op: accfg.LaunchOp, acc_op: accfg.AcceleratorOp) -> Sequence[Operation]:
         if "mult_vals" not in launch_op.attributes:
-            return SNAXAccelerator.lower_acc_launch(launch_op, acc_op)
+            return self.lower_acc_launch(launch_op, acc_op)
 
         # special case for channel-specific quantization scales:
         # for this to work, the schedule must be output-channel stationary


### PR DESCRIPTION
there are some example cases, for example the gemmx quantization params that require specific accelerator information