### PR TITLE
hardfloat: Add convert-hardfloat-to-hw pass

### DIFF
--- a/.github/workflows/easyfloat-lit-tests.yml
+++ b/.github/workflows/easyfloat-lit-tests.yml
@@ -1,0 +1,25 @@
+name: lit-tests (easyfloat)
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - 'tests/filecheck/transforms/hardfloat/convert-hardfloat-to-hw.mlir'
+  pull_request:
+    paths:
+      - 'tests/filecheck/transforms/hardfloat/convert-hardfloat-to-hw.mlir'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  python-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: prefix-dev/setup-pixi@v0.9.0
+        with:
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+      - name: Test with lit
+        shell: bash
+        run: |
+          pixi run lit -v tests/filecheck/transforms/hardfloat/convert-hardfloat-to-hw.mlir -Dforce-easyfloat=1

--- a/.github/workflows/easyfloat-lit-tests.yml
+++ b/.github/workflows/easyfloat-lit-tests.yml
@@ -25,6 +25,7 @@ jobs:
           path: kuleuven-easyfloat
       - uses: prefix-dev/setup-pixi@v0.9.0
         with:
+          manifest-path: snax-mlir/pyproject.toml
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       - name: Test with lit

--- a/.github/workflows/easyfloat-lit-tests.yml
+++ b/.github/workflows/easyfloat-lit-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: b755dcdce7a9df261feff2c654d62241034e6e4a
-          repository: KULeuven-MICAS/snax_cluster
+          repository: KULeuven-MICAS/kuleuven-easyfloat
           path: kuleuven-easyfloat
       - uses: prefix-dev/setup-pixi@v0.9.0
         with:

--- a/.github/workflows/easyfloat-lit-tests.yml
+++ b/.github/workflows/easyfloat-lit-tests.yml
@@ -15,6 +15,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
+      - name: Checkout kuleuven-easyfloat
+        uses: actions/checkout@v4
+        with:
+          ref: b755dcdce7a9df261feff2c654d62241034e6e4a
+          repository: KULeuven-MICAS/snax_cluster
+          path: kuleuven-easyfloat
       - uses: prefix-dev/setup-pixi@v0.9.0
         with:
           cache: true

--- a/.github/workflows/easyfloat-lit-tests.yml
+++ b/.github/workflows/easyfloat-lit-tests.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          path: snax-mlir
       - name: Checkout kuleuven-easyfloat
         uses: actions/checkout@v4
         with:
@@ -27,5 +29,6 @@ jobs:
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       - name: Test with lit
         shell: bash
+        working-directory: snax-mlir
         run: |
           pixi run lit -v tests/filecheck/transforms/hardfloat/convert-hardfloat-to-hw.mlir -Dforce-easyfloat=1

--- a/pixi.lock
+++ b/pixi.lock
@@ -12,6 +12,7 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/amply-0.1.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argparse-dataclass-2.0.0-pyhd8ed1ab_1.conda
@@ -19,7 +20,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_104.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
@@ -36,13 +39,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/connection_pool-0.0.3-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dpath-2.2.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.45-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/immutables-0.21-py312h4c3975b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda
@@ -50,50 +63,74 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-2_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-2_h0358290_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp21.1-21.1.1-default_h99862b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_14.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_114.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_14.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_14.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.4-h6548e54_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_14.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-2_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-2_h6ae95b6_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.1-hf7376ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmlir21-21.1.1-hb700be7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.0-hee844dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-ha9997c6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-h26afc86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-hca6bf5a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lld-21.1.1-hef48ded_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-tools-21-21.1.1-h3b15d91_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-tools-21.1.1-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmdev-21.1.1-h3b15d91_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mill-0.11.8-hed8d791_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mlir-21.1.1-hea31c11_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.9.0-heeeca48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-25.6.1-he4ff34a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-17.0.17-h777afb3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.1.3-py312h5253ce2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulp-2.8.0-py312hd0750ca_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.5-pyhcf101f3_0.conda
@@ -129,6 +166,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/kuleuven-micas/linux-64/vcd-to-csv-0.1.0-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py312h4c3975b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yte-1.9.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h5253ce2_1.conda
@@ -214,6 +263,17 @@ packages:
   version: 2.3.1
   sha256: eeecf07f0c2a93ace0772c92e596ace6d3d3996c042b2128459aaae2a76de11d
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+  sha256: d88aa7ae766cf584e180996e92fef2aa7d8e0a0a5ab1d4d49c32390c1b5fff31
+  md5: dcdc58c15961dbf17a0621312b01f5cb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  license_family: GPL
+  purls: []
+  size: 584660
+  timestamp: 1768327524772
 - conda: https://conda.anaconda.org/conda-forge/noarch/amply-0.1.6-pyhd8ed1ab_1.conda
   sha256: e8d87cb66bcc62bc8d8168037b776de962ebf659e45acb1a813debde558f7339
   md5: 5a81866192811f3a0827f5f93e589f02
@@ -306,6 +366,17 @@ packages:
   purls: []
   size: 260341
   timestamp: 1757437258798
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+  sha256: cc9accf72fa028d31c2a038460787751127317dcfa991f8d1f1babf216bb454e
+  md5: 920bb03579f15389b9e512095ad995b7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 207882
+  timestamp: 1765214722852
 - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
   sha256: b986ba796d42c9d3265602bc038f6f5264095702dd546c14bc684e60c385e773
   md5: f0991f0f84902f6b6009b4d2350a83aa
@@ -315,6 +386,33 @@ packages:
   purls: []
   size: 152432
   timestamp: 1762967197890
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+  sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
+  md5: bb6c4808bfa69d6f7f6b07e5846ced37
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - icu >=78.1,<79.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libglib >=2.86.3,<3.0a0
+  - libpng >=1.6.53,<1.7.0a0
+  - libstdcxx >=14
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.46.4,<1.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: LGPL-2.1-only or MPL-1.1
+  purls: []
+  size: 989514
+  timestamp: 1766415934926
 - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.11.12-pyhd8ed1ab_0.conda
   sha256: 083a2bdad892ccf02b352ecab38ee86c3e610ba9a4b11b073ea769d55a115d32
   md5: 96a02a5c1a65470a7e4eedb644c872fd
@@ -637,6 +735,77 @@ packages:
   name: flatbuffers
   version: 25.9.23
   sha256: 255538574d6cb6d0a79a17ec8bc0d30985913b87513a01cce8bcdb6b4c44d0e2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  md5: 0c96522c6bdaed4b1566d11387caaf45
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 397370
+  timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  md5: 34893075a5c9e55cdafac56607368fc6
+  license: OFL-1.1
+  license_family: Other
+  purls: []
+  size: 96530
+  timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  md5: 4d59c254e01d9cde7957100457e2d5fb
+  license: OFL-1.1
+  license_family: Other
+  purls: []
+  size: 700814
+  timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+  sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+  md5: 49023d73832ef61042f6a237cb2687e7
+  license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+  license_family: Other
+  purls: []
+  size: 1620504
+  timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
+  sha256: aa4a44dba97151221100a637c7f4bde619567afade9c0265f8e1c8eed8d7bd8c
+  md5: 867127763fbe935bab59815b6e0b7b5c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.7.4,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libuuid >=2.41.3,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 270705
+  timestamp: 1771382710863
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  md5: fee5683a3f04bd15cbd8318b096a27ab
+  depends:
+  - fonts-conda-forge
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 3667
+  timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+  sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+  md5: a7970cd949a077b7cb9696379d338681
+  depends:
+  - font-ttf-ubuntu
+  - font-ttf-inconsolata
+  - font-ttf-dejavu-sans-mono
+  - font-ttf-source-code-pro
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 4059
+  timestamp: 1762351264405
 - pypi: https://files.pythonhosted.org/packages/c0/ca/4bb48a26ed95a1e7eba175535fe5805887682140ee0a0d10a88e1de84208/fonttools-4.60.1-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
   name: fonttools
   version: 4.60.1
@@ -676,6 +845,16 @@ packages:
   version: 0.6.0
   sha256: 52b182313f7330389f72b069ba00f174cfe2a06411099547288839c6cbafbd54
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+  sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
+  md5: 3bf7b9fd5a7136126e0234db4b87c8b6
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 77248
+  timestamp: 1712692454246
 - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
   sha256: dbbec21a369872c8ebe23cb9a3b9d63638479ee30face165aa0fccc96e93eec3
   md5: 7c14f3706e099f8fcd47af2d494616cc
@@ -707,6 +886,18 @@ packages:
   sha256: b32482794a366b5366a32c92a9a9201b107821889935a02b3e51f6b432ea84ed
   requires_dist:
   - six
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+  sha256: 25ba37da5c39697a77fce2c9a15e48cf0a84f1464ad2aafbe53d8357a9f6cc8c
+  md5: 2cd94587f3a401ae05e03a6caf09539d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 99596
+  timestamp: 1755102025473
 - pypi: https://files.pythonhosted.org/packages/f5/86/f6ec2164f743d9609691115ae8ece098c76b894ebe4f7c94a655c6b03e98/grpcio-1.76.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: grpcio
   version: 1.76.0
@@ -736,6 +927,26 @@ packages:
   requires_dist:
   - numpy>=1.21.2
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
+  sha256: 92015faf283f9c0a8109e2761042cd47ae7a4505e24af42a53bc3767cb249912
+  md5: d170a70fc1d5c605fcebdf16851bd54a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=78.2,<79.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libglib >=2.86.3,<3.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 2035859
+  timestamp: 1769445400168
 - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
   sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
   md5: 0a802cb9888dd14eeefc611f05c40b6e
@@ -770,18 +981,18 @@ packages:
   - pkg:pypi/hyperframe?source=hash-mapping
   size: 17397
   timestamp: 1737618427549
-- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
-  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
-  md5: 8b189310083baabfb622af68fd9d3ae3
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+  sha256: 142a722072fa96cf16ff98eaaf641f54ab84744af81754c292cb81e0881c0329
+  md5: 186a18e3ba246eccfc7cff00cd19a870
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - libgcc >=14
+  - libstdcxx >=14
   license: MIT
   license_family: MIT
   purls: []
-  size: 12129203
-  timestamp: 1720853576813
+  size: 12728445
+  timestamp: 1767969922681
 - pypi: https://files.pythonhosted.org/packages/0f/1c/e5fd8f973d4f375adb21565739498e2e9a1e54c858a97b9a8ccfdc81da9b/identify-2.6.15-py2.py3-none-any.whl
   name: identify
   version: 2.6.15
@@ -907,11 +1118,50 @@ packages:
   purls: []
   size: 1272697
   timestamp: 1752669126073
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+  sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
+  md5: b38117a3c920364aff79f870c984b4a3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 134088
+  timestamp: 1754905959823
 - pypi: https://files.pythonhosted.org/packages/70/90/6d240beb0f24b74371762873e9b7f499f1e02166a2d9c5801f4dbf8fa12e/kiwisolver-1.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: kiwisolver
   version: 1.4.9
   sha256: f6008a4919fdbc0b0097089f67a1eb55d950ed7e90ce2cc3e640abadd2757a04
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+  sha256: 3e307628ca3527448dd1cb14ad7bb9d04d1d28c7d4c5f97ba196ae984571dd25
+  md5: fb53fb07ce46a575c5d004bbc96032c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - keyutils >=1.6.3,<2.0a0
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.5,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1386730
+  timestamp: 1769769569681
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
+  sha256: 836ec4b895352110335b9fdcfa83a8dcdbe6c5fb7c06c4929130600caea91c0a
+  md5: 6f2e2c8f58160147c4d1c6f4c14cbac4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 249959
+  timestamp: 1768184673131
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_104.conda
   sha256: 9e191baf2426a19507f1d0a17be0fdb7aa155cdf0f61d5a09c808e0a69464312
   md5: a6abd2796fc332536735f68ba23f7901
@@ -925,6 +1175,33 @@ packages:
   purls: []
   size: 725545
   timestamp: 1764007826689
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
+  sha256: 412381a43d5ff9bbed82cd52a0bbca5b90623f62e41007c9c42d3870c60945ff
+  md5: 9344155d33912347b37f0ae6c410a835
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 264243
+  timestamp: 1745264221534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
+  sha256: a7a4481a4d217a3eadea0ec489826a69070fcc3153f00443aa491ed21527d239
+  md5: 6f7b4302263347698fd24565fbf11310
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - libabseil-static =20260107.1=cxx17*
+  - abseil-cpp =20260107.1
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 1384817
+  timestamp: 1770863194876
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-2_h4a7cf45_openblas.conda
   build_number: 2
   sha256: 4287aa2742828dc869b09a17c9f1171903fc1146bdc8f7bdf62ffe5c20674f31
@@ -943,6 +1220,41 @@ packages:
   purls: []
   size: 18495
   timestamp: 1763828445618
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
+  sha256: 318f36bd49ca8ad85e6478bd8506c88d82454cc008c1ac1c6bf00a3c42fa610e
+  md5: 72c8fd1af66bd67bf580645b426513ed
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 79965
+  timestamp: 1764017188531
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
+  sha256: 12fff21d38f98bc446d82baa890e01fd82e3b750378fedc720ff93522ffb752b
+  md5: 366b40a69f0ad6072561c1d09301c886
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.2.0 hb03c661_1
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 34632
+  timestamp: 1764017199083
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+  sha256: a0c15c79997820bbd3fbc8ecf146f4fe0eca36cc60b62b63ac6cf78857f1dd0d
+  md5: 4ffbb341c8b616aa2494b6afb26a0c5f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.2.0 hb03c661_1
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 298378
+  timestamp: 1764017210931
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-2_h0358290_openblas.conda
   build_number: 2
   sha256: 02286c8941f156d11087dedc551b86b99bd55d9d4bdef61316566a2fc133608b
@@ -975,6 +1287,31 @@ packages:
   purls: []
   size: 21102314
   timestamp: 1757614625637
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+  sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
+  md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 4518030
+  timestamp: 1770902209173
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+  sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
+  md5: 6c77a605a7a689d17d4819c0f8ac9a00
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 73490
+  timestamp: 1761979956660
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
   sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
   md5: c277e0a4d549b03ac1e9d6cbbe3d017b
@@ -988,19 +1325,29 @@ packages:
   purls: []
   size: 134676
   timestamp: 1738479519902
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
-  sha256: 1e1b08f6211629cbc2efe7a5bca5953f8f6b3cae0eeb04ca4dacee1bd4e2db2f
-  md5: 8b09ae86839581147ef2e5c5e229d164
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 112766
+  timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
+  sha256: d78f1d3bea8c031d2f032b760f36676d87929b18146351c4464c66b0869df3f5
+  md5: e7f7ce06ec24cfcfb9e36d28cf82ba57
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   constrains:
-  - expat 2.7.3.*
+  - expat 2.7.4.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 76643
-  timestamp: 1763549731408
+  size: 76798
+  timestamp: 1771259418166
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
   sha256: 25cbdfa65580cfab1b8d15ee90b4c9f1e0d72128f1661449c9a999d341377d54
   md5: 35f29eec58405aaf55e01cb470d8c26a
@@ -1012,6 +1359,29 @@ packages:
   purls: []
   size: 57821
   timestamp: 1760295480630
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
+  sha256: 4641d37faeb97cf8a121efafd6afd040904d4bca8c46798122f417c31d5dfbec
+  md5: f4084e4e6577797150f9b04a4560ceb0
+  depends:
+  - libfreetype6 >=2.14.1
+  license: GPL-2.0-only OR FTL
+  purls: []
+  size: 7664
+  timestamp: 1757945417134
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
+  sha256: 4a7af818a3179fafb6c91111752954e29d3a2a950259c14a2fc7ba40a8b03652
+  md5: 8e7251989bca326a28f4a5ffbd74557a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libpng >=1.6.50,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - freetype >=2.14.1
+  license: GPL-2.0-only OR FTL
+  purls: []
+  size: 386739
+  timestamp: 1757945416744
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_14.conda
   sha256: 947bfbe5e47cd5d0cbdb0926d4baadb3e9be25caca7c6c6ef516f7ef85052cec
   md5: 550dceb769d23bcf0e2f97fd4062d720
