### PR TITLE
Add pass to scalarize public modules

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -234,7 +234,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/79/0c/c05523fa3181fdf0c9c52a6ba91a23fbf3246cc095f26f6516f9c60e6771/virtualenv-20.35.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl
-      - pypi: git+https://github.com/xdslproject/xdsl.git?rev=3c5c8794593d05e7d7070ce137c532aaf40095f3#3c5c8794593d05e7d7070ce137c532aaf40095f3
+      - pypi: git+https://github.com/xdslproject/xdsl.git?rev=af4e063ee948b8f62fd8476d2f25d0b018bc274c#af4e063ee948b8f62fd8476d2f25d0b018bc274c
       - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2774,9 +2774,9 @@ packages:
 - pypi: ./
   name: snax-mlir
   version: 0.2.2
-  sha256: d7cdb3b6efc23376fdb37b93b2831f071849449da4c80c9aeedfc45db4ba2e32
+  sha256: a06b3dc11f4409c986f831660c56b18894c1fe04caaac154e8bae9342cb650f4
   requires_dist:
-  - xdsl @ git+https://github.com/xdslproject/xdsl.git@3c5c8794593d05e7d7070ce137c532aaf40095f3
+  - xdsl @ git+https://github.com/xdslproject/xdsl.git@af4e063ee948b8f62fd8476d2f25d0b018bc274c
   - minimalloc @ git+https://github.com/jorendumoulin/minimalloc.git@917a2ddf8ea0f48c7c77145d57c21d7c5dd20ef2
   - numpy
   - dacite>=1.9.2,<2
@@ -3027,9 +3027,9 @@ packages:
   - pkg:pypi/wrapt?source=hash-mapping
   size: 64608
   timestamp: 1756851740646
-- pypi: git+https://github.com/xdslproject/xdsl.git?rev=3c5c8794593d05e7d7070ce137c532aaf40095f3#3c5c8794593d05e7d7070ce137c532aaf40095f3
+- pypi: git+https://github.com/xdslproject/xdsl.git?rev=af4e063ee948b8f62fd8476d2f25d0b018bc274c#af4e063ee948b8f62fd8476d2f25d0b018bc274c
   name: xdsl