@@ -1066,6 +1436,22 @@ packages:
   purls: []
   size: 2480588
   timestamp: 1764277129524
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.4-h6548e54_0.conda
+  sha256: 0d8cf491cb00aeb35fcfb68dfcb5b0ad188a98fb35c21c2421d2b2acc128cbf5
+  md5: b7113551db5a3e2403cdd052c66e9999
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  constrains:
+  - glib 2.86.4 *_0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 4432190
+  timestamp: 1771291719860
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_14.conda
   sha256: 2017cbc0f0f3b1d15df9ca681960eef015f9f58ba0d6e841694277a9f7eae0fc
   md5: 91349c276f84f590487e4c7f6e90e077
@@ -1085,6 +1471,18 @@ packages:
   purls: []
   size: 790176
   timestamp: 1754908768807
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+  sha256: cc9aba923eea0af8e30e0f94f2ad7156e2984d80d1e8e7fe6be5a1f257f0eb32
+  md5: 8397539e3a0bbd1695584fb4f927485a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  purls: []
+  size: 633710
+  timestamp: 1762094827865
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-2_h47877c9_openblas.conda
   build_number: 2
   sha256: d51497ff0af63c4fa854ee7eadca5589eebfc3c9f50eaaa5ede97becde4682ca
@@ -1156,6 +1554,23 @@ packages:
   purls: []
   size: 24984617
   timestamp: 1757610827851
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
+  sha256: a4a7dab8db4dc81c736e9a9b42bdfd97b087816e029e221380511960ac46c690
+  md5: b499ce4b026493a13774bcf0f4c33849
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.34.5,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 666600
+  timestamp: 1756834976695
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
   sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
   md5: d864d34357c3b65a4b731f78c0801dc4
@@ -1182,18 +1597,29 @@ packages:
   purls: []
   size: 5927939
   timestamp: 1763114673331
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.0-hee844dc_0.conda
-  sha256: 4c992dcd0e34b68f843e75406f7f303b1b97c248d18f3c7c330bdc0bc26ae0b3
-  md5: 729a572a3ebb8c43933b30edcc628ceb
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
+  sha256: 36ade759122cdf0f16e2a2562a19746d96cf9c863ffaa812f2f5071ebbe9c03c
+  md5: 5f13ffc7d30ffec87864e678df9957b4
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  purls: []
+  size: 317669
+  timestamp: 1770691470744
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
+  sha256: 04596fcee262a870e4b7c9807224680ff48d4d0cc0dac076a602503d3dc6d217
+  md5: da5be73701eecd0e8454423fd6ffcf30
   depends:
   - __glibc >=2.17,<3.0.a0
-  - icu >=75.1,<76.0a0
+  - icu >=78.2,<79.0a0
   - libgcc >=14
   - libzlib >=1.3.1,<2.0a0
   license: blessing
   purls: []
-  size: 945576
-  timestamp: 1762299687230
+  size: 942808
+  timestamp: 1768147973361
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_14.conda
   sha256: bbeb7cf8b7eff000b2cb5ffb9a40d98fbb8f39c94768afaec38408c3097cde0d
   md5: 8e96fe9b17d5871b5cf9d312cab832f6
@@ -1206,26 +1632,35 @@ packages:
   purls: []
   size: 5856715
   timestamp: 1764277148231
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_14.conda
-  sha256: 63336f51b88029a9557a430aecbb08a11365aa03ec47ec8d14e542fec5dc80fb
-  md5: 9531f671a13eec0597941fa19e489b96
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
+  sha256: e5f8c38625aa6d567809733ae04bb71c161a42e44a9fa8227abe61fa5c60ebe0
+  md5: cd5a90476766d53e901500df9215e927
   depends:
-  - libstdcxx 15.2.0 h934c35e_14
-  license: GPL-3.0-only WITH GCC-exception-3.1
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libstdcxx >=14
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
   purls: []
-  size: 27200
-  timestamp: 1764277193585
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
-  sha256: e5ec6d2ad7eef538ddcb9ea62ad4346fde70a4736342c4ad87bd713641eb9808
-  md5: 80c07c68d2f6870250959dcc95b209d1
+  size: 435273
+  timestamp: 1762022005702
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+  sha256: 1a7539cfa7df00714e8943e18de0b06cceef6778e420a5ee3a2a145773758aee
+  md5: db409b7c1720428638e7c0d509d3e1b5
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 37135
-  timestamp: 1758626800002
+  size: 40311
+  timestamp: 1766271528534
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
   sha256: c180f4124a889ac343fc59d15558e93667d894a966ec6fdb61da1604481be26b
   md5: 0f03292cc56bf91a077a134ea8747118
@@ -1237,6 +1672,33 @@ packages:
   purls: []
   size: 895108
   timestamp: 1753948278280
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+  sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
+  md5: aea31d2e5b1091feca96fcfe945c3cf9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 429011
+  timestamp: 1752159441324
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 395888
+  timestamp: 1727278577118
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
   sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   md5: 5aa797f8787fe7a17d1b0821485b5adc
@@ -1246,28 +1708,28 @@ packages:
   purls: []
   size: 100393
   timestamp: 1702724383534
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-h26afc86_0.conda
-  sha256: ec0735ae56c3549149eebd7dc22c0bed91fd50c02eaa77ff418613ddda190aa8
-  md5: e512be7dc1f84966d50959e900ca121f
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
+  sha256: 047be059033c394bd32ae5de66ce389824352120b3a7c0eff980195f7ed80357
+  md5: 417955234eccd8f252b86a265ccdab7f
   depends:
   - __glibc >=2.17,<3.0.a0
-  - icu >=75.1,<76.0a0
+  - icu >=78.1,<79.0a0
   - libgcc >=14
   - libiconv >=1.18,<2.0a0
   - liblzma >=5.8.1,<6.0a0
-  - libxml2-16 2.15.1 ha9997c6_0
+  - libxml2-16 2.15.1 hca6bf5a_1
   - libzlib >=1.3.1,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 45283
-  timestamp: 1761015644057
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-ha9997c6_0.conda
-  sha256: 71436e72a286ef8b57d6f4287626ff91991eb03c7bdbe835280521791efd1434
-  md5: e7733bc6785ec009e47a224a71917e84
+  size: 45402
+  timestamp: 1766327161688
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-hca6bf5a_1.conda
+  sha256: 8331284bf9ae641b70cdc0e5866502dd80055fc3b9350979c74bb1d192e8e09e
+  md5: 3fdd8d99683da9fe279c2f4cecd1e048
   depends:
   - __glibc >=2.17,<3.0.a0
-  - icu >=75.1,<76.0a0
+  - icu >=78.1,<79.0a0
   - libgcc >=14
   - libiconv >=1.18,<2.0a0
   - liblzma >=5.8.1,<6.0a0
@@ -1277,8 +1739,8 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 556302
-  timestamp: 1761015637262
+  size: 555747
+  timestamp: 1766327145986
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
   sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
   md5: edb0dca6bc32e4f4789199455a1dbeb8
@@ -1456,6 +1918,16 @@ packages:
   version: 0.1.2
   sha256: 84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
   requires_python: '>=3.7'
+- conda: https://conda.anaconda.org/conda-forge/noarch/mill-0.11.8-hed8d791_0.conda
+  sha256: 768c4b9ee618a532fa0f523a577482a2a04a1a4cf4945f257186fe34254a0cd4
+  md5: 874fe845e695f96ad6aaf962fe977dff
+  depends:
+  - openjdk
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 57639165
+  timestamp: 1733193112513
 - pypi: git+https://github.com/jorendumoulin/minimalloc.git?rev=917a2ddf8ea0f48c7c77145d57c21d7c5dd20ef2#917a2ddf8ea0f48c7c77145d57c21d7c5dd20ef2
   name: minimalloc
   version: 0.1.0
@@ -1532,27 +2004,67 @@ packages:
   - pkg:pypi/nodeenv?source=hash-mapping
   size: 34574
   timestamp: 1734112236147
-- conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.9.0-heeeca48_0.conda
-  sha256: 6abb823fd4d28e6474f40dfcf38e772e5869ee755be855cf5d2c0d49f888c75e
-  md5: 8a2a73951c1ea275e76fb1b92d97ff3e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-25.6.1-he4ff34a_0.conda
+  sha256: a722ae31e9e88d320fd28038c14a870001a00cbb23c21a52bfeac955622d811d
+  md5: d4dce17ff21a8d4eea024d32a35073be
   depends:
+  - libgcc >=14
   - __glibc >=2.28,<3.0.a0
   - libstdcxx >=14
-  - libgcc >=14
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libsqlite >=3.51.2,<4.0a0
   - libuv >=1.51.0,<2.0a0
-  - openssl >=3.5.3,<4.0a0
-  - icu >=75.1,<76.0a0
+  - openssl >=3.5.5,<4.0a0
   - libzlib >=1.3.1,<2.0a0
+  - c-ares >=1.34.6,<2.0a0
+  - libabseil >=20260107.1,<20260108.0a0
+  - libabseil * cxx17*
+  - libnghttp2 >=1.67.0,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - icu >=78.2,<79.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 25557455
-  timestamp: 1759064044872
+  size: 18785830
+  timestamp: 1771424256876
 - pypi: https://files.pythonhosted.org/packages/9e/3e/3757f304c704f2f0294a6b8340fcf2be244038be07da4cccf390fa678a9f/numpy-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: numpy
   version: 2.1.3
   sha256: 2312b2aa89e1f43ecea6da6ea9a810d06aae08321609d8dc0d0eda6d946a541b
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-17.0.17-h777afb3_0.conda
+  sha256: cd6c6492abbf32d8cf909bff1d56524177137a5c5ea3a92d08bed6d991c4e15e
+  md5: 42263a215562cdbefd30af6036c37c2e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.14,<1.3.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - giflib >=5.2.2,<5.3.0a0
+  - harfbuzz >=12.2.0
+  - lcms2 >=2.17,<3.0a0
+  - libcups >=2.3.3,<2.4.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - libpng >=1.6.50,<1.7.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxi >=1.8.2,<2.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  - xorg-libxt >=1.3.1,<2.0a0
+  - xorg-libxtst >=1.2.5,<2.0a0
+  license: GPL-2.0-or-later WITH Classpath-exception-2.0
+  license_family: GPL
+  purls: []
+  size: 170064352
+  timestamp: 1762395172991
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
   sha256: a47271202f4518a484956968335b2521409c8173e123ab381e775c358c67fe6d
   md5: 9ee58d5c534af06558933af3c845a780
@@ -1722,6 +2234,19 @@ packages:
   - xlsxwriter>=3.0.5 ; extra == 'all'
   - zstandard>=0.19.0 ; extra == 'all'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+  sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
+  md5: 7a3bff861a6583f1889021facefc08b1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1222481
+  timestamp: 1763655398280
 - pypi: https://files.pythonhosted.org/packages/4f/87/424511bdcd02c8d7acf9f65caa09f291a519b16bd83c3fb3374b3d4ae951/pillow-12.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: pillow
   version: 12.0.0
@@ -1754,6 +2279,19 @@ packages:
   - trove-classifiers>=2024.10.12 ; extra == 'tests'
   - defusedxml ; extra == 'xmp'
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+  sha256: 43d37bc9ca3b257c5dd7bf76a8426addbdec381f6786ff441dc90b1a49143b6a
+  md5: c01af13bdc553d1a8fbfff6e8db075f0
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 450960
+  timestamp: 1754665235234
 - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.0-pyhcf101f3_0.conda
   sha256: 7efd51b48d908de2d75cbb3c4a2e80dd9454e1c5bb8191b261af3136f7fa5888
   md5: 5c7a868f8241e64e1cf5fdf4962f23e2
@@ -1807,6 +2345,17 @@ packages:
   - pkg:pypi/psutil?source=hash-mapping
   size: 495011
   timestamp: 1762092914381
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 8252
+  timestamp: 1726802366959
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pulp-2.8.0-py312hd0750ca_3.conda
   sha256: ebc3fcf01092a6186e574295f808ba272fbf88234991262deef222b039023d73
   md5: 1ade2915cfabbcb8f07e7b4387f4d49b
@@ -2225,7 +2774,7 @@ packages:
 - pypi: ./
   name: snax-mlir
   version: 0.2.2
-  sha256: 327affab6ab3110e0a3461a5cb0c2f958777f44f5a60e147cd12cc99c4f85221
+  sha256: d7cdb3b6efc23376fdb37b93b2831f071849449da4c80c9aeedfc45db4ba2e32
   requires_dist:
   - xdsl @ git+https://github.com/xdslproject/xdsl.git@3c5c8794593d05e7d7070ce137c532aaf40095f3
   - minimalloc @ git+https://github.com/jorendumoulin/minimalloc.git@917a2ddf8ea0f48c7c77145d57c21d7c5dd20ef2
@@ -2505,6 +3054,156 @@ packages:
   - pyclip==0.7 ; extra == 'gui'
   - llvmlite~=0.46.0 ; extra == 'llvm'
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+  sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
+  md5: fb901ff28063514abb6046c9ec2c4a45
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 58628
+  timestamp: 1734227592886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+  sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
+  md5: 1c74ff8c35dcadf952a16f752ca5aa49
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 27590
+  timestamp: 1741896361728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+  sha256: 516d4060139dbb4de49a4dcdc6317a9353fb39ebd47789c14e6fe52de0deee42
+  md5: 861fb6ccbc677bb9a9fb2468430b9c6a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libxcb >=1.17.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 839652
+  timestamp: 1770819209719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+  sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
+  md5: b2895afaf55bf96a8c8282a2e47a5de0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 15321
+  timestamp: 1762976464266
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+  sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
+  md5: 1dafce8548e38671bea82e3f5c6ce22f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 20591
+  timestamp: 1762976546182
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+  sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
+  md5: 34e54f03dfea3e7a2dcf1453a85f1085
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 50326
+  timestamp: 1769445253162
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+  sha256: 83c4c99d60b8784a611351220452a0a85b080668188dce5dfa394b723d7b64f4
+  md5: ba231da7fccf9ea1e768caf5c7099b84
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 20071
+  timestamp: 1759282564045
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+  sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
+  md5: 17dcc85db3c7886650b8908b183d6876
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 47179
+  timestamp: 1727799254088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+  sha256: 80ed047a5cb30632c3dc5804c7716131d767089f65877813d4ae855ee5c9d343
+  md5: e192019153591938acf7322b6459d36e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 30456
+  timestamp: 1769445263457
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+  sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
+  md5: 96d57aba173e878a2089d5638016dc5e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 33005
+  timestamp: 1734229037766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+  sha256: a8afba4a55b7b530eb5c8ad89737d60d60bc151a03fbef7a2182461256953f0e
+  md5: 279b0de5f6ba95457190a1c459a64e31
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 379686
+  timestamp: 1731860547604
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+  sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
+  md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxi >=1.7.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 32808
+  timestamp: 1727964811275
 - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
   sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
   md5: a77f85f77be52ff59391544bfe73390a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,8 @@ default = { features = ["dev", "nn", "viz", "phs"] }
 
 [tool.pixi.feature.phs.dependencies]
 circt = { version = "==1.122.0", channel = "KEKE046" }
+openjdk = "==17.0.17"
+mill = "==0.11.8"
 
 [tool.pixi.dependencies]
 mlir = "==21.1.1"

--- a/snaxc/dialects/hardfloat.py
+++ b/snaxc/dialects/hardfloat.py
@@ -170,7 +170,7 @@ class AddRecFnOp(HardfloatOperation):
 
 @irdl_op_definition
 class FnToRecFnOp(HardfloatOperation):
-    CHISEL_NAME: ClassVar[str] = "RecFNFromFN"
+    CHISEL_NAME: ClassVar[str] = "recFNFromFN"
     CHISEL_INPUT_NAMES: ClassVar[tuple[str, ...]] = ("in",)
     CHISEL_OUTPUT_NAMES: ClassVar[tuple[str, ...]] = ("out",)
     name = "hardfloat.fn_to_rec_fn"
@@ -184,7 +184,7 @@ class FnToRecFnOp(HardfloatOperation):
 
 @irdl_op_definition
 class RecFnToFnOp(HardfloatOperation):
-    CHISEL_NAME: ClassVar[str] = "RecFNToFN"
+    CHISEL_NAME: ClassVar[str] = "fNFromRecFN"
     CHISEL_INPUT_NAMES: ClassVar[tuple[str, ...]] = ("in",)
     CHISEL_OUTPUT_NAMES: ClassVar[tuple[str, ...]] = ("out",)
     name = "hardfloat.rec_fn_to_fn"

--- a/snaxc/dialects/hardfloat.py
+++ b/snaxc/dialects/hardfloat.py
@@ -1,21 +1,19 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections.abc import Sequence
-from typing import cast
+from typing import ClassVar, cast
 
-from xdsl.dialects.builtin import IntAttr, IntegerType, Signedness, SignednessAttr
+from xdsl.dialects.builtin import IntAttr, IntegerType
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, opt_prop_def, prop_def, result_def, traits_def
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-from xdsl.traits import OpTrait, Pure
+from xdsl.traits import Pure
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.hints import isa
 
 
 class HardfloatOperation(IRDLOperation, ABC):
-    res = result_def(IntegerType)
     sig_width = prop_def(IntAttr)
     exp_width = prop_def(IntAttr)
     int_width = opt_prop_def(IntAttr)
@@ -85,135 +83,118 @@ class HardfloatOperation(IRDLOperation, ABC):
             prop_dict=prop_dict,
         )
 
-
-class HardfloatOpTrait(OpTrait, ABC):
-    """Base trait for all Hardfloat-specific verification logic."""
-
-    def verify(self, op: Operation) -> None:
-        if not isinstance(op, HardfloatOperation):
-            raise VerifyException(f"Trait {self.__class__.__name__} expects a HardfloatOperation.")
-        self.verify_hardfloat(op)
-
-    @abstractmethod
-    def verify_hardfloat(self, op: HardfloatOperation) -> None:
-        """Override this instead of verify()"""
-        pass
+    def get_chisel_name(self) -> str:
+        chisel_name = getattr(self, "CHISEL_NAME")
+        assert isinstance(chisel_name, str), f"{self.__class__.__name__} needs to set a CHISEL_NAME ClassVar"
+        return chisel_name
 
 
-class RecodedInputs(HardfloatOpTrait):
-    """
-    Provides verification to HardfloatOperation's to have proper bitwidths for their recoded inputs
-    """
-
-    def verify_hardfloat(self, op: HardfloatOperation) -> None:
-        sig_width = op.sig_width.data
-        exp_width = op.exp_width.data
-        for typ in op.operand_types:
-            if not isinstance(typ, IntegerType):
-                raise VerifyException("Expect input type to be of IntegerType")
-            if typ.bitwidth != sig_width + exp_width + 1:
-                raise VerifyException(
-                    f"Expect input type to be of sig_width ({sig_width}) + exp_width ({exp_width}) + 1 = {typ.bitwidth}"
-                )
+def verify_recoded(op: HardfloatOperation, typ: Attribute) -> None:
+    sig_width, exp_width = (op.sig_width.data, op.exp_width.data)
+    bit_width = cast(IntegerType, typ).bitwidth
+    if bit_width != sig_width + exp_width + 1:
+        raise VerifyException(
+            f"Expect type ({typ}) to be equal to sig_width ({sig_width}) + exp_width ({exp_width}) + 1"
+        )
 
 
-class RecodedOutputs(HardfloatOpTrait):
-    """
-    Provides verification to HardfloatOperation's to have proper bitwidths for their recoded outputs
-    """
-
-    def verify_hardfloat(self, op: HardfloatOperation) -> None:
-        sig_width = op.sig_width.data
-        exp_width = op.exp_width.data
-        for typ in op.result_types:
-            typ = cast(IntegerType, typ)  # verified by IRDL
-            if typ.bitwidth != sig_width + exp_width + 1:
-                raise VerifyException(
-                    f"Expect output type to be of sig_width ({sig_width})"
-                    f" + exp_width ({exp_width}) + 1 = {typ.bitwidth}"
-                )
+def verify_float(op: HardfloatOperation, typ: Attribute) -> None:
+    sig_width, exp_width = (op.sig_width.data, op.exp_width.data)
+    bit_width = cast(IntegerType, typ).bitwidth
+    if bit_width != sig_width + exp_width:
+        raise VerifyException(f"Expect type ({typ}) to be equal to sig_width ({sig_width}) + exp_width ({exp_width})")
 
 
-class IntegerOutputs(HardfloatOpTrait):
-    def verify_hardfloat(self, op: HardfloatOperation) -> None:
-        if op.int_width is None:
-            raise VerifyException("Expect op to have int_width property")
-        for typ in op.result_types:
-            typ = cast(IntegerType, typ)  # verified by IRDL
-            if typ.bitwidth != op.int_width.data:
-                raise VerifyException(
-                    f"Expect output type ({typ}) to have bitwidth given by int_width property ({op.int_width.data})"
-                )
-
-
-class IntegerInputs(HardfloatOpTrait):
-    def verify_hardfloat(self, op: HardfloatOperation) -> None:
-        if op.int_width is None:
-            raise VerifyException("Expect op to have int_width property")
-        for typ in op.operand_types:
-            typ = cast(IntegerType, typ)  # verified by IRDL
-            if typ.bitwidth != op.int_width.data:
-                raise VerifyException(
-                    f"Expect input type ({typ}) to have bitwidth given by int_width property ({op.int_width.data})"
-                )
-
-
-class IntegerConversion(OpTrait):
-    def verify(self, op: Operation):
-        if "signedness" not in op.properties:
-            raise VerifyException("IntegerConversion optrait expects signedness attr")
-        signedness = op.properties["signedness"]
-        if not isa(signedness, SignednessAttr):
-            raise VerifyException("Expect property signedness to have type SignednessAttr")
-        if signedness.data == Signedness.SIGNLESS:
-            raise VerifyException("Property signedness can not be Signless")
-
-
-class UnaryHardfloatOp(HardfloatOperation, ABC):
-    input = operand_def(IntegerType)
-
-
-class BinaryHardfloatOp(HardfloatOperation, ABC):
-    lhs = operand_def(IntegerType)
-    rhs = operand_def(IntegerType)
+def verify_int(op: HardfloatOperation, typ: Attribute):
+    if op.int_width is None:
+        raise VerifyException("Expect op to have int_width property")
+    if cast(IntegerType, typ).bitwidth != op.int_width.data:
+        raise VerifyException(
+            f"Expect output type ({typ}) to have bitwidth given by int_width property ({op.int_width.data})"
+        )
 
 
 @irdl_op_definition
-class MulRecFnOp(BinaryHardfloatOp):
+class MulRecFnOp(HardfloatOperation):
+    CHISEL_NAME: ClassVar[str] = "MulRecFN"
     name = "hardfloat.mul_rec_fn"
-    traits = traits_def(RecodedInputs(), RecodedOutputs())
+    a = operand_def(IntegerType)
+    b = operand_def(IntegerType)
+    roundingMode = operand_def(IntegerType(3))
+    detectTininess = operand_def(IntegerType(1))
+    out = result_def(IntegerType)
+
+    def verify_(self) -> None:
+        verify_recoded(self, self.a.type)
+        verify_recoded(self, self.b.type)
+        verify_recoded(self, self.out.type)
 
 
 @irdl_op_definition
-class AddRecFnOp(BinaryHardfloatOp):
+class AddRecFnOp(HardfloatOperation):
+    CHISEL_NAME: ClassVar[str] = "AddRecFN"
     name = "hardfloat.add_rec_fn"
-    traits = traits_def(RecodedInputs(), RecodedOutputs())
+    subOp = operand_def(IntegerType(1))
+    a = operand_def(IntegerType)
+    b = operand_def(IntegerType)
+    roundingMode = operand_def(IntegerType(3))
+    detectTininess = operand_def(IntegerType(1))
+    out = result_def(IntegerType)
+
+    def verify_(self) -> None:
+        verify_recoded(self, self.a.type)
+        verify_recoded(self, self.b.type)
+        verify_recoded(self, self.out.type)
 
 
 @irdl_op_definition
-class FnToRecFnOp(UnaryHardfloatOp):
+class FnToRecFnOp(HardfloatOperation):
+    CHISEL_NAME: ClassVar[str] = "RecFNFromFN"
     name = "hardfloat.fn_to_rec_fn"
-    traits = traits_def(RecodedOutputs())
+    input = operand_def(IntegerType)
+    out = result_def(IntegerType)
+
+    def verify_(self) -> None:
+        verify_float(self, self.input.type)
+        verify_recoded(self, self.out.type)
 
 
 @irdl_op_definition
-class RecFnToFnOp(UnaryHardfloatOp):
+class RecFnToFnOp(HardfloatOperation):
+    CHISEL_NAME: ClassVar[str] = "RecFNToFN"
     name = "hardfloat.rec_fn_to_fn"
-    traits = traits_def(RecodedInputs())
+    input = operand_def(IntegerType)
+    out = result_def(IntegerType)
+
+    def verify_(self) -> None:
+        verify_recoded(self, self.input.type)
+        verify_float(self, self.out.type)
 
 
 @irdl_op_definition
-class InToRecFnOp(UnaryHardfloatOp):
+class InToRecFnOp(HardfloatOperation):
+    CHISEL_NAME: ClassVar[str] = "INToRecFN"
     name = "hardfloat.in_to_rec_fn"
-    signedness = prop_def(SignednessAttr)
-    traits = traits_def(IntegerInputs(), RecodedOutputs(), IntegerConversion())
+    signedIn = operand_def(IntegerType(1))
+    input = operand_def(IntegerType)
+    out = result_def(IntegerType)
+
+    def verify_(self) -> None:
+        verify_int(self, self.input.type)
+        verify_recoded(self, self.out.type)
 
 
 @irdl_op_definition
-class RecFnToInOp(UnaryHardfloatOp):
+class RecFnToInOp(HardfloatOperation):
+    CHISEL_NAME: ClassVar[str] = "RecFNToIN"
     name = "hardfloat.rec_fn_to_in"