-  version: 0.57.1.dev3+g3c5c87945
+  version: 0.57.2.dev14+gaf4e063ee
   requires_dist:
   - immutabledict<4.2.3
   - typing-extensions>=4.7,<5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = "== 3.12.*"
 
 
 dependencies = [
-  "xdsl @ git+https://github.com/xdslproject/xdsl.git@3c5c8794593d05e7d7070ce137c532aaf40095f3",
+  "xdsl @ git+https://github.com/xdslproject/xdsl.git@af4e063ee948b8f62fd8476d2f25d0b018bc274c",
   "minimalloc @ git+https://github.com/jorendumoulin/minimalloc.git@917a2ddf8ea0f48c7c77145d57c21d7c5dd20ef2",
   "numpy",
   "dacite>=1.9.2,<2",

--- a/snaxc/transforms/__init__.py
+++ b/snaxc/transforms/__init__.py
@@ -90,6 +90,11 @@ def get_all_snax_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return ConvertPEToHWPass
 
+    def get_hw_scalarize_public_modules():
+        from snaxc.transforms.phs.hw_scalarize_public_modules import HwScalarizePublicModulesPass
+
+        return HwScalarizePublicModulesPass
+
     def get_finalize_phs_to_hw():
         from snaxc.transforms.phs.finalize_phs_to_hw import FinalizePhsToHWPass
 
@@ -321,6 +326,7 @@ def get_all_snax_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "construct-pipeline": construct_pipeline,
         "convert-accfg-to-csr": get_convert_accfg_to_csr,
         "convert-pe-to-hw": get_convert_pe_to_hw,
+        "hw-scalarize-public-modules": get_hw_scalarize_public_modules,
         "finalize-phs-to-hw": get_finalize_phs_to_hw,
         "phs-keep-phs": get_phs_keep_phs,
         "phs-remove-phs": get_phs_remove_phs,

--- a/snaxc/transforms/phs/hw_scalarize_public_modules.py
+++ b/snaxc/transforms/phs/hw_scalarize_public_modules.py
@@ -74,7 +74,7 @@ class ScalarizeHwModules(RewritePattern):
             shape, el_type = get_shaped_hw_array_shape(operand.type)
 
             for index in itertools.product(*[range(s) for s in shape]):
-                get_ops, scalar_val = get_from_shaped_hw_array(operand, index)
+                get_ops, scalar_val = get_from_shaped_hw_array(cast(SSAValue[hw.ArrayType], operand), index)
                 rewriter.insert_op(get_ops, InsertPoint(block, insert_before=output_op))
                 new_output_operands.append(scalar_val)
                 new_output_ports.append(

--- a/snaxc/transforms/phs/hw_scalarize_public_modules.py
+++ b/snaxc/transforms/phs/hw_scalarize_public_modules.py
@@ -1,0 +1,99 @@
+import itertools
+from typing import cast
+
+from xdsl.context import Context
+from xdsl.dialects import builtin, hw
+from xdsl.ir import SSAValue, TypeAttribute
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import PatternRewriter, PatternRewriteWalker, RewritePattern, op_type_rewrite_pattern
+from xdsl.rewriter import InsertPoint
+from xdsl.utils.hints import isa
+
+from snaxc.phs.hw_conversion import create_shaped_hw_array, get_from_shaped_hw_array, get_shaped_hw_array_shape
+
+
+class ScalarizeHwModules(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: hw.HWModuleOp, rewriter: PatternRewriter):
+        # Only work on public modules
+        if op.sym_visibility is not None:
+            return
+        block = op.body.block
+
+        # ── 1. Build new port list and replace array input args ──────────
+        new_ports: list[hw.ModulePort] = []
+        insert_offset: int = 0
+        for port in op.module_type.ports:
+            if port.dir.data != hw.Direction.INPUT or not isa(port.type, hw.ArrayType):
+                new_ports.append(port)
+                insert_offset += 1
+                continue
+
+            shape, el_type = get_shaped_hw_array_shape(port.type)
+            flat_size = 1
+            for s in shape:
+                flat_size *= s
+
+            # Insert scalar block args in place of the array arg
+            old_arg = block.args[insert_offset]
+            new_scalar_args: list[SSAValue] = []
+            for i in range(flat_size):
+                new_scalar_args.append(rewriter.insert_block_argument(block, insert_offset + i, el_type))
+
+            # Reconstruct the array from scalars at top of block,
+            # replace all uses of old array arg, let canonicalization clean up
+            reconst_ops, reconst_val = create_shaped_hw_array(new_scalar_args, tuple(shape))
+            rewriter.insert_op(reconst_ops, InsertPoint.at_start(block))
+            old_arg.replace_all_uses_with(reconst_val)
+            rewriter.erase_block_argument(old_arg)
+
+            for i in range(flat_size):
+                new_ports.append(
+                    hw.ModulePort(
+                        builtin.StringAttr(f"{port.port_name.data}_{i}"),
+                        cast(TypeAttribute, el_type),
+                        hw.DirectionAttr(data=hw.Direction.INPUT),
+                    )
+                )
+            insert_offset += flat_size
+        # ── 2. Scalarize output ports in hw.output ───────────────────────
+        output_op = block.last_op
+        assert isinstance(output_op, hw.OutputOp)
+
+        new_output_operands: list[SSAValue] = []
+        new_output_ports: list[hw.ModulePort] = []
+
+        for operand, port in zip(
+            output_op.operands, [p for p in op.module_type.ports if p.dir.data == hw.Direction.OUTPUT]
+        ):
+            if not isa(operand.type, hw.ArrayType):
+                new_output_operands.append(operand)
+                new_output_ports.append(port)
+                continue
+
+            shape, el_type = get_shaped_hw_array_shape(operand.type)
+
+            for index in itertools.product(*[range(s) for s in shape]):
+                get_ops, scalar_val = get_from_shaped_hw_array(operand, index)
+                rewriter.insert_op(get_ops, InsertPoint(block, insert_before=output_op))
+                new_output_operands.append(scalar_val)
+                new_output_ports.append(
+                    hw.ModulePort(
+                        builtin.StringAttr(f"{port.port_name.data}_{'_'.join(str(i) for i in index)}"),
+                        cast(TypeAttribute, el_type),
+                        hw.DirectionAttr(data=hw.Direction.OUTPUT),
+                    )
+                )
+
+        rewriter.replace_op(output_op, hw.OutputOp(new_output_operands))
+
+        # ── 3. Update module type ─────────────────────────────────────────
+        all_new_ports = [p for p in new_ports if p.dir.data != hw.Direction.OUTPUT] + new_output_ports
+        op.module_type = hw.ModuleType(builtin.ArrayAttr(all_new_ports))
+
+
+class HwScalarizePublicModulesPass(ModulePass):
+    name = "hw-scalarize-public-modules"
+
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(ScalarizeHwModules(), apply_recursively=False).rewrite_module(op)

--- a/tests/filecheck/transforms/phs/hw-scalarize-public-modules.mlir
+++ b/tests/filecheck/transforms/phs/hw-scalarize-public-modules.mlir
@@ -1,4 +1,4 @@
-// RUN: snax-opt %s -p hw-scalarize-public-modules --disable-verify | circt-opt --allow-unregistered-dialect --canonicalize | filecheck %s
+// RUN: snax-opt %s -p hw-scalarize-public-modules | circt-opt --allow-unregistered-dialect --canonicalize | filecheck %s
 
 hw.module @test_1d(in %data data_0: !hw.array<4xi64>, in %data_1: !hw.array<4xi64>, in %switch switch_0: i2, out out_0: !hw.array<4xi64>) {
   %0 = "test.op"(%data, %data_1, %switch) : (!hw.array<4xi64>, !hw.array<4xi64>, i2) -> !hw.array<4xi64>

--- a/tests/filecheck/transforms/phs/hw-scalarize-public-modules.mlir
+++ b/tests/filecheck/transforms/phs/hw-scalarize-public-modules.mlir
@@ -1,0 +1,17 @@
+// RUN: snax-opt %s -p hw-scalarize-public-modules --disable-verify | circt-opt --allow-unregistered-dialect --canonicalize | filecheck %s
+
+hw.module @test_1d(in %data data_0: !hw.array<4xi64>, in %data_1: !hw.array<4xi64>, in %switch switch_0: i2, out out_0: !hw.array<4xi64>) {
+  %0 = "test.op"(%data, %data_1, %switch) : (!hw.array<4xi64>, !hw.array<4xi64>, i2) -> !hw.array<4xi64>
+  hw.output %0 : !hw.array<4xi64>
+}
+
+hw.module @test_2d(in %data data_0: !hw.array<2x!hw.array<4xi64>>, in %data_1: !hw.array<2x!hw.array<4xi64>>, out out_0: !hw.array<2x!hw.array<4xi64>>) {
+  hw.output %data : !hw.array<2x!hw.array<4xi64>>
+}
+
+// CHECK: hw.module @test_1d(in %data_0_0 : i64, in %data_0_1 : i64, in %data_0_2 : i64, in %data_0_3 : i64, in %data_1_0 : i64, in %data_1_1 : i64, in %data_1_2 : i64, in %data_1_3 : i64, in %switch_0 : i2, out out_0_0 : i64, out out_0_1 : i64, out out_0_2 : i64, out out_0_3 : i64) {
+// CHECK:   hw.output %3, %4, %5, %6 : i64, i64, i64, i64
+// CHECK-NEXT: }
+// CHECK: hw.module @test_2d(in %data_0_0 : i64, in %data_0_1 : i64, in %data_0_2 : i64, in %data_0_3 : i64, in %data_0_4 : i64, in %data_0_5 : i64, in %data_0_6 : i64, in %data_0_7 : i64, in %data_1_0 : i64, in %data_1_1 : i64, in %data_1_2 : i64, in %data_1_3 : i64, in %data_1_4 : i64, in %data_1_5 : i64, in %data_1_6 : i64, in %data_1_7 : i64, out out_0_0_0 : i64, out out_0_0_1 : i64, out out_0_0_2 : i64, out out_0_0_3 : i64, out out_0_1_0 : i64, out out_0_1_1 : i64, out out_0_1_2 : i64, out out_0_1_3 : i64) {
+// CHECK-NEXT:   hw.output %data_0_0, %data_0_1, %data_0_2, %data_0_3, %data_0_4, %data_0_5, %data_0_6, %data_0_7 : i64, i64, i64, i64, i64, i64, i64, i64
+// CHECK-NEXT: }


### PR DESCRIPTION
It seems the default option for aggregate datatypes in chisel is to emit them scalarized.
There's not a pass/annotation with fine enough granularity to disable this at the module level for chisel BlackBoxes, so I created this pass which should do the same thing that chisel does.