-    signedness = prop_def(SignednessAttr)
-    traits = traits_def(RecodedInputs(), IntegerOutputs(), IntegerConversion())
+    input = operand_def(IntegerType)
+    signedOut = operand_def(IntegerType(1))
+    out = result_def(IntegerType)
+
+    def verify_(self) -> None:
+        verify_recoded(self, self.input.type)
+        verify_int(self, self.out.type)
 
 
 Hardfloat = Dialect(

--- a/snaxc/dialects/hardfloat.py
+++ b/snaxc/dialects/hardfloat.py
@@ -133,13 +133,14 @@ def verify_int(op: HardfloatOperation, typ: Attribute):
 class MulRecFnOp(HardfloatOperation):
     CHISEL_NAME: ClassVar[str] = "MulRecFN"
     CHISEL_INPUT_NAMES: ClassVar[tuple[str, ...]] = ("a", "b", "roundingMode", "detectTininess")
-    CHISEL_OUTPUT_NAMES: ClassVar[tuple[str, ...]] = ("out",)
+    CHISEL_OUTPUT_NAMES: ClassVar[tuple[str, ...]] = ("out", "exceptionFlags")
     name = "hardfloat.mul_rec_fn"
     a = operand_def(IntegerType)
     b = operand_def(IntegerType)
     roundingMode = operand_def(IntegerType(3))
     detectTininess = operand_def(IntegerType(1))
     out = result_def(IntegerType)
+    exceptionFlags = result_def(IntegerType(5))
 
     def verify_(self) -> None:
         verify_recoded(self, self.a.type)
@@ -151,7 +152,7 @@ class MulRecFnOp(HardfloatOperation):
 class AddRecFnOp(HardfloatOperation):
     CHISEL_NAME: ClassVar[str] = "AddRecFN"
     CHISEL_INPUT_NAMES: ClassVar[tuple[str, ...]] = ("subOp", "a", "b", "roundingMode", "detectTininess")
-    CHISEL_OUTPUT_NAMES: ClassVar[tuple[str, ...]] = ("out",)
+    CHISEL_OUTPUT_NAMES: ClassVar[tuple[str, ...]] = ("out", "exceptionFlags")
     name = "hardfloat.add_rec_fn"
     subOp = operand_def(IntegerType(1))
     a = operand_def(IntegerType)
@@ -159,6 +160,7 @@ class AddRecFnOp(HardfloatOperation):
     roundingMode = operand_def(IntegerType(3))
     detectTininess = operand_def(IntegerType(1))
     out = result_def(IntegerType)
+    exceptionFlags = result_def(IntegerType(5))
 
     def verify_(self) -> None:
         verify_recoded(self, self.a.type)
@@ -198,13 +200,14 @@ class RecFnToFnOp(HardfloatOperation):
 class InToRecFnOp(HardfloatOperation):
     CHISEL_NAME: ClassVar[str] = "INToRecFN"
     CHISEL_INPUT_NAMES: ClassVar[tuple[str, ...]] = ("signedIn", "in", "roundingMode", "detectTininess")
-    CHISEL_OUTPUT_NAMES: ClassVar[tuple[str, ...]] = ("out",)
+    CHISEL_OUTPUT_NAMES: ClassVar[tuple[str, ...]] = ("out", "exceptionFlags")
     name = "hardfloat.in_to_rec_fn"
     signedIn = operand_def(IntegerType(1))
     in_ = operand_def(IntegerType)  # "in" is reserved in python
     roundingMode = operand_def(IntegerType(3))
     detectTininess = operand_def(IntegerType(1))
     out = result_def(IntegerType)
+    exceptionFlags = result_def(IntegerType(5))
 
     def verify_(self) -> None:
         verify_int(self, self.in_.type)
@@ -215,12 +218,14 @@ class InToRecFnOp(HardfloatOperation):
 class RecFnToInOp(HardfloatOperation):
     CHISEL_NAME: ClassVar[str] = "RecFNToIN"
     CHISEL_INPUT_NAMES: ClassVar[tuple[str, ...]] = ("in", "roundingMode", "signedOut")
-    CHISEL_OUTPUT_NAMES: ClassVar[tuple[str, ...]] = ("out",)
+    CHISEL_OUTPUT_NAMES: ClassVar[tuple[str, ...]] = ("out", "exceptionFlags")
     name = "hardfloat.rec_fn_to_in"
     in_ = operand_def(IntegerType)  # "in" is reserved in python
     roundingMode = operand_def(IntegerType(3))
     signedOut = operand_def(IntegerType(1))
     out = result_def(IntegerType)
+    # conversions to integer can never underflow or deliver an infinite result
+    exceptionFlags = result_def(IntegerType(3))  # So this is 3 bits instead of 5
 
     def verify_(self) -> None:
         verify_recoded(self, self.in_.type)

--- a/snaxc/dialects/hardfloat.py
+++ b/snaxc/dialects/hardfloat.py
@@ -124,9 +124,7 @@ def verify_int(op: HardfloatOperation, typ: Attribute):
     if op.int_width is None:
         raise VerifyException("Expect op to have int_width property")
     if cast(IntegerType, typ).bitwidth != op.int_width.data:
-        raise VerifyException(
-            f"Expect output type ({typ}) to have bitwidth given by int_width property ({op.int_width.data})"
-        )
+        raise VerifyException(f"Expect type ({typ}) to have bitwidth given by int_width property ({op.int_width.data})")
 
 
 @irdl_op_definition

--- a/snaxc/transforms/__init__.py
+++ b/snaxc/transforms/__init__.py
@@ -115,6 +115,11 @@ def get_all_snax_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return ConvertFloatToHardfloatPass
 
+    def get_convert_hardfloat_to_hw():
+        from snaxc.transforms.hardfloat.convert_hardfloat_to_hw import ConvertHardfloatToHw
+
+        return ConvertHardfloatToHw
+
     def get_hardfloat_reconcile_recodes():
         from snaxc.transforms.hardfloat.reconcile_recodes import ReconcileRecodesPass
 
@@ -321,6 +326,7 @@ def get_all_snax_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "phs-remove-phs": get_phs_remove_phs,
         "phs-convert-float-to-int": get_phs_convert_float_to_int,
         "convert-float-to-hardfloat": get_convert_float_to_hardfloat,
+        "convert-hardfloat-to-hw": get_convert_hardfloat_to_hw,
         "hardfloat-reconcile-recodes": get_hardfloat_reconcile_recodes,
         "convert-dart-to-snax-stream": get_convert_dart_to_snax_stream,
         "convert-kernel-to-linalg": get_convert_kernel_to_linalg,

--- a/snaxc/transforms/hardfloat/convert_float_to_hardfloat.py
+++ b/snaxc/transforms/hardfloat/convert_float_to_hardfloat.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import cast
 
 from xdsl.context import Context
-from xdsl.dialects import arith
+from xdsl.dialects import arith, hw
 from xdsl.dialects.builtin import (
     AnyFloat,
     BFloat16Type,
@@ -12,12 +12,9 @@ from xdsl.dialects.builtin import (
     Float64Type,
     IntegerType,
     ModuleOp,
-    SignednessAttr,
     UnrealizedConversionCastOp,
 )
-from xdsl.ir import Attribute, Operation
-from xdsl.irdl import isa
-from xdsl.parser import Signedness
+from xdsl.ir import Attribute
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -27,7 +24,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 
-from snaxc.dialects import hardfloat
+from snaxc.dialects.hardfloat import AddRecFnOp, FnToRecFnOp, InToRecFnOp, MulRecFnOp, RecFnToFnOp, RecFnToInOp
 
 _type_mapping: dict[type[Attribute], tuple[int, int]] = {
     Float64Type: (11, 53),
@@ -36,35 +33,64 @@ _type_mapping: dict[type[Attribute], tuple[int, int]] = {
     BFloat16Type: (8, 8),
 }
 
-# Op conversion
-_arith_to_hardfloat: dict[type[Operation], type[hardfloat.HardfloatOperation]] = {
-    arith.AddfOp: hardfloat.AddRecFnOp,
-    arith.MulfOp: hardfloat.MulRecFnOp,
-}
 
-
-class ConvertFloatBinaryOps(RewritePattern):
+class ConvertAddSubOp(RewritePattern):
     @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: arith.FloatingPointLikeBinaryOperation, rewriter: PatternRewriter):
+    def match_and_rewrite(self, op: arith.AddfOp | arith.SubfOp, rewriter: PatternRewriter):
         # Get sig_width and exp_witdh:
-        in_type = op.lhs.type
+        in_type = cast(AnyFloat, op.lhs.type)  # These are verified by IRDL
         if type(in_type) not in _type_mapping:
             return
         exp_width, sig_width = _type_mapping[type(in_type)]
-        assert isa(in_type, AnyFloat)
         bitwidth = in_type.bitwidth
-        if type(op) not in _arith_to_hardfloat:
+        match op:
+            case arith.AddfOp():
+                subOp = hw.ConstantOp(0, 1)
+            case arith.SubfOp():
+                subOp = hw.ConstantOp(1, 1)
+        # Create the recode - core_op - unrecode sandwich
+        new_ops = [
+            subOp,
+            cast_lhs := UnrealizedConversionCastOp.get([op.lhs], [IntegerType(bitwidth)]),
+            cast_rhs := UnrealizedConversionCastOp.get([op.rhs], [IntegerType(bitwidth)]),
+            recode_lhs := FnToRecFnOp([cast_lhs], [IntegerType(bitwidth + 1)], sig_width, exp_width),
+            recode_rhs := FnToRecFnOp([cast_rhs], [IntegerType(bitwidth + 1)], sig_width, exp_width),
+            rounding_mode := hw.ConstantOp(0, 3),
+            tininess := hw.ConstantOp(1, 1),
+            add := AddRecFnOp(
+                [subOp, recode_lhs, recode_rhs, rounding_mode, tininess],
+                [IntegerType(bitwidth + 1)],
+                sig_width,
+                exp_width,
+            ),
+            unrecode := RecFnToFnOp([add], [IntegerType(bitwidth)], sig_width, exp_width),
+            cast_res := UnrealizedConversionCastOp.get([unrecode], [in_type]),
+        ]
+        rewriter.replace_op(op, new_ops=new_ops, new_results=[cast_res.results[0]])
+
+
+class ConvertMulOp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: arith.MulfOp, rewriter: PatternRewriter):
+        # Get sig_width and exp_witdh:
+        in_type = cast(AnyFloat, op.lhs.type)  # These are verified by IRDL
+        if type(in_type) not in _type_mapping:
             return
-        CoreOp = _arith_to_hardfloat[type(op)]
+        exp_width, sig_width = _type_mapping[type(in_type)]
+        bitwidth = in_type.bitwidth
 
         # Create the recode - core_op - unrecode sandwich
         new_ops = [
             cast_lhs := UnrealizedConversionCastOp.get([op.lhs], [IntegerType(bitwidth)]),
             cast_rhs := UnrealizedConversionCastOp.get([op.rhs], [IntegerType(bitwidth)]),
-            recode_lhs := hardfloat.FnToRecFnOp([cast_lhs], [IntegerType(bitwidth + 1)], sig_width, exp_width),
-            recode_rhs := hardfloat.FnToRecFnOp([cast_rhs], [IntegerType(bitwidth + 1)], sig_width, exp_width),
-            core_op := CoreOp([recode_lhs, recode_rhs], [IntegerType(bitwidth + 1)], sig_width, exp_width),
-            unrecode := hardfloat.RecFnToFnOp([core_op], [IntegerType(bitwidth)], sig_width, exp_width),
+            recode_lhs := FnToRecFnOp([cast_lhs], [IntegerType(bitwidth + 1)], sig_width, exp_width),
+            recode_rhs := FnToRecFnOp([cast_rhs], [IntegerType(bitwidth + 1)], sig_width, exp_width),
+            rounding_mode := hw.ConstantOp(0, 3),
+            tininess := hw.ConstantOp(1, 1),
+            mul := MulRecFnOp(
+                [recode_lhs, recode_rhs, rounding_mode, tininess], [IntegerType(bitwidth + 1)], sig_width, exp_width
+            ),
+            unrecode := RecFnToFnOp([mul], [IntegerType(bitwidth)], sig_width, exp_width),
             cast_res := UnrealizedConversionCastOp.get([unrecode], [in_type]),
         ]
         rewriter.replace_op(op, new_ops=new_ops, new_results=[cast_res.results[0]])
@@ -72,21 +98,20 @@ class ConvertFloatBinaryOps(RewritePattern):
 
 class ConvertIToFPOp(RewritePattern):
     @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: arith.IntegerToFloatingPointBaseOp, rewriter: PatternRewriter):
-        match op.name:
-            case arith.SIToFPOp.name:
-                props = {"signedness": cast(Attribute, SignednessAttr.get(Signedness.SIGNED))}
-            case arith.UIToFPOp.name:
-                props = {"signedness": cast(Attribute, SignednessAttr.get(Signedness.UNSIGNED))}
-            case _:
-                raise NotImplementedError()
+    def match_and_rewrite(self, op: arith.SIToFPOp | arith.UIToFPOp, rewriter: PatternRewriter):
+        match op:
+            case arith.SIToFPOp():
+                signed_in = hw.ConstantOp(1, 1)
+            case arith.UIToFPOp():
+                signed_in = hw.ConstantOp(0, 1)
         exp_width, sig_width = _type_mapping[type(op.result.type)]
         bitwidth = cast(IntegerType, op.input.type).bitwidth
         new_ops = [
-            rec_fn := hardfloat.InToRecFnOp(
-                [op.input], [IntegerType(bitwidth + 1)], sig_width, exp_width, bitwidth, prop_dict=props
+            signed_in,
+            rec_fn := InToRecFnOp(
+                [signed_in.result, op.input], [IntegerType(bitwidth + 1)], sig_width, exp_width, bitwidth
             ),
-            unrecode := hardfloat.RecFnToFnOp([rec_fn], [IntegerType(bitwidth)], sig_width, exp_width),
+            unrecode := RecFnToFnOp([rec_fn], [IntegerType(bitwidth)], sig_width, exp_width),
             cast_res := UnrealizedConversionCastOp.get([unrecode], [op.result.type]),
         ]
         rewriter.replace_op(op, new_ops=new_ops, new_results=[cast_res.results[0]])
@@ -97,19 +122,18 @@ class ConvertFPToIOp(RewritePattern):
     def match_and_rewrite(self, op: arith.FloatingPointToIntegerBaseOp, rewriter: PatternRewriter):
         match op.name:
             case arith.FPToSIOp.name:
-                props = {"signedness": cast(Attribute, SignednessAttr.get(Signedness.SIGNED))}
+                constant = hw.ConstantOp(1, 1)
             case arith.FPToUIOp.name:
-                props = {"signedness": cast(Attribute, SignednessAttr.get(Signedness.UNSIGNED))}
+                constant = hw.ConstantOp(0, 1)
             case _:
                 raise NotImplementedError()
         exp_width, sig_width = _type_mapping[type(op.input.type)]
         bitwidth = cast(IntegerType, op.input.type).bitwidth
         new_ops = [
+            constant,
             cast_res := UnrealizedConversionCastOp.get([op.input], [op.result.type]),
-            recode := hardfloat.FnToRecFnOp([cast_res], [IntegerType(bitwidth + 1)], sig_width, exp_width),
-            rec_fn := hardfloat.RecFnToInOp(
-                [recode], [IntegerType(bitwidth)], sig_width, exp_width, bitwidth, prop_dict=props
-            ),
+            recode := FnToRecFnOp([cast_res], [IntegerType(bitwidth + 1)], sig_width, exp_width),
+            rec_fn := RecFnToInOp([recode, constant], [IntegerType(bitwidth)], sig_width, exp_width, bitwidth),
         ]
         rewriter.replace_op(op, new_ops=new_ops, new_results=[rec_fn.results[0]])
 
@@ -119,6 +143,6 @@ class ConvertFloatToHardfloatPass(ModulePass):
 
     def apply(self, ctx: Context, op: ModuleOp) -> None:
         PatternRewriteWalker(
-            GreedyRewritePatternApplier([ConvertFloatBinaryOps(), ConvertIToFPOp(), ConvertFPToIOp()]),
+            GreedyRewritePatternApplier([ConvertAddSubOp(), ConvertMulOp(), ConvertIToFPOp(), ConvertFPToIOp()]),
             apply_recursively=False,
         ).rewrite_module(op)

--- a/snaxc/transforms/hardfloat/convert_hardfloat_to_hw.py
+++ b/snaxc/transforms/hardfloat/convert_hardfloat_to_hw.py
@@ -6,8 +6,8 @@ from typing import cast
 
 from xdsl.context import Context
 from xdsl.dialects import builtin, hw
-from xdsl.dialects.builtin import ModuleOp, SymbolRefAttr
-from xdsl.ir import Attribute, SSAValue, TypeAttribute
+from xdsl.dialects.builtin import IntegerType, ModuleOp, SymbolRefAttr
+from xdsl.ir import Attribute, Operation, SSAValue, TypeAttribute
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -17,10 +17,18 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 
-from snaxc.dialects import hardfloat
+from snaxc.dialects.hardfloat import (
+    AddRecFnOp,
+    Exception5,
+    FnToRecFnOp,
+    HardfloatOperation,
+    MulRecFnOp,
+    RecFnToFnOp,
+    Rounding,
+)
 
 
-def get_suffix(op: hardfloat.HardfloatOperation) -> str:
+def get_suffix(op: HardfloatOperation) -> str:
     if op.int_width is None:
         return f"_s{op.sig_width.data}_e{op.exp_width.data}"
     else:
@@ -63,30 +71,50 @@ class HWBlockSpec:
         return hw.InstanceOp(
             name,
             self.symbol_attr,
-            tuple(zip(self.in_ports, inputs)),
-            tuple(zip(self.out_ports, [cast(TypeAttribute, out_type) for out_type in self.out_types])),
+            tuple(
+                zip(self.in_ports, inputs, strict=True),
+            ),
+            tuple(
+                zip(
+                    self.out_ports,
+                    [cast(TypeAttribute, out_type) for out_type in self.out_types],
+                )
+            ),
         )
 
     def module(self) -> hw.HWModuleExternOp:
-        mod_type = hw.ModuleType(
-            builtin.ArrayAttr(
-                [
-                    *(
-                        hw.ModulePort(
-                            builtin.StringAttr(p), cast(TypeAttribute, t), hw.DirectionAttr(hw.Direction.INPUT)
-                        )
-                        for p, t in zip(self.in_ports, self.in_types)
-                    ),
-                    *(
-                        hw.ModulePort(
-                            builtin.StringAttr(p), cast(TypeAttribute, t), hw.DirectionAttr(hw.Direction.OUTPUT)
-                        )
-                        for p, t in zip(self.out_ports, self.out_types)
-                    ),
-                ]
+        in_ports: list[hw.ModulePort] = []
+        for p, t in zip(self.in_ports, self.in_types):
+            in_ports.append(
+                hw.ModulePort(builtin.StringAttr(p), cast(TypeAttribute, t), hw.DirectionAttr(hw.Direction.INPUT))
             )
-        )
+        out_ports: list[hw.ModulePort] = []
+        for p, t in zip(self.out_ports, self.out_types):
+            out_ports.append(
+                hw.ModulePort(builtin.StringAttr(p), cast(TypeAttribute, t), hw.DirectionAttr(hw.Direction.OUTPUT))
+            )
+        mod_type = hw.ModuleType(builtin.ArrayAttr([*in_ports, *out_ports]))
         return hw.HWModuleExternOp(builtin.StringAttr(self.symbol_name), mod_type)
+
+    @staticmethod
+    def from_op(op: HardfloatOperation) -> HWBlockSpec:
+        suffix = get_suffix(op)
+        symbol_name = op.get_chisel_name() + suffix
+        # Input names
+        input_names = ["a", "b", "c"][: len(op.operands)]
+        input_types = [*op.operand_types]
+        if Rounding() in op.traits:
+            input_names.extend(["roundingMode", "detectTininess"])
+            input_types.extend([IntegerType(3), IntegerType(1)])
+        io_input_names = (*(f"io_{name}" for name in input_names),)
+        # Output names
+        output_names = ["out"]
+        output_types = [*op.result_types]
+        if Exception5() in op.traits:
+            output_names.extend(["exceptionFlags"])
+            output_types.extend([IntegerType(5)])
+        io_output_names = (*(f"io_{name}" for name in output_names),)
+        return HWBlockSpec(symbol_name, io_input_names, tuple(input_types), io_output_names, tuple(output_types))
 
 
 @dataclass
@@ -96,32 +124,37 @@ class ConvertSimpleOps(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(
         self,
-        op: hardfloat.AddRecFnOp
-        | hardfloat.MulRecFnOp
-        | hardfloat.RecFnToFnOp
-        | hardfloat.FnToRecFnOp
-        | hardfloat.RecFnToInOp
-        | hardfloat.InToRecFnOp,
+        op: AddRecFnOp | MulRecFnOp | RecFnToFnOp | FnToRecFnOp,
         rewriter: PatternRewriter,
     ):
-        suffix = get_suffix(op)
         match op:
-            case hardfloat.AddRecFnOp():
-                symbol_name = f"AddRecFN{suffix}"
-            case hardfloat.MulRecFnOp():
-                symbol_name = f"MulRecFN{suffix}"
-            case hardfloat.RecFnToFnOp():
-                symbol_name = f"RecFnToFnOp{suffix}"
-            case hardfloat.FnToRecFnOp():
-                symbol_name = f"FnToRecFnOp{suffix}"
-            case hardfloat.RecFnToInOp():
-                symbol_name = f"RecFnToInOp{suffix}"
-            case hardfloat.InToRecFnOp():
-                symbol_name = f"InToRecFnOp{suffix}"
-        hw_block = HWBlockSpec(symbol_name, ("io_a",), op.operand_types, ("io_out",), op.result_types)
+            case AddRecFnOp():
+                new_ops: list[Operation] = [
+                    c0_i3 := hw.ConstantOp(0, 3),
+                    c0_i1 := hw.ConstantOp(0, 1),
+                ]
+                input_vals = [*op.operands, c0_i3.result, c0_i1.result]
+                hw_block = HWBlockSpec.from_op(op)
+            case MulRecFnOp():
+                new_ops: list[Operation] = [
+                    c0_i3 := hw.ConstantOp(0, 3),
+                    c0_i1 := hw.ConstantOp(0, 1),
+                ]
+                input_vals = [*op.operands, c0_i3.result, c0_i1.result]
+                hw_block = HWBlockSpec.from_op(op)
+            case RecFnToFnOp():
+                new_ops: list[Operation] = []
+                input_vals = op.operands
+                hw_block = HWBlockSpec.from_op(op)
+            case FnToRecFnOp():
+                new_ops: list[Operation] = []
+                input_vals = [*op.operands]
+                hw_block = HWBlockSpec.from_op(op)
+        symbol_name = hw_block.symbol_name
         count = get_count(self.counts, hw_block)
-        instance_op = hw_block.instance(f"{symbol_name}_{count}", [*op.operands])
-        rewriter.replace_op(op, instance_op, new_results=instance_op.results)
+        instance_op = hw_block.instance(f"{symbol_name}_{count}", input_vals)
+        new_ops.append(instance_op)
+        rewriter.replace_op(op, new_ops, new_results=[instance_op.results[0]])
 
 
 class ConvertHardfloatToHw(ModulePass):

--- a/snaxc/transforms/hardfloat/convert_hardfloat_to_hw.py
+++ b/snaxc/transforms/hardfloat/convert_hardfloat_to_hw.py
@@ -170,5 +170,3 @@ class ConvertHardfloatToHw(ModulePass):
         assert body is not None
         for spec in sorted(counts.keys(), key=lambda spec: spec.symbol_name):
             body.add_op(spec.module())
-        # for i, (spec, count) in enumerate(counts.items()):
-        #    print(f"{i}) {spec.symbol_name:20} : {count}")

--- a/snaxc/transforms/hardfloat/convert_hardfloat_to_hw.py
+++ b/snaxc/transforms/hardfloat/convert_hardfloat_to_hw.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import cast
+
+from xdsl.context import Context
+from xdsl.dialects import builtin, hw
+from xdsl.dialects.builtin import ModuleOp, SymbolRefAttr
+from xdsl.ir import Attribute, SSAValue, TypeAttribute
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+from snaxc.dialects import hardfloat
+
+
+def get_suffix(op: hardfloat.HardfloatOperation) -> str:
+    return f"_s{op.sig_width.data}_e{op.exp_width.data}"
+
+
+@dataclass(frozen=True)
+class HWBlockSpec:
+    """
+    Represents an external HW module that can be called
+
+    Makes it easier to wrangle the hw dialect.
+
+    This helper allows one to easily define a certain piece of hardware declaratively, and then create
+    both hw.instance ops and hw.module.external ops.
+    """
+
+    symbol_name: str
+    in_ports: tuple[str, ...]
+    in_types: tuple[Attribute, ...]
+    out_ports: tuple[str, ...]
+    out_types: tuple[Attribute, ...]
+
+    @property
+    def symbol_attr(self) -> SymbolRefAttr:
+        return SymbolRefAttr(self.symbol_name)
+
+    def instance(self, name: str, inputs: Sequence[SSAValue]) -> hw.InstanceOp:
+        return hw.InstanceOp(
+            name,
+            self.symbol_attr,
+            tuple(zip(self.in_ports, inputs)),
+            tuple(zip(self.out_ports, [cast(TypeAttribute, out_type) for out_type in self.out_types])),
+        )
+
+    def module(self) -> hw.HWModuleExternOp:
+        mod_type = hw.ModuleType(
+            builtin.ArrayAttr(
+                [
+                    *(
+                        hw.ModulePort(
+                            builtin.StringAttr(p), cast(TypeAttribute, t), hw.DirectionAttr(hw.Direction.INPUT)
+                        )
+                        for p, t in zip(self.in_ports, self.in_types)
+                    ),
+                    *(
+                        hw.ModulePort(
+                            builtin.StringAttr(p), cast(TypeAttribute, t), hw.DirectionAttr(hw.Direction.OUTPUT)
+                        )
+                        for p, t in zip(self.out_ports, self.out_types)
+                    ),
+                ]
+            )
+        )
+        return hw.HWModuleExternOp(builtin.StringAttr(self.symbol_name), mod_type)
+
+
+@dataclass
+class ConvertAdd(RewritePattern):
+    seen: set[HWBlockSpec] = field(default_factory=set[HWBlockSpec])
+    counter = 0
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: hardfloat.AddRecFnOp, rewriter: PatternRewriter):
+        instance_name = f"AddRecFN{get_suffix(op)}"
+        add_block = HWBlockSpec(
+            instance_name, ("io_a", "io_b"), (op.lhs.type, op.rhs.type), ("io_out",), (op.res.type,)
+        )
+        self.seen.add(add_block)
+        instance_op = add_block.instance(f"{instance_name}_{self.counter}", [op.lhs, op.rhs])
+        rewriter.replace_op(op, instance_op, new_results=instance_op.results)
+
+
+class ConvertHardfloatToHw(ModulePass):
+    name = "convert-hardfloat-to-hw"
+
+    def apply(self, ctx: Context, op: ModuleOp) -> None:
+        seen: set[HWBlockSpec] = set()
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    ConvertAdd(seen),
+                ]
+            ),
+            apply_recursively=False,
+        ).rewrite_module(op)
+        body = op.body.block
+        assert body is not None
+        for spec in sorted(seen, key=lambda spec: spec.symbol_name):
+            body.add_op(spec.module())

--- a/snaxc/transforms/hardfloat/convert_hardfloat_to_hw.py
+++ b/snaxc/transforms/hardfloat/convert_hardfloat_to_hw.py
@@ -119,8 +119,12 @@ class ConvertHardfloatOps(RewritePattern):
         rewriter.replace_op(op, instance_op, new_results=instance_op.results)
 
 
+@dataclass(frozen=True)
 class ConvertHardfloatToHw(ModulePass):
     name = "convert-hardfloat-to-hw"
+
+    easyfloat_path: str = ""
+    external_modules: bool = False
 
     def apply(self, ctx: Context, op: ModuleOp) -> None:
         counts: dict[HWBlockSpec, int] = {}
@@ -129,20 +133,28 @@ class ConvertHardfloatToHw(ModulePass):
             apply_recursively=False,
         ).rewrite_module(op)
 
-        external_modules = False
-        if external_modules:
+        # Don't proceed with adding modules if no operations were inserted
+        if len(counts) == 0:
+            return
+
+        # Reference new hw blocks as external modules
+        if self.external_modules:
             body = op.body.block
             assert body is not None
             for spec in sorted(counts.keys(), key=lambda spec: spec.symbol_name):
                 body.add_op(spec.module())
+
+        # Call EasyFloat to generate hw dialect for blocks,
+        # parse the output, and inline in the module
         else:
-            # Call EasyFloat to generate hw dialect for blocks and parse the output
+            if len(self.easyfloat_path) == 0:
+                raise RuntimeError("Must provide easyfloat path if not using external_modules=True")
             ops = ",".join([spec.symbol_name for spec in counts.keys()])
             mill_cmd = f"mill 'EasyFloat.run' --ops {ops} --format=hw"
             try:
                 mill_process = subprocess.run(
                     mill_cmd,
-                    cwd="/home/josse/kuleuven-easyfloat",
+                    cwd=self.easyfloat_path,
                     capture_output=True,
                     shell=True,
                     text=True,
@@ -153,12 +165,12 @@ class ConvertHardfloatToHw(ModulePass):
                 )
             except subprocess.CalledProcessError as e:
                 if e.stdout:
-                    print("\n[STDOUT CAPTURE]")
+                    print("\n[Error occured during Easyfloat module inlining: STDOUT CAPTURE]")
                     print(e.stdout)
                 if e.stderr:
-                    print("\n[STDERR CAPTURE]")
+                    print("\n[Error occured during Easyfloat module inlining: STDERR CAPTURE]")
                     print(e.stderr)
-                exit(0)
+                raise DiagnosticException("Error occured during Easyfloat module inlining")
             # Get the stdout output
             stdout_output = opt_process.stdout
             parser = Parser(ctx, stdout_output)

--- a/tests/filecheck/dialects/hardfloat/invalid.mlir
+++ b/tests/filecheck/dialects/hardfloat/invalid.mlir
@@ -1,68 +1,56 @@
 // RUN: snax-opt %s --verify-diagnostics --split-input-file | filecheck %s
 
-// 1. Test RecodedInputs: Input bitwidth != sig_width + exp_width + 1
-func.func @test_recoded_inputs_width(%a : i32, %b : i33) {
-  // CHECK: Expect input type to be of sig_width (24) + exp_width (8) + 1 = 32
-  %mul = hardfloat.mul_rec_fn<24, 8>(%a, %b) : (i32, i33) -> i33
+// 1. Test verify_recoded: Input/Output bitwidth != sig_width + exp_width + 1
+func.func @test_verify_recoded(%a : i32, %b : i33, %rm : i3, %tininess : i1) {
+  // CHECK: Expect type (i32) to be equal to sig_width (24) + exp_width (8) + 1
+  %mul = hardfloat.mul_rec_fn<24, 8>(%a, %b, %rm, %tininess) : (i32, i33, i3, i1) -> i33
   func.return
 }
 
 // -----
 
-// 2. Test RecodedInputs: Input is not an IntegerType (if applicable in IR parsing)
-// Note: In xDSL, if the operand_def is IntegerType, the parser might catch it first,
-// but the verifier trait ensures it.
-func.func @test_recoded_inputs_type(%a : f32, %b : i33) {
-  // CHECK: operand 'lhs' at position 0 does not verify:
-  // CHECK-NEXT: f32 should be of base attribute integer_type
-  %mul = hardfloat.mul_rec_fn<24, 8>(%a, %b) : (f32, i33) -> i33
+// 2. Test verify_float: Input bitwidth != sig_width + exp_width
+func.func @test_verify_float(%a : i31) {
+  // CHECK: Expect type (i31) to be equal to sig_width (24) + exp_width (8)
+  %recoded = hardfloat.fn_to_rec_fn<24, 8>(%a) : (i31) -> i33
   func.return
 }
 
 // -----
 
-// 3. Test RecodedOutputs: Output bitwidth != sig_width + exp_width + 1
-func.func @test_recoded_outputs_width(%a : i33, %b : i33) {
-  // expected-error@+1 {{Expect output type to be of sig_width (24) + exp_width (8) + 1 = 32}}
-  %mul = hardfloat.mul_rec_fn<24, 8>(%a, %b) : (i33, i33) -> i32
+// 3. Test verify_int: Missing int_width property (Parsing should fail or verify catch)
+func.func @test_missing_int_width(%a : i33, %signed : i1) {
+  // If the parser allowed skipping the third param, the verifier catches the missing int_width
+  // CHECK: Expect op to have int_width property
+  %to_int = hardfloat.rec_fn_to_in<24, 8>(%a, %signed) : (i33, i1) -> i32
   func.return
 }
 
 // -----
 
-// 4. Test IntegerOutputs: Output bitwidth != int_width
-func.func @test_int_outputs_width(%a : i33) {
-  // expected-error@+1 {{Expect output type (i16) to have bitwidth given by int_width property (32)}}
-  %to_int = hardfloat.rec_fn_to_in<24, 8, 32>(%a) <{signedness=#builtin.signedness<unsigned>}>: (i33) -> i16
+// 4. Test verify_int: bitwidth != int_width.data
+func.func @test_int_width_mismatch(%a : i33, %signed : i1) {
+  // CHECK: Expect output type (i16) to have bitwidth given by int_width property (32)
+  %to_int = hardfloat.rec_fn_to_in<24, 8, 32>(%a, %signed) : (i33, i1) -> i16
   func.return
 }
 
 // -----
 
-// 5. Test IntegerInputs: Input bitwidth != int_width
-func.func @test_int_inputs_width(%a : i16) {
-  // expected-error@+1 {{Expect input type (i16) to have bitwidth given by int_width property (32)}}
-  %int_to_rec = hardfloat.in_to_rec_fn<24, 8, 32>(%a) <{signedness=#builtin.signedness<unsigned>}>: (i16) -> i33
+// 5. Test AddRecFnOp: Specific check on one of the new operands (subOp)
+func.func @test_add_subop_type(%a : i33, %b : i33, %rm : i3, %tininess : i1, %bad_sub : i32) {
+  // IRDL verifier will catch the i32 where i1 is expected for subOp
+  // CHECK: Operation does not verify: operand 'subOp' at position 0 does not verify:
+  // CHECK-NEXT: Expected attribute i1 but got i32
+  %add = "hardfloat.add_rec_fn"(%bad_sub, %a, %b, %rm, %tininess) {"exp_width" = 8 : i64, "sig_width" = 24 : i64} : (i32, i33, i33, i3, i1) -> i33
   func.return
 }
 
 // -----
 
-// 6. Test IntegerConversion: Signedness cannot be Signless
-func.func @test_signless_conversion(%a : i33) {
-  // expected-error@+1 {{Property signedness can not be Signless}}
-  %to_int = hardfloat.rec_fn_to_in<24, 8, 32>(%a) <{signedness=#builtin.signedness<signless>}>: (i33) -> i32
+// 6. Test verify_recoded on Result: Output bitwidth mismatch
+func.func @test_recoded_result_mismatch(%a : i32, %signed : i1) {
+  // CHECK: Expect type (i16) to be equal to sig_width (24) + exp_width (8) + 1
+  %int_to_rec = hardfloat.in_to_rec_fn<24, 8, 32>(%signed, %a) : (i1, i32) -> i16
   func.return
 }
-
-// -----
-
-// 7. Test IntegerConversion: Missing signedness property
-// Note: This assumes the parser allows a missing property; if prop_def is mandatory,
-// the parser will fail, but if forced, the trait verifier catches it.
-"func.func"() ({
-  %0 = "test.op"() : () -> i33
-  // expected-error@+1 {{IntegerConversion optrait expects signedness attr}}
-  %1 = "hardfloat.rec_fn_to_in"(%0) {"exp_width" = 8 : i64, "int_width" = 32 : i64, "sig_width" = 24 : i64} : (i33) -> i32
-  "func.return"() : () -> ()
-}) : () -> ()

--- a/tests/filecheck/dialects/hardfloat/invalid.mlir
+++ b/tests/filecheck/dialects/hardfloat/invalid.mlir
@@ -3,7 +3,7 @@
 // 1. Test verify_recoded: Input/Output bitwidth != sig_width + exp_width + 1
 func.func @test_verify_recoded(%a : i32, %b : i33, %rm : i3, %tininess : i1) {
   // CHECK: Expect type (i32) to be equal to sig_width (24) + exp_width (8) + 1
-  %mul = hardfloat.mul_rec_fn<24, 8>(%a, %b, %rm, %tininess) : (i32, i33, i3, i1) -> i33
+  %mul, %exception_flags = hardfloat.mul_rec_fn<24, 8>(%a, %b, %rm, %tininess) : (i32, i33, i3, i1) -> (i33, i5)
   func.return
 }
 
@@ -19,19 +19,19 @@ func.func @test_verify_float(%a : i31) {
 // -----
 
 // 3. Test verify_int: Missing int_width property (Parsing should fail or verify catch)
-func.func @test_missing_int_width(%a : i33, %signed : i1) {
+func.func @test_missing_int_width(%a : i33, %rm : i3, %signed : i1) {
   // If the parser allowed skipping the third param, the verifier catches the missing int_width
   // CHECK: Expect op to have int_width property
-  %to_int = hardfloat.rec_fn_to_in<24, 8>(%a, %signed) : (i33, i1) -> i32
+  %to_int, %exception_flags = hardfloat.rec_fn_to_in<24, 8>(%a, %rm, %signed) : (i33, i3, i1) -> (i32, i3)
   func.return
 }
 
 // -----
 
 // 4. Test verify_int: bitwidth != int_width.data
-func.func @test_int_width_mismatch(%a : i33, %signed : i1) {
-  // CHECK: Expect output type (i16) to have bitwidth given by int_width property (32)
-  %to_int = hardfloat.rec_fn_to_in<24, 8, 32>(%a, %signed) : (i33, i1) -> i16
+func.func @test_int_width_mismatch(%a : i33, %rm : i3, %signed : i1) {
+  // CHECK: Expect type (i16) to have bitwidth given by int_width property (32)
+  %to_int, %exception_flags = hardfloat.rec_fn_to_in<24, 8, 32>(%a, %rm, %signed) : (i33, i3, i1) -> (i16, i3)
   func.return
 }
 
@@ -42,15 +42,15 @@ func.func @test_add_subop_type(%a : i33, %b : i33, %rm : i3, %tininess : i1, %ba
   // IRDL verifier will catch the i32 where i1 is expected for subOp
   // CHECK: Operation does not verify: operand 'subOp' at position 0 does not verify:
   // CHECK-NEXT: Expected attribute i1 but got i32
-  %add = "hardfloat.add_rec_fn"(%bad_sub, %a, %b, %rm, %tininess) {"exp_width" = 8 : i64, "sig_width" = 24 : i64} : (i32, i33, i33, i3, i1) -> i33
+  %add, %exception_flags = "hardfloat.add_rec_fn"(%bad_sub, %a, %b, %rm, %tininess) {"exp_width" = 8 : i64, "sig_width" = 24 : i64} : (i32, i33, i33, i3, i1) -> (i33, i5)
   func.return
 }
 
 // -----
 
 // 6. Test verify_recoded on Result: Output bitwidth mismatch
-func.func @test_recoded_result_mismatch(%a : i32, %signed : i1) {
+func.func @test_recoded_result_mismatch(%signed : i1, %a : i32, %rm : i3, %dt: i1) {
   // CHECK: Expect type (i16) to be equal to sig_width (24) + exp_width (8) + 1
-  %int_to_rec = hardfloat.in_to_rec_fn<24, 8, 32>(%signed, %a) : (i1, i32) -> i16
+  %int_to_rec, %exception_flags = hardfloat.in_to_rec_fn<24, 8, 32>(%signed, %a, %rm, %dt) : (i1, i32, i3, i1) -> (i16, i5)
   func.return
 }

--- a/tests/filecheck/dialects/hardfloat/ops.mlir
+++ b/tests/filecheck/dialects/hardfloat/ops.mlir
@@ -1,25 +1,50 @@
 // RUN: XDSL_ROUNDTRIP
 
-func.func @test_mul(%a : i33, %b : i33, %c : i32) -> (i33, i33, i32, i33, i33) {
-  %mul = hardfloat.mul_rec_fn<24, 8>(%a, %b) : (i33, i33) -> i33
-  %add = hardfloat.add_rec_fn<24, 8>(%a, %b) : (i33, i33) -> i33
-  %recoded = hardfloat.fn_to_rec_fn<24, 8>(%c) : (i32) -> i33
+
+func.func @test_hardfloat_ops(%a : i33, %b : i33, %float_in : i32) -> (i33, i33, i32, i33, i33) {
+  // Control signals required by the new operand definitions
+  %false = arith.constant 0 : i1
+  %true = arith.constant 1 : i1
+  %rm = arith.constant 0 : i3
+
+  // %mul: (a, b, roundingMode, detectTininess)
+  %mul = hardfloat.mul_rec_fn<24, 8>(%a, %b, %rm, %false) : (i33, i33, i3, i1) -> i33
+
+  // %add: (subOp, a, b, roundingMode, detectTininess)
+  %add = hardfloat.add_rec_fn<24, 8>(%false, %a, %b, %rm, %false) : (i1, i33, i33, i3, i1) -> i33
+
+  // %recoded: (input)
+  %recoded = hardfloat.fn_to_rec_fn<24, 8>(%float_in) : (i32) -> i33
+
+  // %unrecoded: (input)
   %unrecoded = hardfloat.rec_fn_to_fn<24, 8>(%recoded) : (i33) -> i32
-  %to_int = hardfloat.rec_fn_to_in<24, 8, 32>(%recoded) <{signedness = #builtin.signedness<unsigned>}> : (i33) -> i32
-  %int_to_rec = hardfloat.in_to_rec_fn<24, 8, 32>(%to_int) <{signedness = #builtin.signedness<unsigned>}> : (i32) -> i33
-  %to_sint = hardfloat.rec_fn_to_in<24, 8, 32>(%recoded) <{signedness = #builtin.signedness<signed>}> : (i33) -> i32
-  %sint_to_rec = hardfloat.in_to_rec_fn<24, 8, 32>(%to_sint) <{signedness = #builtin.signedness<signed>}> : (i32) -> i33
-  func.return %mul, %add, %unrecoded, %int_to_rec, %sint_to_rec: i33, i33, i32, i33, i33
+
+  // %to_int: (input, signedOut)
+  %to_int = hardfloat.rec_fn_to_in<24, 8, 32>(%recoded, %false) : (i33, i1) -> i32
+
+  // %int_to_rec: (signedIn, input)
+  %int_to_rec = hardfloat.in_to_rec_fn<24, 8, 32>(%false, %to_int) : (i1, i32) -> i33
+
+  // %to_sint: (input, signedOut)
+  %to_sint = hardfloat.rec_fn_to_in<24, 8, 32>(%recoded, %true) : (i33, i1) -> i32
+
+  // %sint_to_rec: (signedIn, input)
+  %sint_to_rec = hardfloat.in_to_rec_fn<24, 8, 32>(%true, %to_sint) : (i1, i32) -> i33
+
+  func.return %mul, %add, %unrecoded, %int_to_rec, %sint_to_rec : i33, i33, i32, i33, i33
 }
 
-// CHECK: func.func @test_mul(%a : i33, %b : i33, %c : i32) -> (i33, i33, i32, i33, i33) {
-// CHECK-NEXT:   %mul = hardfloat.mul_rec_fn<24, 8>(%a, %b) : (i33, i33) -> i33
-// CHECK-NEXT:   %add = hardfloat.add_rec_fn<24, 8>(%a, %b) : (i33, i33) -> i33
-// CHECK-NEXT:   %recoded = hardfloat.fn_to_rec_fn<24, 8>(%c) : (i32) -> i33
-// CHECK-NEXT:   %unrecoded = hardfloat.rec_fn_to_fn<24, 8>(%recoded) : (i33) -> i32
-// CHECK-NEXT:   %to_int = hardfloat.rec_fn_to_in<24, 8, 32>(%recoded) <{signedness = #builtin.signedness<unsigned>}> : (i33) -> i32
-// CHECK-NEXT:   %int_to_rec = hardfloat.in_to_rec_fn<24, 8, 32>(%to_int) <{signedness = #builtin.signedness<unsigned>}> : (i32) -> i33
-// CHECK-NEXT:   %to_sint = hardfloat.rec_fn_to_in<24, 8, 32>(%recoded) <{signedness = #builtin.signedness<signed>}> : (i33) -> i32
-// CHECK-NEXT:   %sint_to_rec = hardfloat.in_to_rec_fn<24, 8, 32>(%to_sint) <{signedness = #builtin.signedness<signed>}> : (i32) -> i33
-// CHECK-NEXT:   func.return %mul, %add, %unrecoded, %int_to_rec, %sint_to_rec : i33, i33, i32, i33, i33
-// CHECK-NEXT: }
+// CHECK:       func.func @test_hardfloat_ops(%{{.*}} : i33, %{{.*}} : i33, %{{.*}} : i32) -> (i33, i33, i32, i33, i33) {
+// CHECK-NEXT:    %false = arith.constant false
+// CHECK-NEXT:    %true = arith.constant true
+// CHECK-NEXT:    %rm = arith.constant 0 : i3
+// CHECK-NEXT:    %mul = hardfloat.mul_rec_fn<24, 8>(%a, %b, %rm, %false) : (i33, i33, i3, i1) -> i33
+// CHECK-NEXT:    %add = hardfloat.add_rec_fn<24, 8>(%false, %a, %b, %rm, %false) : (i1, i33, i33, i3, i1) -> i33
+// CHECK-NEXT:    %recoded = hardfloat.fn_to_rec_fn<24, 8>(%float_in) : (i32) -> i33
+// CHECK-NEXT:    %unrecoded = hardfloat.rec_fn_to_fn<24, 8>(%recoded) : (i33) -> i32
+// CHECK-NEXT:    %to_int = hardfloat.rec_fn_to_in<24, 8, 32>(%recoded, %false) : (i33, i1) -> i32
+// CHECK-NEXT:    %int_to_rec = hardfloat.in_to_rec_fn<24, 8, 32>(%false, %to_int) : (i1, i32) -> i33
+// CHECK-NEXT:    %to_sint = hardfloat.rec_fn_to_in<24, 8, 32>(%recoded, %true) : (i33, i1) -> i32
+// CHECK-NEXT:    %sint_to_rec = hardfloat.in_to_rec_fn<24, 8, 32>(%true, %to_sint) : (i1, i32) -> i33
+// CHECK-NEXT:    func.return %mul, %add, %unrecoded, %int_to_rec, %sint_to_rec : i33, i33, i32, i33, i33
+// CHECK-NEXT:  }

--- a/tests/filecheck/dialects/hardfloat/ops.mlir
+++ b/tests/filecheck/dialects/hardfloat/ops.mlir
@@ -1,50 +1,42 @@
 // RUN: XDSL_ROUNDTRIP
 
-
-func.func @test_hardfloat_ops(%a : i33, %b : i33, %float_in : i32) -> (i33, i33, i32, i33, i33) {
-  // Control signals required by the new operand definitions
-  %false = arith.constant 0 : i1
-  %true = arith.constant 1 : i1
+func.func @test_hardfloat_roundtrip(%a : i33, %b : i33, %val_i32 : i32) {
+  // Setup constants for control signals
+  %false = arith.constant false
+  %true = arith.constant true
   %rm = arith.constant 0 : i3
 
-  // %mul: (a, b, roundingMode, detectTininess)
-  %mul = hardfloat.mul_rec_fn<24, 8>(%a, %b, %rm, %false) : (i33, i33, i3, i1) -> i33
+  // 1. Multiply: (a, b, rm, tininess) -> (res, flags)
+  %mul, %m_flags = hardfloat.mul_rec_fn<24, 8>(%a, %b, %rm, %false) : (i33, i33, i3, i1) -> (i33, i5)
 
-  // %add: (subOp, a, b, roundingMode, detectTininess)
-  %add = hardfloat.add_rec_fn<24, 8>(%false, %a, %b, %rm, %false) : (i1, i33, i33, i3, i1) -> i33
+  // 2. Add: (subOp, a, b, rm, tininess) -> (res, flags)
+  %add, %a_flags = hardfloat.add_rec_fn<24, 8>(%false, %a, %b, %rm, %false) : (i1, i33, i33, i3, i1) -> (i33, i5)
 
-  // %recoded: (input)
-  %recoded = hardfloat.fn_to_rec_fn<24, 8>(%float_in) : (i32) -> i33
+  // 3. Float to Recoded: (in) -> (out)
+  %rec = hardfloat.fn_to_rec_fn<24, 8>(%val_i32) : (i32) -> i33
 
-  // %unrecoded: (input)
-  %unrecoded = hardfloat.rec_fn_to_fn<24, 8>(%recoded) : (i33) -> i32
+  // 4. Recoded to Float: (in) -> (out)
+  %f_out = hardfloat.rec_fn_to_fn<24, 8>(%rec) : (i33) -> i32
 
-  // %to_int: (input, signedOut)
-  %to_int = hardfloat.rec_fn_to_in<24, 8, 32>(%recoded, %false) : (i33, i1) -> i32
+  // 5. Integer to Recoded: (signedIn, in, rm, tininess) -> (out, flags)
+  %i2r, %i2r_flags = hardfloat.in_to_rec_fn<24, 8, 32>(%false, %val_i32, %rm, %false) : (i1, i32, i3, i1) -> (i33, i5)
 
-  // %int_to_rec: (signedIn, input)
-  %int_to_rec = hardfloat.in_to_rec_fn<24, 8, 32>(%false, %to_int) : (i1, i32) -> i33
+  // 6. Recoded to Integer: (in, rm, signedOut) -> (out, flags)
+  // Note: exceptionFlags is i3 for this op
+  %r2i, %r2i_flags = hardfloat.rec_fn_to_in<24, 8, 32>(%rec, %rm, %true) : (i33, i3, i1) -> (i32, i3)
 
-  // %to_sint: (input, signedOut)
-  %to_sint = hardfloat.rec_fn_to_in<24, 8, 32>(%recoded, %true) : (i33, i1) -> i32
-
-  // %sint_to_rec: (signedIn, input)
-  %sint_to_rec = hardfloat.in_to_rec_fn<24, 8, 32>(%true, %to_sint) : (i1, i32) -> i33
-
-  func.return %mul, %add, %unrecoded, %int_to_rec, %sint_to_rec : i33, i33, i32, i33, i33
+  func.return
 }
 
-// CHECK:       func.func @test_hardfloat_ops(%{{.*}} : i33, %{{.*}} : i33, %{{.*}} : i32) -> (i33, i33, i32, i33, i33) {
+// CHECK:       func.func @test_hardfloat_roundtrip(%{{.*}}: i33, %{{.*}}: i33, %{{.*}}: i32) {
 // CHECK-NEXT:    %false = arith.constant false
 // CHECK-NEXT:    %true = arith.constant true
 // CHECK-NEXT:    %rm = arith.constant 0 : i3
-// CHECK-NEXT:    %mul = hardfloat.mul_rec_fn<24, 8>(%a, %b, %rm, %false) : (i33, i33, i3, i1) -> i33
-// CHECK-NEXT:    %add = hardfloat.add_rec_fn<24, 8>(%false, %a, %b, %rm, %false) : (i1, i33, i33, i3, i1) -> i33
-// CHECK-NEXT:    %recoded = hardfloat.fn_to_rec_fn<24, 8>(%float_in) : (i32) -> i33
-// CHECK-NEXT:    %unrecoded = hardfloat.rec_fn_to_fn<24, 8>(%recoded) : (i33) -> i32
-// CHECK-NEXT:    %to_int = hardfloat.rec_fn_to_in<24, 8, 32>(%recoded, %false) : (i33, i1) -> i32
-// CHECK-NEXT:    %int_to_rec = hardfloat.in_to_rec_fn<24, 8, 32>(%false, %to_int) : (i1, i32) -> i33
-// CHECK-NEXT:    %to_sint = hardfloat.rec_fn_to_in<24, 8, 32>(%recoded, %true) : (i33, i1) -> i32
-// CHECK-NEXT:    %sint_to_rec = hardfloat.in_to_rec_fn<24, 8, 32>(%true, %to_sint) : (i1, i32) -> i33
-// CHECK-NEXT:    func.return %mul, %add, %unrecoded, %int_to_rec, %sint_to_rec : i33, i33, i32, i33, i33
+// CHECK-NEXT:    %mul, %m_flags = hardfloat.mul_rec_fn<24, 8>(%a, %b, %rm, %false) : (i33, i33, i3, i1) -> (i33, i5)
+// CHECK-NEXT:    %add, %a_flags = hardfloat.add_rec_fn<24, 8>(%false, %a, %b, %rm, %false) : (i1, i33, i33, i3, i1) -> (i33, i5)
+// CHECK-NEXT:    %rec = hardfloat.fn_to_rec_fn<24, 8>(%val_i32) : (i32) -> i33
+// CHECK-NEXT:    %f_out = hardfloat.rec_fn_to_fn<24, 8>(%rec) : (i33) -> i32
+// CHECK-NEXT:    %i2r, %i2r_flags = hardfloat.in_to_rec_fn<24, 8, 32>(%false, %val_i32, %rm, %false) : (i1, i32, i3, i1) -> (i33, i5)
+// CHECK-NEXT:    %r2i, %r2i_flags = hardfloat.rec_fn_to_in<24, 8, 32>(%rec, %rm, %true) : (i33, i3, i1) -> (i32, i3)
+// CHECK-NEXT:    return
 // CHECK-NEXT:  }

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -1,15 +1,28 @@
-import lit.formats
 import os
+import sys
+
+import lit.formats
 
 config.test_source_root = os.path.dirname(__file__)
 snax_src = os.path.dirname(os.path.dirname(config.test_source_root))
 
 config.name = "SNAX"
 config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {snax_src}"])
-config.suffixes = ['.test', '.mlir', '.py']
+config.suffixes = [".test", ".mlir", ".py"]
+config.excludes = ["lit.cfg.py"]
 
-config.substitutions.append(('XDSL_PARSING_DIAG', "snax-opt %s --print-op-generic --parsing-diagnostics --split-input-file | filecheck %s"))
-config.substitutions.append(('XDSL_VERIFY_DIAG', "snax-opt %s --print-op-generic --verify-diagnostics --split-input-file | filecheck %s"))
-config.substitutions.append(('XDSL_ROUNDTRIP', "snax-opt %s --print-op-generic --split-input-file | snax-opt --split-input-file | filecheck %s"))
-config.substitutions.append(('XDSL_SINGLETRIP', "snax-opt %s --split-input-file | filecheck %s"))
+config.substitutions.append(("XDSL_PARSING_DIAG", "snax-opt %s --print-op-generic --parsing-diagnostics --split-input-file | filecheck %s"))
+config.substitutions.append(("XDSL_VERIFY_DIAG", "snax-opt %s --print-op-generic --verify-diagnostics --split-input-file | filecheck %s"))
+config.substitutions.append(("XDSL_ROUNDTRIP", "snax-opt %s --print-op-generic --split-input-file | snax-opt --split-input-file | filecheck %s"))
+config.substitutions.append(("XDSL_SINGLETRIP", "snax-opt %s --split-input-file | filecheck %s"))
 config.substitutions.append(("XDSL_GENERIC_ROUNDTRIP", "snax-opt %s --print-op-generic --split-input-file | filecheck %s --check-prefix=CHECK-GENERIC"))
+
+
+# Get the directory where lit.cfg.py is located
+config_dir = os.path.dirname(__file__)
+easyfloat_path = os.path.abspath(os.path.join(config_dir, "..", "..", "..", "kuleuven-easyfloat"))
+if os.path.isdir(easyfloat_path):
+    config.available_features.add("has_easyfloat_installed")
+    sys.stderr.write(f"--- Found easyfloat at: {easyfloat_path} ---\n")
+else:
+    sys.stderr.write(f"--- Easyfloat not found at {easyfloat_path} ---\n")

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -21,8 +21,12 @@ config.substitutions.append(("XDSL_GENERIC_ROUNDTRIP", "snax-opt %s --print-op-g
 # Get the directory where lit.cfg.py is located
 config_dir = os.path.dirname(__file__)
 easyfloat_path = os.path.abspath(os.path.join(config_dir, "..", "..", "..", "kuleuven-easyfloat"))
-if os.path.isdir(easyfloat_path):
+manual_force = lit_config.params.get("force-easyfloat") == "1"
+
+if os.path.isdir(easyfloat_path) or manual_force:
     config.available_features.add("has_easyfloat_installed")
-    sys.stderr.write(f"--- Found easyfloat at: {easyfloat_path} ---\n")
+    if lit_config.debug:
+      sys.stderr.write(f"--- Found easyfloat at: {easyfloat_path} ---\n")
 else:
-    sys.stderr.write(f"--- Easyfloat not found at {easyfloat_path} ---\n")
+    if lit_config.debug:
+      sys.stderr.write(f"--- Easyfloat not found at {easyfloat_path} ---\n")

--- a/tests/filecheck/transforms/hardfloat/convert-float-to-hardfloat.mlir
+++ b/tests/filecheck/transforms/hardfloat/convert-float-to-hardfloat.mlir
@@ -11,31 +11,46 @@ func.func @test_hardfloat(%a : f32, %b : f32, %c: i32, %d : f32) -> (f32, f32, f
 }
 
 // CHECK: func.func @test_hardfloat(%a : f32, %b : f32, %c : i32, %d : f32) -> (f32, f32, f32, f32, i32, i32) {
-// CHECK-NEXT:   %add = builtin.unrealized_conversion_cast %a : f32 to i32
-// CHECK-NEXT:   %add_1 = builtin.unrealized_conversion_cast %b : f32 to i32
-// CHECK-NEXT:   %add_2 = hardfloat.fn_to_rec_fn<24, 8>(%add) : (i32) -> i33
+// CHECK-NEXT:   %add = hw.constant false
+// CHECK-NEXT:   %add_1 = builtin.unrealized_conversion_cast %a : f32 to i32
+// CHECK-NEXT:   %add_2 = builtin.unrealized_conversion_cast %b : f32 to i32
 // CHECK-NEXT:   %add_3 = hardfloat.fn_to_rec_fn<24, 8>(%add_1) : (i32) -> i33
-// CHECK-NEXT:   %add_4 = hardfloat.add_rec_fn<24, 8>(%add_2, %add_3) : (i33, i33) -> i33
-// CHECK-NEXT:   %add_5 = hardfloat.rec_fn_to_fn<24, 8>(%add_4) : (i33) -> i32
-// CHECK-NEXT:   %add_6 = builtin.unrealized_conversion_cast %add_5 : i32 to f32
+// CHECK-NEXT:   %add_4 = hardfloat.fn_to_rec_fn<24, 8>(%add_2) : (i32) -> i33
+// CHECK-NEXT:   %add_5 = hw.constant 0 : i3
+// CHECK-NEXT:   %add_6 = hw.constant true
+// CHECK-NEXT:   %add_7, %add_8 = hardfloat.add_rec_fn<24, 8>(%add, %add_3, %add_4, %add_5, %add_6) : (i1, i33, i33, i3, i1) -> (i33, i5)
+// CHECK-NEXT:   %add_9 = hardfloat.rec_fn_to_fn<24, 8>(%add_7) : (i33) -> i32
+// CHECK-NEXT:   %add_10 = builtin.unrealized_conversion_cast %add_9 : i32 to f32
 // CHECK-NEXT:   %mul = builtin.unrealized_conversion_cast %a : f32 to i32
 // CHECK-NEXT:   %mul_1 = builtin.unrealized_conversion_cast %b : f32 to i32
 // CHECK-NEXT:   %mul_2 = hardfloat.fn_to_rec_fn<24, 8>(%mul) : (i32) -> i33
 // CHECK-NEXT:   %mul_3 = hardfloat.fn_to_rec_fn<24, 8>(%mul_1) : (i32) -> i33
-// CHECK-NEXT:   %mul_4 = hardfloat.mul_rec_fn<24, 8>(%mul_2, %mul_3) : (i33, i33) -> i33
-// CHECK-NEXT:   %mul_5 = hardfloat.rec_fn_to_fn<24, 8>(%mul_4) : (i33) -> i32
-// CHECK-NEXT:   %mul_6 = builtin.unrealized_conversion_cast %mul_5 : i32 to f32
-// CHECK-NEXT:   %sfp = hardfloat.in_to_rec_fn<24, 8, 32>(%c) <{signedness = #builtin.signedness<signed>}> : (i32) -> i33
-// CHECK-NEXT:   %sfp_1 = hardfloat.rec_fn_to_fn<24, 8>(%sfp) : (i33) -> i32
-// CHECK-NEXT:   %sfp_2 = builtin.unrealized_conversion_cast %sfp_1 : i32 to f32
-// CHECK-NEXT:   %ufp = hardfloat.in_to_rec_fn<24, 8, 32>(%c) <{signedness = #builtin.signedness<unsigned>}> : (i32) -> i33
-// CHECK-NEXT:   %ufp_1 = hardfloat.rec_fn_to_fn<24, 8>(%ufp) : (i33) -> i32
-// CHECK-NEXT:   %ufp_2 = builtin.unrealized_conversion_cast %ufp_1 : i32 to f32
-// CHECK-NEXT:   %sint = builtin.unrealized_conversion_cast %d : f32 to i32
-// CHECK-NEXT:   %sint_1 = hardfloat.fn_to_rec_fn<24, 8>(%sint) : (i32) -> i33
-// CHECK-NEXT:   %sint_2 = hardfloat.rec_fn_to_in<24, 8, 32>(%sint_1) <{signedness = #builtin.signedness<signed>}> : (i33) -> i32
-// CHECK-NEXT:   %uint = builtin.unrealized_conversion_cast %d : f32 to i32
-// CHECK-NEXT:   %uint_1 = hardfloat.fn_to_rec_fn<24, 8>(%uint) : (i32) -> i33
-// CHECK-NEXT:   %uint_2 = hardfloat.rec_fn_to_in<24, 8, 32>(%uint_1) <{signedness = #builtin.signedness<unsigned>}> : (i33) -> i32
-// CHECK-NEXT:   func.return %add_6, %mul_6, %sfp_2, %ufp_2, %uint_2, %sint_2 : f32, f32, f32, f32, i32, i32
+// CHECK-NEXT:   %mul_4 = hw.constant 0 : i3
+// CHECK-NEXT:   %mul_5 = hw.constant true
+// CHECK-NEXT:   %mul_6, %mul_7 = hardfloat.mul_rec_fn<24, 8>(%mul_2, %mul_3, %mul_4, %mul_5) : (i33, i33, i3, i1) -> (i33, i5)
+// CHECK-NEXT:   %mul_8 = hardfloat.rec_fn_to_fn<24, 8>(%mul_6) : (i33) -> i32
+// CHECK-NEXT:   %mul_9 = builtin.unrealized_conversion_cast %mul_8 : i32 to f32
+// CHECK-NEXT:   %sfp = hw.constant true
+// CHECK-NEXT:   %sfp_1 = hw.constant 0 : i3
+// CHECK-NEXT:   %sfp_2 = hw.constant true
+// CHECK-NEXT:   %sfp_3, %sfp_4 = hardfloat.in_to_rec_fn<24, 8, 32>(%sfp, %c, %sfp_1, %sfp_2) : (i1, i32, i3, i1) -> (i33, i5)
+// CHECK-NEXT:   %sfp_5 = hardfloat.rec_fn_to_fn<24, 8>(%sfp_3) : (i33) -> i32
+// CHECK-NEXT:   %sfp_6 = builtin.unrealized_conversion_cast %sfp_5 : i32 to f32
+// CHECK-NEXT:   %ufp = hw.constant false
+// CHECK-NEXT:   %ufp_1 = hw.constant 0 : i3
+// CHECK-NEXT:   %ufp_2 = hw.constant true
+// CHECK-NEXT:   %ufp_3, %ufp_4 = hardfloat.in_to_rec_fn<24, 8, 32>(%ufp, %c, %ufp_1, %ufp_2) : (i1, i32, i3, i1) -> (i33, i5)
+// CHECK-NEXT:   %ufp_5 = hardfloat.rec_fn_to_fn<24, 8>(%ufp_3) : (i33) -> i32
+// CHECK-NEXT:   %ufp_6 = builtin.unrealized_conversion_cast %ufp_5 : i32 to f32
+// CHECK-NEXT:   %sint = hw.constant true
+// CHECK-NEXT:   %sint_1 = hw.constant 0 : i3
+// CHECK-NEXT:   %sint_2 = builtin.unrealized_conversion_cast %d : f32 to i32
+// CHECK-NEXT:   %sint_3 = hardfloat.fn_to_rec_fn<24, 8>(%sint_2) : (i32) -> i33
+// CHECK-NEXT:   %sint_4, %sint_5 = hardfloat.rec_fn_to_in<24, 8, 32>(%sint_3, %sint_1, %sint) : (i33, i3, i1) -> (i32, i3)
+// CHECK-NEXT:   %uint = hw.constant false
+// CHECK-NEXT:   %uint_1 = hw.constant 0 : i3
+// CHECK-NEXT:   %uint_2 = builtin.unrealized_conversion_cast %d : f32 to i32
+// CHECK-NEXT:   %uint_3 = hardfloat.fn_to_rec_fn<24, 8>(%uint_2) : (i32) -> i33
+// CHECK-NEXT:   %uint_4, %uint_5 = hardfloat.rec_fn_to_in<24, 8, 32>(%uint_3, %uint_1, %uint) : (i33, i3, i1) -> (i32, i3)
+// CHECK-NEXT:   func.return %add_10, %mul_9, %sfp_6, %ufp_6, %uint_4, %sint_4 : f32, f32, f32, f32, i32, i32
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/hardfloat/convert-hardfloat-to-hw.mlir
+++ b/tests/filecheck/transforms/hardfloat/convert-hardfloat-to-hw.mlir
@@ -1,4 +1,5 @@
-// snax-opt -p convert-hardfloat-to-hw
+// RUN: snax-opt -p convert-hardfloat-to-hw{'easyfloat_path="%p/../../../../../kuleuven-easyfloat"'} %s | filecheck %s
+
 
 func.func @test_hardfloat(%a : f32, %b : f32) -> f32 {
   %false = arith.constant false

--- a/tests/filecheck/transforms/hardfloat/convert-hardfloat-to-hw.mlir
+++ b/tests/filecheck/transforms/hardfloat/convert-hardfloat-to-hw.mlir
@@ -1,4 +1,5 @@
 // RUN: snax-opt -p convert-hardfloat-to-hw{'easyfloat_path="%p/../../../../../kuleuven-easyfloat"'} %s | filecheck %s
+// RUN: snax-opt -p convert-hardfloat-to-hw{external_modules=true} %s | filecheck %s --check-prefix=EXTERN
 
 
 func.func @test_hardfloat(%a : f32, %b : f32) -> f32 {
@@ -37,3 +38,8 @@ func.func @test_hardfloat(%a : f32, %b : f32) -> f32 {
 // CHECK: hw.module private @MulRawFN(in %io_a_isNaN: i1, in %io_a_isInf: i1, in %io_a_isZero: i1, in %io_a_sign: i1, in %io_a_sExp: i10, in %io_a_sig: i25, in %io_b_isNaN: i1, in %io_b_isInf: i1, in %io_b_isZero: i1, in %io_b_sign: i1, in %io_b_sExp: i10, in %io_b_sig: i25, out io_invalidExc: i1, out io_rawOut_isNaN: i1, out io_rawOut_isInf: i1, out io_rawOut_isZero: i1, out io_rawOut_sign: i1, out io_rawOut_sExp: i10, out io_rawOut_sig: i27) {
 // CHECK: hw.module private @MulRecFN_s24_e8(in %io_a: i33, in %io_b: i33, in %io_roundingMode: i3, in %io_detectTininess: i1, out io_out: i33, out io_exceptionFlags: i5) {
 // CHECK: hw.module private @fNFromRecFN_s24_e8(in %io_in: i33, out io_out: i32) {
+
+// EXTERN: hw.module.extern @AddRecFN_s24_e8(in %port0 io_subOp: i1, in %port1 io_a: i33, in %port2 io_b: i33, in %port3 io_roundingMode: i3, in %port4 io_detectTininess: i1, out io_out: i33, out io_exceptionFlags: i5)
+// EXTERN-NEXT: hw.module.extern @MulRecFN_s24_e8(in %port0 io_a: i33, in %port1 io_b: i33, in %port2 io_roundingMode: i3, in %port3 io_detectTininess: i1, out io_out: i33, out io_exceptionFlags: i5)
+// EXTERN-NEXT: hw.module.extern @fNFromRecFN_s24_e8(in %port0 io_in: i33, out io_out: i32)
+// EXTERN-NEXT: hw.module.extern @recFNFromFN_s24_e8(in %port0 io_in: i32, out io_out: i33)

--- a/tests/filecheck/transforms/hardfloat/convert-hardfloat-to-hw.mlir
+++ b/tests/filecheck/transforms/hardfloat/convert-hardfloat-to-hw.mlir
@@ -1,0 +1,38 @@
+// snax-opt -p convert-hardfloat-to-hw
+
+func.func @test_hardfloat(%a : f32, %b : f32) -> f32 {
+  %false = arith.constant false
+  %rm = arith.constant 0 : i3
+  %a_i32 = builtin.unrealized_conversion_cast %a : f32 to i32
+  %b_i32 = builtin.unrealized_conversion_cast %b : f32 to i32
+  %a_rec = hardfloat.fn_to_rec_fn<24, 8>(%a_i32) : (i32) -> i33
+  %b_rec = hardfloat.fn_to_rec_fn<24, 8>(%b_i32) : (i32) -> i33
+  %add_res, %add_flags = hardfloat.add_rec_fn<24, 8>(%false, %a_rec, %b_rec, %rm, %false) : (i1, i33, i33, i3, i1) -> (i33, i5)
+  %mul_res, %mul_flags = hardfloat.mul_rec_fn<24, 8>(%add_res, %b_rec, %rm, %false) : (i33, i33, i3, i1) -> (i33, i5)
+  %mul_val_i32 = hardfloat.rec_fn_to_fn<24, 8>(%mul_res) : (i33) -> i32
+  %final_f32 = builtin.unrealized_conversion_cast %mul_val_i32 : i32 to f32
+  func.return %final_f32 : f32
+}
+
+// CHECK: func.func @test_hardfloat(%a : f32, %b : f32) -> f32 {
+// CHECK-NEXT:   %false = arith.constant false
+// CHECK-NEXT:   %rm = arith.constant 0 : i3
+// CHECK-NEXT:   %a_i32 = builtin.unrealized_conversion_cast %a : f32 to i32
+// CHECK-NEXT:   %b_i32 = builtin.unrealized_conversion_cast %b : f32 to i32
+// CHECK-NEXT:   %a_rec = hw.instance "recFNFromFN_s24_e8_0" @recFNFromFN_s24_e8(io_in: %a_i32: i32) -> (io_out: i33)
+// CHECK-NEXT:   %b_rec = hw.instance "recFNFromFN_s24_e8_1" @recFNFromFN_s24_e8(io_in: %b_i32: i32) -> (io_out: i33)
+// CHECK-NEXT:   %add_res, %add_flags = hw.instance "AddRecFN_s24_e8_0" @AddRecFN_s24_e8(io_subOp: %false: i1, io_a: %a_rec: i33, io_b: %b_rec: i33, io_roundingMode: %rm: i3, io_detectTininess: %false: i1) -> (io_out: i33, io_exceptionFlags: i5)
+// CHECK-NEXT:   %mul_res, %mul_flags = hw.instance "MulRecFN_s24_e8_0" @MulRecFN_s24_e8(io_a: %add_res: i33, io_b: %b_rec: i33, io_roundingMode: %rm: i3, io_detectTininess: %false: i1) -> (io_out: i33, io_exceptionFlags: i5)
+// CHECK-NEXT:   %mul_val_i32 = hw.instance "fNFromRecFN_s24_e8_0" @fNFromRecFN_s24_e8(io_in: %mul_res: i33) -> (io_out: i32)
+// CHECK-NEXT:   %final_f32 = builtin.unrealized_conversion_cast %mul_val_i32 : i32 to f32
+// CHECK-NEXT:   func.return %final_f32 : f32
+// CHECK-NEXT: }
+// CHECK: hw.module private @recFNFromFN_s24_e8(in %io_in: i32, out io_out: i33) {
+// CHECK: hw.module private @AddRawFN(in %io_subOp: i1, in %io_a_isNaN: i1, in %io_a_isInf: i1, in %io_a_isZero: i1, in %io_a_sign: i1, in %io_a_sExp: i10, in %io_a_sig: i25, in %io_b_isNaN: i1, in %io_b_isInf: i1, in %io_b_isZero: i1, in %io_b_sign: i1, in %io_b_sExp: i10, in %io_b_sig: i25, in %io_roundingMode: i3, out io_invalidExc: i1, out io_rawOut_isNaN: i1, out io_rawOut_isInf: i1, out io_rawOut_isZero: i1, out io_rawOut_sign: i1, out io_rawOut_sExp: i10, out io_rawOut_sig: i27) {
+// CHECK: hw.module private @RoundAnyRawFNToRecFN_ie8_is26_oe8_os24(in %io_invalidExc: i1, in %io_in_isNaN: i1, in %io_in_isInf: i1, in %io_in_isZero: i1, in %io_in_sign: i1, in %io_in_sExp: i10, in %io_in_sig: i27, in %io_roundingMode: i3, in %io_detectTininess: i1, out io_out: i33, out io_exceptionFlags: i5) {
+// CHECK: hw.module private @RoundRawFNToRecFN_e8_s24(in %io_invalidExc: i1, in %io_in_isNaN: i1, in %io_in_isInf: i1, in %io_in_isZero: i1, in %io_in_sign: i1, in %io_in_sExp: i10, in %io_in_sig: i27, in %io_roundingMode: i3, in %io_detectTininess: i1, out io_out: i33, out io_exceptionFlags: i5) {
+// CHECK: hw.module private @AddRecFN_s24_e8(in %io_subOp: i1, in %io_a: i33, in %io_b: i33, in %io_roundingMode: i3, in %io_detectTininess: i1, out io_out: i33, out io_exceptionFlags: i5) {
+// CHECK: hw.module private @MulFullRawFN(in %io_a_isNaN: i1, in %io_a_isInf: i1, in %io_a_isZero: i1, in %io_a_sign: i1, in %io_a_sExp: i10, in %io_a_sig: i25, in %io_b_isNaN: i1, in %io_b_isInf: i1, in %io_b_isZero: i1, in %io_b_sign: i1, in %io_b_sExp: i10, in %io_b_sig: i25, out io_invalidExc: i1, out io_rawOut_isNaN: i1, out io_rawOut_isInf: i1, out io_rawOut_isZero: i1, out io_rawOut_sign: i1, out io_rawOut_sExp: i10, out io_rawOut_sig: i48) {
+// CHECK: hw.module private @MulRawFN(in %io_a_isNaN: i1, in %io_a_isInf: i1, in %io_a_isZero: i1, in %io_a_sign: i1, in %io_a_sExp: i10, in %io_a_sig: i25, in %io_b_isNaN: i1, in %io_b_isInf: i1, in %io_b_isZero: i1, in %io_b_sign: i1, in %io_b_sExp: i10, in %io_b_sig: i25, out io_invalidExc: i1, out io_rawOut_isNaN: i1, out io_rawOut_isInf: i1, out io_rawOut_isZero: i1, out io_rawOut_sign: i1, out io_rawOut_sExp: i10, out io_rawOut_sig: i27) {
+// CHECK: hw.module private @MulRecFN_s24_e8(in %io_a: i33, in %io_b: i33, in %io_roundingMode: i3, in %io_detectTininess: i1, out io_out: i33, out io_exceptionFlags: i5) {
+// CHECK: hw.module private @fNFromRecFN_s24_e8(in %io_in: i33, out io_out: i32) {

--- a/tests/filecheck/transforms/hardfloat/convert-hardfloat-to-hw.mlir
+++ b/tests/filecheck/transforms/hardfloat/convert-hardfloat-to-hw.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: has_easyfloat_installed
 // RUN: snax-opt -p convert-hardfloat-to-hw{'easyfloat_path="%p/../../../../../kuleuven-easyfloat"'} %s | filecheck %s
 // RUN: snax-opt -p convert-hardfloat-to-hw{external_modules=true} %s | filecheck %s --check-prefix=EXTERN
 

--- a/tests/filecheck/transforms/hardfloat/hardfloat-reconcile-recodes.mlir
+++ b/tests/filecheck/transforms/hardfloat/hardfloat-reconcile-recodes.mlir
@@ -1,34 +1,35 @@
-// RUN: snax-opt -p convert-float-to-hardfloat,hardfloat-reconcile-recodes %s | filecheck %s
+// RUN: snax-opt -p hardfloat-reconcile-recodes %s | filecheck %s
+
 
 func.func @test_hardfloat(%a : f32, %b : f32) -> f32 {
-  %add = builtin.unrealized_conversion_cast %a : f32 to i32
-  %add_1 = builtin.unrealized_conversion_cast %b : f32 to i32
-  %add_2 = hardfloat.fn_to_rec_fn<24, 8>(%add) : (i32) -> i33
-  %add_3 = hardfloat.fn_to_rec_fn<24, 8>(%add_1) : (i32) -> i33
-  %add_4 = hardfloat.add_rec_fn<24, 8>(%add_2, %add_3) : (i33, i33) -> i33
-  %add_5 = hardfloat.rec_fn_to_fn<24, 8>(%add_4) : (i33) -> i32
-  %add_6 = builtin.unrealized_conversion_cast %add_5 : i32 to f32
-  %mul = builtin.unrealized_conversion_cast %add_6 : f32 to i32
-  %mul_1 = builtin.unrealized_conversion_cast %b : f32 to i32
-  %mul_2 = hardfloat.fn_to_rec_fn<24, 8>(%mul) : (i32) -> i33
-  %mul_3 = hardfloat.fn_to_rec_fn<24, 8>(%mul_1) : (i32) -> i33
-  %mul_4 = hardfloat.mul_rec_fn<24, 8>(%mul_2, %mul_3) : (i33, i33) -> i33
-  %mul_5 = hardfloat.rec_fn_to_fn<24, 8>(%mul_4) : (i33) -> i32
-  %mul_6 = builtin.unrealized_conversion_cast %mul_5 : i32 to f32
-  func.return %mul_6 : f32
+  %false = arith.constant 0 : i1
+  %rm = arith.constant 0 : i3
+  %a_i32 = builtin.unrealized_conversion_cast %a : f32 to i32
+  %b_i32 = builtin.unrealized_conversion_cast %b : f32 to i32
+  %a_rec = hardfloat.fn_to_rec_fn<24, 8>(%a_i32) : (i32) -> i33
+  %b_rec = hardfloat.fn_to_rec_fn<24, 8>(%b_i32) : (i32) -> i33
+  %add_res, %add_flags = hardfloat.add_rec_fn<24, 8>(%false, %a_rec, %b_rec, %rm, %false) : (i1, i33, i33, i3, i1) -> (i33, i5)
+  %add_val_i32 = hardfloat.rec_fn_to_fn<24, 8>(%add_res) : (i33) -> i32
+  %add_f32 = builtin.unrealized_conversion_cast %add_val_i32 : i32 to f32
+  %mul_lhs_i32 = builtin.unrealized_conversion_cast %add_f32 : f32 to i32
+  %mul_lhs_rec = hardfloat.fn_to_rec_fn<24, 8>(%mul_lhs_i32) : (i32) -> i33
+  %mul_res, %mul_flags = hardfloat.mul_rec_fn<24, 8>(%mul_lhs_rec, %b_rec, %rm, %false) : (i33, i33, i3, i1) -> (i33, i5)
+  %mul_val_i32 = hardfloat.rec_fn_to_fn<24, 8>(%mul_res) : (i33) -> i32
+  %final_f32 = builtin.unrealized_conversion_cast %mul_val_i32 : i32 to f32
+  func.return %final_f32 : f32
 }
 
 
 // CHECK: func.func @test_hardfloat(%a : f32, %b : f32) -> f32 {
-// CHECK-NEXT:   %add = builtin.unrealized_conversion_cast %a : f32 to i32
-// CHECK-NEXT:   %add_1 = builtin.unrealized_conversion_cast %b : f32 to i32
-// CHECK-NEXT:   %add_2 = hardfloat.fn_to_rec_fn<24, 8>(%add) : (i32) -> i33
-// CHECK-NEXT:   %add_3 = hardfloat.fn_to_rec_fn<24, 8>(%add_1) : (i32) -> i33
-// CHECK-NEXT:   %add_4 = hardfloat.add_rec_fn<24, 8>(%add_2, %add_3) : (i33, i33) -> i33
-// CHECK-NEXT:   %mul = builtin.unrealized_conversion_cast %b : f32 to i32
-// CHECK-NEXT:   %mul_1 = hardfloat.fn_to_rec_fn<24, 8>(%mul) : (i32) -> i33
-// CHECK-NEXT:   %mul_2 = hardfloat.mul_rec_fn<24, 8>(%add_4, %mul_1) : (i33, i33) -> i33
-// CHECK-NEXT:   %mul_3 = hardfloat.rec_fn_to_fn<24, 8>(%mul_2) : (i33) -> i32
-// CHECK-NEXT:   %mul_4 = builtin.unrealized_conversion_cast %mul_3 : i32 to f32
-// CHECK-NEXT:   func.return %mul_4 : f32
+// CHECK-NEXT:   %false = arith.constant false
+// CHECK-NEXT:   %rm = arith.constant 0 : i3
+// CHECK-NEXT:   %a_i32 = builtin.unrealized_conversion_cast %a : f32 to i32
+// CHECK-NEXT:   %b_i32 = builtin.unrealized_conversion_cast %b : f32 to i32
+// CHECK-NEXT:   %a_rec = hardfloat.fn_to_rec_fn<24, 8>(%a_i32) : (i32) -> i33
+// CHECK-NEXT:   %b_rec = hardfloat.fn_to_rec_fn<24, 8>(%b_i32) : (i32) -> i33
+// CHECK-NEXT:   %add_res, %add_flags = hardfloat.add_rec_fn<24, 8>(%false, %a_rec, %b_rec, %rm, %false) : (i1, i33, i33, i3, i1) -> (i33, i5)
+// CHECK-NEXT:   %mul_res, %mul_flags = hardfloat.mul_rec_fn<24, 8>(%add_res, %b_rec, %rm, %false) : (i33, i33, i3, i1) -> (i33, i5)
+// CHECK-NEXT:   %mul_val_i32 = hardfloat.rec_fn_to_fn<24, 8>(%mul_res) : (i33) -> i32
+// CHECK-NEXT:   %final_f32 = builtin.unrealized_conversion_cast %mul_val_i32 : i32 to f32
+// CHECK-NEXT:   func.return %final_f32 : f32
 // CHECK-NEXT: }


### PR DESCRIPTION
This PR:
* Overhauls the hardfloat dialect to be easier to convert to hardware dialect
* Changes hardfloat's trait-based system to a regular IRDL-based definition.
* Calls into KULeuven-easyfloat to insert floating point modules into the generated systemverilog